### PR TITLE
Add error logging for invalid garbage collection

### DIFF
--- a/addons/sys_server/fnc_clientGCRadio.sqf
+++ b/addons/sys_server/fnc_clientGCRadio.sqf
@@ -22,7 +22,7 @@ private _radioList = [] call EFUNC(sys_data,getPlayerRadioList);
 _radioList = _radioList apply {toLower _x};
 
 if ((toLower _radioId) in _radioList) then {
-    private _message = format ["[ACRE] Your radio '%1' is being garbage collected. The server believes you do not have this radio. You are probably desycned. Please contact the server administrator.",_radioId];
+    private _message = format ["[ACRE] Your radio '%1' is being garbage collected. The server believes you do not have this radio. You are probably desynced. Please contact the server administrator.",_radioId];
     systemChat _message;
     ERROR(_message);
 

--- a/addons/sys_server/fnc_clientGCRadio.sqf
+++ b/addons/sys_server/fnc_clientGCRadio.sqf
@@ -22,8 +22,8 @@ private _radioList = [] call EFUNC(sys_data,getPlayerRadioList);
 _radioList = _radioList apply {toLower _x};
 
 if ((toLower _radioId) in _radioList) then {
-    private _message = format ["[ACRE] Your radio '%1' is being garbage collected. The server believes you do not have this radio. You are probably desynced. Please contact the server administrator.",_radioId];
-    systemChat _message;
+    private _message = format ["Your radio '%1' is being garbage collected. The server believes you do not have this radio. You are probably desynced. Please contact the server administrator.",_radioId];
+    systemChat format ["[ACRE2] %1", _message];
     ERROR(_message);
 
     // Send event to server - so it is logged to server RPT as well.

--- a/addons/sys_server/fnc_clientGCRadio.sqf
+++ b/addons/sys_server/fnc_clientGCRadio.sqf
@@ -18,13 +18,27 @@
 
 params ["_radioId"];
 
+private _radioList = [] call EFUNC(sys_data,getPlayerRadioList);
+_radioList = _radioList apply {toLower _x};
+
+if ((toLower _radioId) in _radioList) then {
+    private _message = format ["[ACRE] Your radio '%1' is being garbage collected. The server believes you do not have this radio. You are probably desycned. Please contact the server administrator.",_radioId];
+    systemChat _message;
+    ERROR(_message);
+
+    // Send event to server - so it is logged to server RPT as well.
+    [QGVAR(invalidGarbageCollect), [acre_player, _radioId]] call CALLSTACK(CBA_fnc_serverEvent);
+};
+
+
 // if (!(_radioId in ([] call EFUNC(sys_data,getPlayerRadioList)))) then {
     HASH_SET(acre_sys_data_radioData, _radioId, nil);
     if (HASH_HASKEY(acre_sys_data_radioScratchData, _radioId)) then {
         HASH_REM(acre_sys_data_radioScratchData, _radioId);
     };
-    HASH_REM(GVAR(objectIdRelationTable), _radioId)
+    HASH_REM(GVAR(objectIdRelationTable), _radioId);
 // } else {
+    // NOTE - If you intend to uncomment this the format of Radio Data is now HASH - This would need addressing if the following was to be re-used.
     // _radioData = HASH_GET(acre_sys_data_radioData, _radioId);
 
     // [QGVAR(invalidGarbageCollect), [acre_player, _radioId, _radioData]] call CALLSTACK(CBA_fnc_serverEvent);

--- a/addons/sys_server/fnc_collect.sqf
+++ b/addons/sys_server/fnc_collect.sqf
@@ -17,7 +17,7 @@
 #include "script_component.hpp"
 
 params ["_radioId"];
-
+_radioId = toLower _radioId;
 private _baseRadio = configName (inheritsFrom (configFile >> "CfgWeapons" >> _radioId));
 private _idNumber = getNumber (configFile >> "CfgWeapons" >> _radioId >> "acre_uniqueId");
 private _keyIndex = (GVAR(radioIdMap) select 0) find _baseRadio;

--- a/addons/sys_server/fnc_invalidGarbageCollect.sqf
+++ b/addons/sys_server/fnc_invalidGarbageCollect.sqf
@@ -16,11 +16,13 @@
  */
 #include "script_component.hpp"
 
-params ["_player", "_radioId", "_radioData"];
+params ["_player", "_radioId"/*, "_radioData"*/];
 
-WARNING_2("Invalid garbage collection done on radio %1 for player %2! Restoring all data!",_radioId,name _player);
+ERROR_2("Invalid garbage collection done on radio %1 for player %2! Please forward on the client and server RPTs to the ACRE2 bug tracker.",_radioId,name _player);
 
-private _baseRadio = configName(inheritsFrom (configFile >> "CfgWeapons" >> _radioId));
+// NOTE - Format of Radio Data is now HASH - This would need addressing if the following was to be re-used.
+
+/*private _baseRadio = configName(inheritsFrom (configFile >> "CfgWeapons" >> _radioId));
 private _idNumber = getNumber (configFile >> "CfgWeapons" >> _radioId >> "acre_uniqueId");
 
 private _key = (GVAR(radioIdMap) select 0) find _baseRadio;
@@ -32,7 +34,7 @@ if (_key != -1) then {
     PUSH(GVAR(masterIdList), tolower(_radioId));
     HASH_SET(acre_sys_data_radioData, tolower(_radioId), _radioData);
 
-    [QGVAR(restoreInvalidGCData), [_this select 1, _this select 2]] call CALLSTACK(CBA_fnc_globalEvent);
+    [QGVAR(restoreInvalidGCData), [_radioId, _radioData]] call CALLSTACK(CBA_fnc_globalEvent);
 } else {
     WARNING_1("Looking to restore type %1. Could not find!",_radioId);
-};
+};*/

--- a/addons/sys_server/fnc_onGetRadioId.sqf
+++ b/addons/sys_server/fnc_onGetRadioId.sqf
@@ -27,7 +27,7 @@ if (_ret != -1) then {
     private _uniqueClass = format["%1_id_%2", tolower(_class), _ret];
 
     if (!(_uniqueClass in GVAR(masterIdList))) then {
-        PUSH(GVAR(masterIdList), _uniqueClass);
+        GVAR(masterIdList) pushBack _uniqueClass;
         if (isServer) then {
             private _dataHash = HASH_CREATE;
             if (_replacementId != "") then {
@@ -36,7 +36,7 @@ if (_ret != -1) then {
             HASH_SET(acre_sys_data_radioData,_uniqueClass,_dataHash);
         };
         TRACE_1("callback=", _callback);
-        PUSH(GVAR(unacknowledgedIds), _uniqueClass);
+        GVAR(unacknowledgedIds) pushBack _uniqueClass;
         HASH_SET(GVAR(masterIdTable), _uniqueClass, [ARR_2(acre_player,acre_player)]);
         [_callback, [_player, _uniqueClass, _ret, _replacementId]] call CALLSTACK(CBA_fnc_globalEvent);
         // GVAR(waitingForIdAck) = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Adds RPT logging on both client and server if a radio is garbage collected that is contained in a player's inventory
- Adds a `systemChat` notification to the local player - Which isn't too intrusive as if this were to occur it would likely be mid-game.