### PR TITLE
API - Difficulty setting functions remove logging on dedicated server/headless clients

### DIFF
--- a/addons/api/fnc_ignoreAntennaDirection.sqf
+++ b/addons/api/fnc_ignoreAntennaDirection.sqf
@@ -15,9 +15,9 @@
  */
 #include "script_component.hpp"
 
-if (!hasInterface) exitWith {false};
-
 INFO_2("%1 called with: %2",QFUNC(ignoreAntennaDirection),_this);
+
+if (!hasInterface) exitWith {false};
 
 params ["_value"];
 

--- a/addons/api/fnc_ignoreAntennaDirection.sqf
+++ b/addons/api/fnc_ignoreAntennaDirection.sqf
@@ -15,6 +15,8 @@
  */
 #include "script_component.hpp"
 
+if (!hasInterface) exitWith {false};
+
 INFO_2("%1 called with: %2",QFUNC(ignoreAntennaDirection),_this);
 
 params ["_value"];

--- a/addons/api/fnc_setFullDuplex.sqf
+++ b/addons/api/fnc_setFullDuplex.sqf
@@ -15,9 +15,9 @@
  */
 #include "script_component.hpp"
 
-if (!hasInterface) exitWith {false};
-
 INFO_2("%1 called with: %2",QFUNC(setFullDuplex),_this);
+
+if (!hasInterface) exitWith {false};
 
 params ["_value"];
 

--- a/addons/api/fnc_setFullDuplex.sqf
+++ b/addons/api/fnc_setFullDuplex.sqf
@@ -15,6 +15,8 @@
  */
 #include "script_component.hpp"
 
+if (!hasInterface) exitWith {false};
+
 INFO_2("%1 called with: %2",QFUNC(setFullDuplex),_this);
 
 params ["_value"];

--- a/addons/api/fnc_setInterference.sqf
+++ b/addons/api/fnc_setInterference.sqf
@@ -15,9 +15,9 @@
  */
 #include "script_component.hpp"
 
-if (!hasInterface) exitWith {false};
-
 INFO_2("%1 called with: %2",QFUNC(setInterference),_this);
+
+if (!hasInterface) exitWith {false};
 
 params ["_value"];
 

--- a/addons/api/fnc_setInterference.sqf
+++ b/addons/api/fnc_setInterference.sqf
@@ -15,6 +15,8 @@
  */
 #include "script_component.hpp"
 
+if (!hasInterface) exitWith {false};
+
 INFO_2("%1 called with: %2",QFUNC(setInterference),_this);
 
 params ["_value"];

--- a/addons/api/fnc_setLossModelScale.sqf
+++ b/addons/api/fnc_setLossModelScale.sqf
@@ -15,9 +15,9 @@
  */
 #include "script_component.hpp"
 
-if (!hasInterface) exitWith {false};
-
 INFO_2("%1 called with: %2",QFUNC(setLossModelScale),_this);
+
+if (!hasInterface) exitWith {false};
 
 params ["_scale"];
 

--- a/addons/api/fnc_setLossModelScale.sqf
+++ b/addons/api/fnc_setLossModelScale.sqf
@@ -15,6 +15,8 @@
  */
 #include "script_component.hpp"
 
+if (!hasInterface) exitWith {false};
+
 INFO_2("%1 called with: %2",QFUNC(setLossModelScale),_this);
 
 params ["_scale"];

--- a/addons/api/fnc_setRevealToAI.sqf
+++ b/addons/api/fnc_setRevealToAI.sqf
@@ -16,11 +16,11 @@
  */
 #include "script_component.hpp"
 
+if (!hasInterface) exitWith {false};
+
 INFO_2("%1 called with: %2",QFUNC(setRevealToAI),_this);
 
 params ["_var"];
-
-if (!hasInterface) exitWith {false};
 
 //if(!isServer) exitWith {
 //    WARNING_1("%1 called on client! Function is server-side only!",QFUNC(setRevealToAI));

--- a/addons/api/fnc_setRevealToAI.sqf
+++ b/addons/api/fnc_setRevealToAI.sqf
@@ -16,9 +16,9 @@
  */
 #include "script_component.hpp"
 
-if (!hasInterface) exitWith {false};
-
 INFO_2("%1 called with: %2",QFUNC(setRevealToAI),_this);
+
+if (!hasInterface) exitWith {false};
 
 params ["_var"];
 


### PR DESCRIPTION
These functions are not intended to be called on dedicated clients. Previously a server RPT may look like:

```
17:50:48 [ACRE] (api) INFO: acre_api_fnc_setRevealToAI called with: [true]
17:50:48 [ACRE] (api) INFO: acre_api_fnc_setLossModelScale called with: [0.5]
17:50:48 [ACRE] (api) INFO: Difficulty changed. Interference: any - Duplex: any - Terrain Loss: 0.5 - Omni-directional: any - AI Hearing: any
17:50:48 [ACRE] (api) INFO: acre_api_fnc_setFullDuplex called with: [false]
17:50:48 [ACRE] (api) INFO: Difficulty changed. Interference: any - Duplex: false - Terrain Loss: 0.5 - Omni-directional: any - AI Hearing: any
17:50:48 [ACRE] (api) INFO: acre_api_fnc_setInterference called with: [true]
17:50:48 [ACRE] (api) INFO: Difficulty changed. Interference: true - Duplex: false - Terrain Loss: 0.5 - Omni-directional: any - AI Hearing: any
17:50:48 [ACRE] (api) INFO: acre_api_fnc_ignoreAntennaDirection called with: [true]
17:50:48 [ACRE] (api) INFO: Difficulty changed. Interference: true - Duplex: false - Terrain Loss: 0.5 - Omni-directional: 1 - AI Hearing: any
```

This simply removes this RPT logging on dedicated clients (on which it would make no difference anyway).
