### PR TITLE
Cleanup unacknowledged IDs after a time-out period

### DIFF
--- a/addons/sys_server/XEH_preInitServer.sqf
+++ b/addons/sys_server/XEH_preInitServer.sqf
@@ -23,9 +23,11 @@ DGVAR(masterIdList) = [];
 DVAR(ACRE_SPECTATORS_LIST) = [];
 
 GVAR(masterIdTable) = HASH_CREATE;
-GVAR(unacknowledgedIds) = [];
 GVAR(doFullSearch) = false;
 GVAR(waitingForIdAck) = false;
 GVAR(nextSearchTime) = diag_tickTime + 5;
+
+GVAR(unacknowledgedIds) = [];
+GVAR(unacknowledgedTable) = HASH_CREATE;
 
 ADDON = true;

--- a/addons/sys_server/fnc_acknowledgeId.sqf
+++ b/addons/sys_server/fnc_acknowledgeId.sqf
@@ -1,22 +1,23 @@
 /*
  * Author: ACRE2Team
- * SHORT DESCRIPTION
+ * Acknowledges that a radio of with the ID has been created.
  *
  * Arguments:
- * 0: ARGUMENT ONE <TYPE>
- * 1: ARGUMENT TWO <TYPE>
+ * 0: Radio class name <STRING>
+ * 1: Player <OBJECT>
  *
  * Return Value:
- * RETURN VALUE <TYPE>
+ * None
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * ["acre_prc343_id_1", acre_player] call acre_sys_server_fnc_acknowledgeId;
  *
  * Public: No
  */
 #include "script_component.hpp"
 
 params ["_class","_player"];
+_class = toLower _class;
 
 if ((GVAR(unacknowledgedIds) find _class) != -1) then {
     if (!isDedicated) then {
@@ -24,11 +25,13 @@ if ((GVAR(unacknowledgedIds) find _class) != -1) then {
             private _fnc = {
                 _class = _this;
                 GVAR(unacknowledgedIds) = GVAR(unacknowledgedIds) - [_class];
+                HASH_REM(GVAR(unacknowledgedTable), _class);
             };
             [_fnc, _class] call CBA_fnc_execNextFrame;
         };
     } else {
         GVAR(unacknowledgedIds) = GVAR(unacknowledgedIds) - [_class];
+        HASH_REM(GVAR(unacknowledgedTable), _class);
     };
 } else {
     WARNING_2("%1 attempted to acknowledge ID %2 which was not awaiting acknowledgement",_player,_class);

--- a/addons/sys_server/fnc_acknowledgeId.sqf
+++ b/addons/sys_server/fnc_acknowledgeId.sqf
@@ -10,7 +10,7 @@
  * None
  *
  * Example:
- * ["acre_prc343_id_1", acre_player] call acre_sys_server_fnc_acknowledgeId;
+ * ["acre_prc343_id_1", acre_player] call acre_sys_server_fnc_acknowledgeId
  *
  * Public: No
  */

--- a/addons/sys_server/fnc_doAddComponentCargo.sqf
+++ b/addons/sys_server/fnc_doAddComponentCargo.sqf
@@ -19,17 +19,18 @@
 params["_container","_type","_preset","_player","_callBack","_failCallback"];
 
 diag_log text format ["this: %1", _this];
-_hasUnique = getNumber (configFile >> "CfgWeapons" >> _type >> "acre_hasUnique");
+private _hasUnique = getNumber (configFile >> "CfgWeapons" >> _type >> "acre_hasUnique");
 
 if (_hasUnique == 1) then {
-    _ret = [_type] call FUNC(getRadioId);
+    private _ret = [_type] call FUNC(getRadioId);
     if (_ret != -1) then {
-         _uniqueComponent = format ["%1_id_%2", tolower _type, _ret];
+         private _uniqueComponent = format ["%1_id_%2", tolower _type, _ret];
          if (!(_uniqueComponent in GVAR(masterIdList))) then {
-             PUSH(GVAR(masterIdList), _uniqueComponent);
-             _dataHash = HASH_CREATE;
+             GVAR(masterIdList) pushBack _uniqueComponent;
+             private _dataHash = HASH_CREATE;
              HASH_SET(acre_sys_data_radioData,_uniqueComponent,_dataHash);
-             PUSH(GVAR(unacknowledgedIds), _uniqueComponent);
+             GVAR(unacknowledgedIds) pushBack _uniqueComponent;
+             HASH_SET(GVAR(unacknowledgedTable), _uniqueComponent, time);
              HASH_SET(GVAR(masterIdTable), _uniqueComponent, [ARR_2(_container,_container)]);
              _container addItemCargoGlobal [_uniqueComponent, 1];
              [_uniqueComponent, "initializeComponent", [_type, _preset]] call EFUNC(sys_data,dataEvent);
@@ -37,8 +38,9 @@ if (_hasUnique == 1) then {
                  [_callBack, [_uniqueComponent]+_this] call CALLSTACK(CBA_fnc_globalEvent);
              };
              _fnc = {
-                 _uniqueComponent = _this;
+                 private _uniqueComponent = _this;
                  GVAR(unacknowledgedIds) = GVAR(unacknowledgedIds) - [_uniqueComponent];
+                 HASH_REM(GVAR(unacknowledgedTable),_uniqueComponent);
              };
              [_fnc, _uniqueComponent] call CBA_fnc_execNextFrame;
              // GVAR(waitingForIdAck) = true;

--- a/addons/sys_server/fnc_onGetRadioId.sqf
+++ b/addons/sys_server/fnc_onGetRadioId.sqf
@@ -37,6 +37,7 @@ if (_ret != -1) then {
         };
         TRACE_1("callback=", _callback);
         GVAR(unacknowledgedIds) pushBack _uniqueClass;
+        HASH_SET(GVAR(unacknowledgedTable), _uniqueClass, time);
         HASH_SET(GVAR(masterIdTable), _uniqueClass, [ARR_2(acre_player,acre_player)]);
         [_callback, [_player, _uniqueClass, _ret, _replacementId]] call CALLSTACK(CBA_fnc_globalEvent);
         // GVAR(waitingForIdAck) = true;


### PR DESCRIPTION
**When merged this pull request will:**
- When a unique radio ID is created it reverses an ID this becomes an unacknowledged ID until the client that requested the unique ID acknowledges it. One quirk was that if a client disconnects mid-process the ID would be reserved forever. This PR will now free-up the unacknowledged IDs after 60 seconds.