### PR TITLE
Fixes the too agressive muting on briefing stage

### DIFF
--- a/addons/sys_core/XEH_post_init.sqf
+++ b/addons/sys_core/XEH_post_init.sqf
@@ -125,7 +125,7 @@ ADDPFH(_vehicleCrewPFH, 1.1, []);
 if (getClientStateNumber < 10) then { // Check before game has started (in briefing state or earlier)
     ["setSoundSystemMasterOverride", [1]] call EFUNC(sys_rpc,callRemoteProcedure);
     private _briefingCheck = {
-        if (getClientStateNumber > 9) then { // Briefing has been read.
+        if (getClientStateNumber > 9 && time > 0) then { // Briefing has been read AND Mission has started.
             ["setSoundSystemMasterOverride", [0]] call EFUNC(sys_rpc,callRemoteProcedure);
             [(_this select 1)] call CBA_fnc_removePerFrameHandler;
         } else {


### PR DESCRIPTION
**When merged this pull request will:**
- The muting on briefing screen happened as soon as a player clicked on continue. This PR fixes that, so players are still able to talk globally
