### PR TITLE
Add CBA Versioning

### DIFF
--- a/addons/main/CfgSettings.hpp
+++ b/addons/main/CfgSettings.hpp
@@ -1,0 +1,11 @@
+class CfgSettings {
+    class CBA {
+        class Versioning {
+            class PREFIX {
+                class dependencies {
+                    CBA[] = {"cba_main", REQUIRED_CBA_VERSION, "(true)"};
+                };
+            };
+        };
+    };
+};

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+
 class CfgPatches {
     class ADDON {
         units[] = {};
@@ -24,5 +25,6 @@ class CfgMods {
 
 #include "CfgRscStd.hpp"
 #include "Dialog.hpp"
+#include "CfgSettings.hpp"
 
 //#include "CfgEventHandlers.hpp"

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -14,5 +14,6 @@
 
 // MINIMAL required version for the Mod. Components can specify others..
 #define REQUIRED_VERSION 1.01
+#define REQUIRED_CBA_VERSION {3,1,0}
 
 #define AUTHOR author = "ACRE2 Team"

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -13,7 +13,7 @@
 #define ACRE_TAG ACRE
 
 // MINIMAL required version for the Mod. Components can specify others..
-#define REQUIRED_VERSION 1.01
+#define REQUIRED_VERSION 1.64
 #define REQUIRED_CBA_VERSION {3,1,0}
 
 #define AUTHOR author = "ACRE2 Team"


### PR DESCRIPTION
**When merged this pull request will:**
- Add CBA versioning, requiring CBA 3.1.0 (changed in a macro in `script_mod.hpp` next to A3 version), will print error if old version is used on mission start.
- Update A3 version to 1.64 (we use CBA and don't compile linux plugins for the linux port).
