### PR TITLE
Fix Volume control init

### DIFF
--- a/addons/sys_gui/XEH_preInit.sqf
+++ b/addons/sys_gui/XEH_preInit.sqf
@@ -25,7 +25,7 @@ DFUNC(inventoryListMouseUp) = {
 
 //[] call FUNC(initializeVolumeControl);
 
-DVAR(ACRE_CustomVolumeControl) = nil;
+DVAR(ACRE_CustomVolumeControl) = [displayNull]; //Stores the display of the volume control
 GVAR(VolumeControl_Level) = 0; // range of -2 to +2
 GVAR(keyBlock) = false;
 

--- a/addons/sys_gui/XEH_preInit.sqf
+++ b/addons/sys_gui/XEH_preInit.sqf
@@ -25,7 +25,7 @@ DFUNC(inventoryListMouseUp) = {
 
 //[] call FUNC(initializeVolumeControl);
 
-DVAR(ACRE_CustomVolumeControl) = [displayNull]; //Stores the display of the volume control
+DVAR(ACRE_CustomVolumeControl) = nil;
 GVAR(VolumeControl_Level) = 0; // range of -2 to +2
 GVAR(keyBlock) = false;
 

--- a/addons/sys_gui/fnc_onVolumeControlAdjust.sqf
+++ b/addons/sys_gui/fnc_onVolumeControlAdjust.sqf
@@ -21,6 +21,8 @@ params ["","_amount"];
 
 if ((!alive player) || (time < 2)) exitWith {};
 
+if (isNil QGVAR(VolumeControlDialog)) exitWith {};
+
 if (isNull (GVAR(VolumeControlDialog) select 0)) exitWith {};
 
 if (_amount > 0) then {


### PR DESCRIPTION
**When merged this pull request will:**
- In essence there was a bug where using scroll wheel prior to the first opening of the volume control in  mission would effect the volume state. Two fold:
    - The visual indication would change confusing the user as this could be incorrect.
    - The second issue is this would be commit if the user starts transmitting on the radio. Due to the feature where people talking on the radio are at one volume state lower (and it uses the visual indication variable).
- Fix #84 