### PR TITLE
Optimization: Do not do full signal calculations for self-broadcasting

### DIFF
--- a/addons/sys_modes/fnc_sc_speaking.sqf
+++ b/addons/sys_modes/fnc_sc_speaking.sqf
@@ -23,7 +23,11 @@ private _txData = [_txRadioId, "getCurrentChannelData"] call EFUNC(sys_data,data
 private _txFreq = HASH_GET(_txData, "frequencyTX");
 private _txPower = HASH_GET(_txData, "power");
 
-private _maxSignal = [_txFreq, _txPower, _rxRadioId, _txRadioId] call EFUNC(sys_signal,getSignal);
+private _maxSignal = [0,-993];
+
+if (_rxRadioId != _txRadioId) then {
+    _maxSignal = [_txFreq, _txPower, _rxRadioId, _txRadioId] call EFUNC(sys_signal,getSignal);
+};
 
 private _return = [_txRadioId, _rxRadioId, _maxSignal select 0, _maxSignal select 1, 0];
 


### PR DESCRIPTION
**When merged this pull request will:**
- Less overhead when self-broadcasting - This would tend to rapidly call callExtension on the client broadcasting. This removes the need for that.
