### PR TITLE
Correct underwater check for spectator - use camera position rather than unit position

### DIFF
--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -115,13 +115,6 @@ ACRE_PLAYER_VEHICLE_CREW = [];
 
 private _vehicleCrewPFH = {
     private _vehicle = vehicle acre_player;
-    private _height = eyePos acre_player param [2, 1];
-
-    if (_height < 0) then {
-        ACRE_LISTENER_DIVE = 1;
-    } else {
-        ACRE_LISTENER_DIVE = 0;
-    };
 
     if (_vehicle != acre_player) then {
         private _crew = [driver _vehicle, gunner _vehicle, commander _vehicle];

--- a/addons/sys_core/fnc_updateSelf.sqf
+++ b/addons/sys_core/fnc_updateSelf.sqf
@@ -28,5 +28,13 @@ if(!ACRE_IS_SPECTATOR) then {
 } else {
     ACRE_LISTENER_POS = _projectPos1;
 };
+
+private _height = ACRE_LISTENER_POS param [2, 1];
+if (_height < 0) then {
+    ACRE_LISTENER_DIVE = 1;
+} else {
+    ACRE_LISTENER_DIVE = 0;
+};
+
 private _additionalValues = [([] call FUNC(getSpeakingLanguageId))];
 CALL_RPC("updateSelf", ACRE_LISTENER_POS + ACRE_LISTENER_DIR + _additionalValues);


### PR DESCRIPTION
**When merged this pull request will:**
- Correct underwater check for spectator - use camera position rather than `acre_player` position