### PR TITLE
Fix loadSound - Will now wait until TS is connected

### DIFF
--- a/addons/sys_sounds/fnc_loadSound.sqf
+++ b/addons/sys_sounds/fnc_loadSound.sqf
@@ -1,16 +1,17 @@
 /*
  * Author: ACRE2Team
- * SHORT DESCRIPTION
+ * Function to send a b64 sound to the teamspeak plugin to be loaded. Once loaded the sound will always be available.
  *
  * Arguments:
- * 0: ARGUMENT ONE <TYPE>
- * 1: ARGUMENT TWO <TYPE>
+ * 0: Sound classname (in CfgAcreSounds) <STRING>
+ * 1: Return function <CODE>
+ * 2: Force <BOOL> - Forces the sound to be loaded again.
  *
  * Return Value:
- * RETURN VALUE <TYPE>
+ * None <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * ["Acre_GenericClick"] call acre_sys_sounds_fnc_loadSound;
  *
  * Public: No
  */
@@ -18,20 +19,36 @@
 
 params["_className",["_returnFunction",nil],["_force",false]];
 
-if(!(_className in GVAR(loadedSounds)) && {!_force}) then {
-    private _fileName = getText(configFile >> "CfgAcreSounds" >> _className >> "sound");
-    if(_fileName != "") then {
-        [] call (compile loadFile _fileName);
-        if(!isNil "ACRE_B64_FILE") then {
-            TRACE_2("Lounding Sound File", _className, _fileName);
-            if(!isNil "_returnFunction") then {
-                HASH_SET(GVAR(callBacks),_className,_returnFunction);
+// If teamspeak is connected.
+if (EGVAR(sys_core,ts3id) != -1) then { 
+    if(!(_className in GVAR(loadedSounds)) && {!_force}) then {
+        private _fileName = getText(configFile >> "CfgAcreSounds" >> _className >> "sound");
+        if(_fileName != "") then {
+            [] call (compile loadFile _fileName);
+            if(!isNil "ACRE_B64_FILE") then {
+                TRACE_2("Lounding Sound File", _className, _fileName);
+                if(!isNil "_returnFunction") then {
+                    HASH_SET(GVAR(callBacks),_className,_returnFunction);
+                };
+                {
+                    ["loadSound", [_className, _forEachIndex+1, count(ACRE_B64_FILE), _x]] call EFUNC(sys_rpc,callRemoteProcedure);
+                } forEach ACRE_B64_FILE;
+                ACRE_B64_FILE = nil;
+                TRACE_2("Sound File Sent", _className, _fileName);
             };
-            {
-                ["loadSound", [_className, _forEachIndex+1, count(ACRE_B64_FILE), _x]] call EFUNC(sys_rpc,callRemoteProcedure);
-            } forEach ACRE_B64_FILE;
-            ACRE_B64_FILE = nil;
-            TRACE_2("Sound File Sent", _className, _fileName);
         };
+    };
+} else {
+    //teamspeak is not connected store in a buffer.
+    if (isNil QGVAR(soundLoadBuffer)) then {
+        GVAR(soundLoadBuffer) = [_this];
+        [{EGVAR(sys_core,ts3id) != -1}, {
+        {
+            _x call FUNC(loadSound);
+        } forEach (GVAR(soundLoadBuffer));
+        GVAR(soundLoadBuffer) = nil;
+        },[]] call CBA_fnc_waitUntilAndExecute;
+    } else {
+        GVAR(soundLoadBuffer) pushBackUnique _this;
     };
 };

--- a/addons/sys_sounds/fnc_loadSound.sqf
+++ b/addons/sys_sounds/fnc_loadSound.sqf
@@ -8,7 +8,7 @@
  * 2: Force <BOOL> - Forces the sound to be loaded again.
  *
  * Return Value:
- * None <TYPE>
+ * None
  *
  * Example:
  * ["Acre_GenericClick"] call acre_sys_sounds_fnc_loadSound;
@@ -43,10 +43,10 @@ if (EGVAR(sys_core,ts3id) != -1) then {
     if (isNil QGVAR(soundLoadBuffer)) then {
         GVAR(soundLoadBuffer) = [_this];
         [{EGVAR(sys_core,ts3id) != -1}, {
-        {
-            _x call FUNC(loadSound);
-        } forEach (GVAR(soundLoadBuffer));
-        GVAR(soundLoadBuffer) = nil;
+            {
+                _x call FUNC(loadSound);
+            } forEach (GVAR(soundLoadBuffer));
+            GVAR(soundLoadBuffer) = nil;
         },[]] call CBA_fnc_waitUntilAndExecute;
     } else {
         GVAR(soundLoadBuffer) pushBackUnique _this;


### PR DESCRIPTION
**When merged this pull request will:**
- Ensure that loadSound waits until Teamspeak is connected before attempting to transfer the sounds.
