### PR TITLE
Add removed game component backwards compatibility

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -873,6 +873,9 @@ class CfgPatches {
         url = CSTRING(URL);
         VERSION_CONFIG;
     };
+
+    // Backwards compatibility
+    class acre_game: ADDON {}; // Component removed in 2.3.0
 };
 
 class CfgMods {


### PR DESCRIPTION
**When merged this pull request will:**
- Close #79 
- Assure `acre_game` requirement backwards compatibility

Missions created before 2.3.0 that used Virtual Arsenal (which automatically adds a radio on opening) require `acre_game`, they will not open otherwise and can only be opened by manually editing `mission.sqm` (only if unbinarized) or loading old version of ACRE2 which still contains `acre_game` as a component.