### PR TITLE
Reset sub-version counters with increment argument in make.py

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -471,7 +471,6 @@ def copy_optionals_for_building(mod,pbos):
     finally:
         os.chdir(current_dir)
 
-    print("")
     try:
         for dir_name in src_directories:
             mod.append(dir_name)
@@ -616,14 +615,19 @@ def get_project_version(version_increments=[]):
                 patchText = re.search(r"#define PATCHLVL (.*\b)", hpptext).group(1)
                 buildText = re.search(r"#define BUILD (.*\b)", hpptext).group(1)
 
-                # Increment version
+                # Increment version (reset all below except build)
                 if version_increments != []:
                     if "major" in version_increments:
                         majorText = int(majorText) + 1
-                    if "minor" in version_increments:
+                        minorText = 0
+                        patchText = 0
+                    elif "minor" in version_increments:
                         minorText = int(minorText) + 1
-                    if "patch" in version_increments:
+                        patchText = 0
+                    elif "patch" in version_increments:
                         patchText = int(patchText) + 1
+
+                    # Always increment build
                     if "build" in version_increments:
                         buildText = int(buildText) + 1
 
@@ -705,6 +709,7 @@ def set_version_in_files():
                     for versionFound in versionsFound:
                         if versionFound:
                             # Use the same version length as the one found
+                            newVersionUsed = "" # In case undefined
                             if len(versionFound) == len(newVersion):
                                 newVersionUsed = newVersion
                             if len(versionFound) == len(newVersionShort):
@@ -780,20 +785,47 @@ def get_commit_ID():
     # Get latest commit ID
     global make_root
     curDir = os.getcwd()
+    commit_id = ""
+
     try:
+        # Verify if Git repository
         gitpath = os.path.join(os.path.dirname(make_root), ".git")
         assert os.path.exists(gitpath)
-        os.chdir(make_root)
 
+        # Try to get commit ID through Git client
+        os.chdir(make_root)
         commit_id = subprocess.check_output(["git", "rev-parse", "HEAD"])
         commit_id = str(commit_id, "utf-8")[:8]
+    except FileNotFoundError:
+        # Try to get commit ID from git files (subprocess failed - eg. no Git client)
+        head_path = os.path.join(gitpath, "HEAD")
+        if os.path.exists(head_path):
+            with open(head_path, "r") as head_file:
+                branch_path = head_file.readline().split(": ")
+
+                # Commit ID is written in HEAD file directly when in detached state
+                if len(branch_path) == 1:
+                    commit_id = branch_path[0]
+                else:
+                    branch_path = branch_path[-1].strip()
+                    ref_path = os.path.join(gitpath, branch_path)
+                    if os.path.exists(ref_path):
+                        with open(ref_path, "r") as ref_file:
+                            commit_id = ref_file.readline()
+
+        if commit_id != "":
+            commit_id = commit_id.strip()[:8]
+        else:
+            raise
     except:
-        print_error("FAILED TO DETERMINE COMMIT ID.")
-        print_yellow("Verify that \GIT\BIN or \GIT\CMD is in your system path or user path.")
-        commit_id = "NOGIT"
-        raise
+        # All other exceptions (eg. AssertionException)
+        if commit_id == "":
+            raise
     finally:
         pass
+        if commit_id == "":
+            print_error("Failed to determine commit ID - folder is not a Git repository.")
+            commit_id = "NOGIT"
         os.chdir(curDir)
 
     print_yellow("COMMIT ID set to {}".format(commit_id))

--- a/tools/make.py
+++ b/tools/make.py
@@ -710,9 +710,9 @@ def set_version_in_files():
                         if versionFound:
                             # Use the same version length as the one found
                             newVersionUsed = "" # In case undefined
-                            if len(versionFound) == len(newVersion):
+                            if versionFound.count(".") == newVersion.count("."):
                                 newVersionUsed = newVersion
-                            if len(versionFound) == len(newVersionShort):
+                            if versionFound.count(".") == newVersionShort.count("."):
                                 newVersionUsed = newVersionShort
 
                             # Print change and modify the file if changed


### PR DESCRIPTION
**When merged this pull request will:**
- Make version increment arguments reset version parts below that, except build
- Add another way of retrieving Git commit ID if no Git client could be found (from ACE3's version)
- Fix possible undefined variable error

Wiki updated accordingly.
