### PR TITLE
Add CBA setting for desync hint display

### DIFF
--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -29,7 +29,7 @@
 ] call CBA_Settings_fnc_init;
 
 [
-    QGVAR(disableGearDesync),
+    QGVAR(disableDesyncHint),
     "CHECKBOX",
     "Disable Gear Desync Hint",
     "ACRE2",

--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -33,7 +33,7 @@
     "CHECKBOX",
     "Disable Gear Desync Hint",
     "ACRE2",
-    false,
+    true,
     false,
     {EGVAR(sys_radio,disableDesyncHint) = _this}
 ] call CBA_Settings_fnc_init;

--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -27,3 +27,13 @@
     false,
     {["disableUnmuteClients", _this] call FUNC(setPluginSetting)}
 ] call CBA_Settings_fnc_init;
+
+[
+    QGVAR(disableGearDesync),
+    "CHECKBOX",
+    "Disable Gear Desync Hint",
+    "ACRE2",
+    false,
+    false,
+    {EGVAR(sys_radio,disableDesyncHint) = _this}
+] call CBA_Settings_fnc_init;

--- a/addons/sys_radio/fnc_monitorRadios.sqf
+++ b/addons/sys_radio/fnc_monitorRadios.sqf
@@ -190,12 +190,17 @@ DFUNC(checkServerDesyncBug) = {
 ADDPFH(DFUNC(checkServerDesyncBug), 1, []);
 
 DFUNC(hasGearDesync) = {
-    if(ACRE_SERVER_GEAR_DESYNCED && GVAR(disableDesyncHint)) then {
+    if(ACRE_SERVER_GEAR_DESYNCED) then {
         private _message = "ACRE has determined that players in this mission have an inventory that has desynchronized from the server, this is due to a bug in the mission or a bug in Arma 3, NOT ACRE. This message will not dissappear and is a warning that ACRE may no longer be functioning correctly in this mission. The players experiencing the bug are listed below:\n\n";
         {
             _message = _message + format ["%1\n", name _x];
         } forEach ACRE_SERVER_DESYNCED_PLAYERS;
-        hintSilent _message;
+        if(GVAR(disableDesyncHint)) then {
+            diag_log _message;
+        } else {
+            hintSilent _message;
+        };
+
         WARNING(_message);
     };
 };

--- a/addons/sys_radio/fnc_monitorRadios.sqf
+++ b/addons/sys_radio/fnc_monitorRadios.sqf
@@ -190,7 +190,7 @@ DFUNC(checkServerDesyncBug) = {
 ADDPFH(DFUNC(checkServerDesyncBug), 1, []);
 
 DFUNC(hasGearDesync) = {
-    if(ACRE_SERVER_GEAR_DESYNCED) then {
+    if(ACRE_SERVER_GEAR_DESYNCED && GVAR(disableDesyncHint)) then {
         private _message = "ACRE has determined that players in this mission have an inventory that has desynchronized from the server, this is due to a bug in the mission or a bug in Arma 3, NOT ACRE. This message will not dissappear and is a warning that ACRE may no longer be functioning correctly in this mission. The players experiencing the bug are listed below:\n\n";
         {
             _message = _message + format ["%1\n", name _x];

--- a/addons/sys_radio/fnc_monitorRadios.sqf
+++ b/addons/sys_radio/fnc_monitorRadios.sqf
@@ -195,12 +195,9 @@ DFUNC(hasGearDesync) = {
         {
             _message = _message + format ["%1\n", name _x];
         } forEach ACRE_SERVER_DESYNCED_PLAYERS;
-        if(GVAR(disableDesyncHint)) then {
-            diag_log _message;
-        } else {
+        if (!GVAR(disableDesyncHint)) then {
             hintSilent _message;
         };
-
         WARNING(_message);
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Allow the player to disable the GearDesync Hint
- Most communities are aware of the issues with gearDesyncs
- Some players want to capture videos and don't care about gear desync
- If hint is disabled, it is written to rpt. So we can still debug it on upcoming issues