### PR TITLE
Remove redundant hasShownWelcome TeamSpeak plugin config entry

### DIFF
--- a/extensions/src/ACRE2Core/AcreSettings.cpp
+++ b/extensions/src/ACRE2Core/AcreSettings.cpp
@@ -11,12 +11,11 @@ ACRE_RESULT CAcreSettings::save(std::string filename) {
         return ACRE_ERROR;
     }
     iniFile << "[acre2]\n";
-    iniFile << "hasShownWelcome = " << (this->m_HasShownWelcome ? "true" : "false") << ";\n";
     iniFile << "lastVersion = " << ACRE_VERSION << ";\n";
     iniFile << "globalVolume = " << this->m_GlobalVolume << ";\n";
     iniFile << "premixGlobalVolume = " << this->m_PremixGlobalVolume << ";\n";
     iniFile << "disableUnmuteClients = " << (this->m_DisableUnmuteClients ? "true" : "false") << ";\n";
-    
+
     //LOG("Config Save: %f,%f", m_GlobalVolume, m_PremixGlobalVolume);
     iniFile.flush();
     iniFile.close();
@@ -34,7 +33,6 @@ ACRE_RESULT CAcreSettings::load(std::string filename) {
         return ACRE_ERROR;
     }
 
-    this->m_HasShownWelcome = config.GetBoolean("acre2", "hasShownWelcome", true);
     this->m_LastVersion = config.Get("acre2", "lastVersion", ACRE_VERSION);
     this->m_GlobalVolume = (float)config.GetReal("acre2", "globalVolume", 1.0f);
     this->m_PremixGlobalVolume = (float)config.GetReal("acre2", "premixGlobalVolume", 1.0f);
@@ -64,7 +62,6 @@ CAcreSettings::CAcreSettings() :
     m_DisableRadioFilter(false),
     m_DisableUnmuteClients(false),
     m_LastVersion(ACRE_VERSION),
-    m_HasShownWelcome(false),
     m_Path("acre2.ini")
     {
     // Set defaults!

--- a/extensions/src/ACRE2Core/AcreSettings.h
+++ b/extensions/src/ACRE2Core/AcreSettings.h
@@ -7,7 +7,7 @@
 #include "SoundEngine.h"
 #include "ini_reader.hpp"
 
-class CAcreSettings : 
+class CAcreSettings :
     public TSingleton<CAcreSettings>, public CLockable {
 public:
     CAcreSettings();
@@ -18,7 +18,6 @@ public:
     ACRE_RESULT save(std::string filename);
     ACRE_RESULT load(std::string filename);
 
-    DECLARE_MEMBER(bool, HasShownWelcome);
     DECLARE_MEMBER(std::string, LastVersion);
 
     DECLARE_MEMBER(float, GlobalVolume);


### PR DESCRIPTION
**When merged this pull request will:**
- Remove redundant `hasShownWelcome` TeamSpeak plugin config entry.

As far as I know this shouldn't cause any issues with loading, as it reads it as a config file.
