### PR TITLE
Improve Island loading (WRP Parser)

### DIFF
--- a/addons/sys_core/XEH_post_init.sqf
+++ b/addons/sys_core/XEH_post_init.sqf
@@ -62,18 +62,18 @@ INFO_1("Loading Map: %1",_wrpLocation);
     true,
     {
         params ["_args", "_result"];
-        // Log island name.
-        INFO_1("Map Load Complete: %1",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
+
         if (_result < 0) then {
             if (_result == -1) then {
-                WARNING("Map Load (WRP) parsing error - ACRE will now assume the terrain is flat and all at elevation 0m.");
+                WARNING_1("Map Load [%1] (WRP) parsing error - ACRE will now assume the terrain is flat and all at elevation 0m.",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
             } else {
-                ERROR("Map Load (WRP) failed");
+                ERROR_MSG_1("ACRE was unable to parse the map [%1]. Please file a ticket on our tracker http://github.com/idi-systems/acre2 ",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
             };
+        } else {
+            INFO_1("Map Load Complete: %1",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
         };
 
         ACRE_MAP_LOADED = true;
-        INFO_1("Map Load Complete: %1",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
     },
     []
 ] call FUNC(callExt);

--- a/addons/sys_core/XEH_post_init.sqf
+++ b/addons/sys_core/XEH_post_init.sqf
@@ -61,6 +61,17 @@ INFO_1("Loading Map: %1",_wrpLocation);
     [_wrpLocation],
     true,
     {
+        params ["_args", "_result"];
+        // Log island name.
+        INFO_1("Map Load Complete: %1",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
+        if (_result < 0) then {
+            if (_result == -1) then {
+                WARNING("Map Load (WRP) parsing error - ACRE will now assume the terrain is flat and all at elevation 0m.");
+            } else {
+                ERROR("Map Load (WRP) failed");
+            };
+        };
+
         ACRE_MAP_LOADED = true;
         INFO_1("Map Load Complete: %1",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
     },

--- a/extensions/src/ACRE2Arma/common/wrp/landscape.hpp
+++ b/extensions/src/ACRE2Arma/common/wrp/landscape.hpp
@@ -161,7 +161,7 @@ namespace acre {
             uint32_t version;
             float cell_size;
             float map_grid_size;
-
+            int32_t failure; // 0 - success, -1 recovered, -2 failure - no recovery
         protected:
             bool _read_binary_tree_block(std::istream &, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t);
             bool _process(std::istream &);

--- a/extensions/src/ACRE2Arma/signal/map/map.hpp
+++ b/extensions/src/ACRE2Arma/signal/map/map.hpp
@@ -34,6 +34,7 @@ namespace acre {
                     return landscape.get()->failure;
                 }
 
+                LOG(ERROR) << "WRP unable to find wrp file: " << wrp_path_;
                 return -2;
             };
 

--- a/extensions/src/ACRE2Arma/signal/map/map.hpp
+++ b/extensions/src/ACRE2Arma/signal/map/map.hpp
@@ -18,11 +18,12 @@ namespace acre {
         public:
             map_loader() {};
             ~map_loader() {};
-            bool get_map(const std::string wrp_path_, map_p &result_, bool &loaded_) {
+            int32_t get_map(const std::string wrp_path_, map_p &result_, bool &loaded_) {
+                //Return 0 = OKAY, -1 RECOVERD, -2 FAILURE
                 if (wrp_path_ == _current_map && _map != nullptr) { 
                     result_ = _map;
                     loaded_ = true;
-                    return true;
+                    return 0;
                 }
                 loaded_ = false;
                 acre::pbo::file_entry_p wrp_file;
@@ -30,10 +31,10 @@ namespace acre {
                     acre::wrp::landscape_p landscape = std::make_shared<acre::wrp::landscape>(wrp_file->stream());
                     result_ = std::make_shared<map>(landscape);
                     _current_map = wrp_path_;
-                    return true;
+                    return landscape.get()->failure;
                 }
 
-                return false;
+                return -2;
             };
 
         protected:

--- a/extensions/src/ACRE2Arma/signal/signal.hpp
+++ b/extensions/src/ACRE2Arma/signal/signal.hpp
@@ -78,17 +78,15 @@ namespace acre {
 
             bool load(const arguments & args_, std::string & result) {
                 bool loaded = false;
-                bool ok = acre::signal::map_loader::get().get_map(args_.as_string(0), _map, loaded);
-                if (ok) {
+                int32_t map_load_result = acre::signal::map_loader::get().get_map(args_.as_string(0), _map, loaded);
+
+                if (map_load_result > -2) { //Return 0 = OKAY, -1 RECOVERD, -2 FAILURE
                     if (!loaded) {
                         _signal_processor = acre::signal::model::multipath(_map);
                     }
                     LOG(INFO) << "Map Loaded";
-                    result = "1";
                 }
-                else {
-                    result = "-1";
-                }
+                result = std::to_string(map_load_result);
                 return true;
             }
             //#define DEBUG_OUTPUT

--- a/extensions/src/ACRE2Arma/tests/map_test.cpp
+++ b/extensions/src/ACRE2Arma/tests/map_test.cpp
@@ -46,14 +46,19 @@ int main(int argc, char **argv) {
     //std::string pbo_path = "C:\\Steam\\SteamApps\\common\\Arma 3\\@UOMAPS_A3\\addons\\sara.pbo";
     //std::string wrp_path = "\\ca\\chernarus\\chernarus.wrp";
     //std::string pbo_path = "C:\\Steam\\SteamApps\\common\\Arma 3\\@UOMAPS_A3_CUP\\addons\\chernarus.pbo";
-    std::string wrp_path = "\\ca\\takistan\\takistan.wrp";
-    std::string pbo_path = "C:\\Steam\\SteamApps\\common\\Arma 3\\@UOMAPS_A3_CUP\\addons\\takistan.pbo";
+    //std::string wrp_path = "\\ca\\takistan\\takistan.wrp";
+    //std::string pbo_path = "C:\\Steam\\SteamApps\\common\\Arma 3\\@UOMAPS_A3_CUP\\addons\\takistan.pbo";
+	//std::string wrp_path = "\\WW2\\Terrains_w\\Worlds\\Ivachev_w\\Ivachev.wrp";
+	//std::string pbo_path = "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Arma 3\\!Workshop\\@IFA3LITE\\addons\\ww2_terrains_w_worlds_ivachev_w.pbo";
+	//std::string wrp_path = "\\a3\\map_altis\\Altis.wrp";
+	//std::string pbo_path = "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Arma 3\\Addons\\map_altis.pbo";
+	std::string wrp_path = "\\ca\\afghan\\Mountains_ACR.wrp";
+	std::string pbo_path = "C:\\Program Files (x86)\\Steam\\SteamApps\\common\\Arma 3\\swifty\\@cup_terrains\\addons\\cup_terrains_maps_afghan.pbo";
 
     _filestream.open(pbo_path, std::ios::binary | std::ios::in);
     acre::signal::map_p test_map;
     bool loaded;
-    bool ok = acre::signal::map_loader::get().get_map(wrp_path, test_map, loaded);
-    return 0;
+    int32_t ok = acre::signal::map_loader::get().get_map(wrp_path, test_map, loaded);
     int offset_x = 0;
     int offset_y = 0;
     int size_x = -1;
@@ -78,8 +83,8 @@ int main(int argc, char **argv) {
     int map_size = test_map->map_size()*scale;
     float cell_sample_size = test_map->cell_size() / scale;
     bitmap_image image(size_x, size_y);
-    bitmap_image land_grad("d:\\land_grad.bmp");
-    bitmap_image sea_grad("d:\\sea_grad.bmp");
+    //bitmap_image land_grad("d:\\land_grad.bmp");
+    //bitmap_image sea_grad("d:\\sea_grad.bmp");
 
 
 
@@ -108,7 +113,7 @@ int main(int argc, char **argv) {
             glm::vec3 normal = glm::normalize(glm::vec3(-r_x, -r_y, 1.0f));
             float factor = glm::dot(normal, -light_source);
             
-            if (height > 0.0f) {
+            //if (height > 0.0f) {
                 //r.R = fg.R * fg.A / r.A + bg.R * bg.A * (1 - fg.A) / r.A; // 0.67
                 //r.G = fg.G * fg.A / r.A + bg.G * bg.A * (1 - fg.A) / r.A; // 0.33
                 //r.B = fg.B * fg.A / r.A + bg.B * bg.A * (1 - fg.A) / r.A; // 0.00
@@ -116,7 +121,8 @@ int main(int argc, char **argv) {
                 uint8_t shadow = 254 + shade;
                 uint8_t color_index = (height / max_height) * 254;
 
-                land_grad.get_pixel(color_index, 0, colorR, colorG, colorB);
+                colorR = 0.5; colorG = 0.5; colorB = 0.5;
+                //land_grad.get_pixel(color_index, 0, colorR, colorG, colorB);
                 //colorR = colorG = colorB = 254;
                 float r, g, b, fa, s, ra, ba;
                 
@@ -139,7 +145,7 @@ int main(int argc, char **argv) {
                 colorB = b * 254;
 
                 //colorR = colorG = colorB = color_index + shadow;
-            }
+            /*}
             else {
                 int8_t shade = 127 * factor;
                 uint8_t shadow = 127 + shade;
@@ -167,7 +173,7 @@ int main(int argc, char **argv) {
                 colorG = g * 254;
                 colorB = b * 254;
                 //colorR = colorG = colorB = 254;
-            }
+            }*/
             image.set_pixel(x - offset_x, (size_y-1)-(y - offset_y), colorR, colorG, colorB);
         }
     }


### PR DESCRIPTION
**When merged this pull request will:**
- Allow ACRE2 to recover from some errors the WRP parser may incur - Particularly in decompressing LZO data.
- Prevent crashing on CUP terrains - Takistan Mountains and IFA's Ivachev.
- Also minor improvements to parsing grid blocks
- Update the map test parser project to be standalone of the sea/land images.