### PR TITLE
Fix setVariable being protected for vehicleAttenuation

### DIFF
--- a/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
+++ b/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
@@ -38,6 +38,7 @@ if (_unit != _vehicle) then {
         };
     } forEach allTurrets [_vehicle, true];
 
+    if (_effectType == "") exitWith {};
     // CfgSoundEffects >> AttenuationsEffects
     private _value = HASH_GET(GVAR(attenuationCache), _effectType);
     if (isNil "_value") then {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix this for future versions of arma when setvariable on to empty "" is bad.
