### PR TITLE
Optimise: getGear for large item counts

### DIFF
--- a/addons/game/XEH_pre_init.sqf
+++ b/addons/game/XEH_pre_init.sqf
@@ -240,6 +240,9 @@ FUNC(getGear) = {
     if (isNull _unit) exitWith {[]};
     // diag_log text format["Assigned Items: %1", (assignedItems _unit)];
     private _gear = (weapons _unit) + (items _unit) + (assignedItems _unit);
+    _gear = _gear select {(_x select [0, 4]) == "ACRE" || _x == "ItemRadio" || _x == "ItemRadioAcreFlagged"}; // We are only interested in ACRE gear.
+    // The below is really slow and tends to worsen performance.
+    //_gear = _gear select {(_x call EFUNC(api,getBaseRadio)) in (call EFUNC(api,getAllRadios) select 0) || {_x == "ItemRadio"} || {_x == "ItemRadioAcreFlagged"}};
     _gear;
 };
 

--- a/addons/sys_radio/fnc_monitorRadios.sqf
+++ b/addons/sys_radio/fnc_monitorRadios.sqf
@@ -35,14 +35,13 @@ DFUNC(monitorRadios_PFH) = {
     if(time < 1) exitWith { };
 
     if(ACREALIVE(acre_player)) then {
-        _currentUniqueItems = [];
-        _weapons = [acre_player] call EFUNC(lib,getGear);
-
+        private _currentUniqueItems = [];
+        private _weapons = [acre_player] call EFUNC(lib,getGear);
 
         if(!("ItemRadio" in _weapons) && !("ItemRadioAcreFlagged" in _weapons) && !ACRE_HOLD_OFF_ITEMRADIO_CHECK) then {
-            // [acre_player, "ItemRadioAcreFlagged"] call EFUNC(lib,addGear);
-            acre_player linkItem "ItemRadioAcreFlagged";
-            _newWeapons = [acre_player] call EFUNC(lib,getGear);
+            acre_player linkItem "ItemRadioAcreFlagged"; // Only ItemRadio/ItemRadioAcreFlagged can be in the linked item slot for Radios.
+            // Check if the linkItem removes anything... Only ItemRadio
+            /*_newWeapons = [acre_player] call EFUNC(lib,getGear);
             {
                 _radio = _x;
                 _hasUnique = getNumber(configFile >> "CfgWeapons" >> _radio >> "acre_hasUnique");
@@ -52,7 +51,7 @@ DFUNC(monitorRadios_PFH) = {
                     };
                 };
             } forEach _weapons;
-            _weapons = _newWeapons;
+            _weapons = _newWeapons;*/
         } else {
             if("ItemRadioAcreFlagged" in _weapons && !("ItemRadioAcreFlagged" in (assignedItems acre_player)) && !ACRE_HOLD_OFF_ITEMRADIO_CHECK) then {
                 acre_player assignItem "ItemRadioAcreFlagged";
@@ -110,7 +109,7 @@ DFUNC(monitorRadios_PFH) = {
                     [acre_player, _radio, _baseRadio] call EFUNC(lib,replaceGear);
                     _radio = _baseRadio;
                 };
-                PUSH(_currentUniqueItems, _radio);
+                _currentUniqueItems pushBack _radio;
             };
         } forEach _weapons;
 

--- a/addons/sys_server/fnc_masterIdTracker.sqf
+++ b/addons/sys_server/fnc_masterIdTracker.sqf
@@ -46,6 +46,7 @@ if (!GVAR(doFullSearch)) then {
             } else {
                 #ifdef PLATFORM_A3
                 _items = itemCargo _object;
+                _items = _items select {(_x select [0, 4]) == "ACRE" || _x == "ItemRadio" || _x == "ItemRadioAcreFlagged"};
                 #endif
                 #ifdef PLATFORM_A2
                 _items = (getWeaponCargo _object) select 0;
@@ -103,6 +104,7 @@ if(GVAR(doFullSearch) && !GVAR(fullSearchRunning) ) then {
                     } else {
                         #ifdef PLATFORM_A3
                         _items = itemCargo _object;
+                        _items = _items select {(_x select [0, 4]) == "ACRE" || _x == "ItemRadio" || _x == "ItemRadioAcreFlagged"};
                         #endif
                         #ifdef PLATFORM_A2
                         _items = (getWeaponCargo _object) select 0;


### PR DESCRIPTION
**When merged this pull request will:**
- Improve acre_lib_fnc_getGear. Only returns ACRE radios. This improves performance for many of the frequently run gear checks. Particularly for high item counts. This should prove gains particularly when running ACE due to all the new items.
- Local check for uninitialised radio worst case performance significantly lowered (38 to 2 milliseconds for 400 items). This was causing noticable stutter for medics carrying large amounts of medical supplies
- Server radio ID monitor runs faster particularly when doing a full search. I created a test mission with ~10 equipment crates, ~10 vehicles and several squads of AI. With the getGear improvement it ran twice as fast (50ms v 24ms) with 150 vanilla units (running ACE). I later implemented the optimisation for ItemCargo. Further reducing runtime from 24 ms to 20ms.
- Downside all acre radios should begin with acre*. Several other solutions were tested but this led to the best performance.
