### PR TITLE
SEM52: Fix floating point number issues

### DIFF
--- a/addons/sys_sem52sl/functions/fnc_onChannelKnobPress.sqf
+++ b/addons/sys_sem52sl/functions/fnc_onChannelKnobPress.sqf
@@ -112,7 +112,7 @@ if(_knobPosition != _newKnobPosition) then {
                             private _floor = floor (GVAR(newFrequency));
                             private _dif = GVAR(newFrequency) - _floor;
                             _dif = _dif + GVAR(selectionDir)*0.025;
-                            if (_dif >= 1) then {
+                            if (_dif >= 0.999) then {
                                 _dif = 0;
                             };
                             if (_dif < 0) then {

--- a/addons/sys_sem52sl/functions/fnc_onPTTButtonPress.sqf
+++ b/addons/sys_sem52sl/functions/fnc_onPTTButtonPress.sqf
@@ -49,8 +49,12 @@ if (_knobPosition == 15) then { //programming mode
             // SAVE.
             private _channels = GET_STATE("channels");
             private _channel = _channels select GVAR(selectedChannel);
-            HASH_SET(_channel,"frequencyRX",GVAR(newFrequency));
-            HASH_SET(_channel,"frequencyTX",GVAR(newFrequency));
+
+            private _floored = floor (GVAR(newFrequency));
+            private _decimal = GVAR(newFrequency) - _floored;
+            private _frequency = _floored + ((round (_decimal * 40)) * 0.025);
+            HASH_SET(_channel,"frequencyRX",_frequency);
+            HASH_SET(_channel,"frequencyTX",_frequency);
             ["setChannelData", [GVAR(selectedChannel), _channel]] call GUI_DATA_EVENT;
 
             [GVAR(currentRadioId), "setState", ["programmingStep",0]] call EFUNC(sys_data,dataEvent);


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes floating point issues that arose when programming SEM52 channels. Addressing #121 
- Prevents 49 rolling over to 50.
- Ensures that regardless of increasing or decreasing a frequency that they will always match.