### PR TITLE
SEM52SL - Fix knob position in UI not updating when using acre_api_fnc_setRadioChannel

### DIFF
--- a/addons/sys_sem52sl/functions/fnc_render.sqf
+++ b/addons/sys_sem52sl/functions/fnc_render.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 #define RADIO_CTRL(var1) (_display displayCtrl var1)
-
+disableSerialization;
 params ["_display"];
 
 

--- a/addons/sys_sem52sl/radio/fnc_setCurrentChannel.sqf
+++ b/addons/sys_sem52sl/radio/fnc_setCurrentChannel.sqf
@@ -46,3 +46,14 @@ private _channelCount = count (HASH_GET(_radioData, "channels")) - 1;
 // And write the new channel to the radioData hash
 private _newChannel = (0 max _eventData) min _channelCount;
 HASH_SET(_radioData,"currentChannel",_newChannel);
+
+private _channelKnobPosition = _newChannel+2; // position 0 is off, 1 is last channel, so offset by 2
+private _currentChannelKnobPosition = HASH_GET(_radioData,"channelKnobPosition");
+if (_currentChannelKnobPosition != 1) then { //If set to Ein channel don't update the knob position.
+    if (_currentChannelKnobPosition != _channelKnobPosition) then {
+        HASH_SET(_radioData,"channelKnobPosition",_channelKnobPosition);
+        if (!(GVAR(currentRadioId) isEqualTo -1)) then { // is dialog open.
+            [MAIN_DISPLAY] call FUNC(render);
+        };
+    };
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes `acre_api_fnc_setRadioChannel` when used on a SEM52SL. Previously the UI knob position would not update.
- Also will update the UI if called when UI is open.