### PR TITLE
Change example documentation for company signals setup

### DIFF
--- a/extras/examples/mission_setupCompanySignals.sqf
+++ b/extras/examples/mission_setupCompanySignals.sqf
@@ -1,7 +1,7 @@
 /*
  * Sample of setting up RTO's for a company signals setup.
  *
- * Called by: [this, "platoon_rto"] call compile "mission_setupCompanySignals.sqf";
+ * Called by: [this, "platoon_rto"] call compile preprocessFileLineNumbers "mission_setupCompanySignals.sqf";
  *
  * This setup assumes that each RTO has a single PRC-152 and a single PRC-117F.
  * Each platoon command and the company commander has not been configured in this config,


### PR DESCRIPTION
As per a brief discussion on Slack, the call given in the `mission_setupCompanySignals.sqf` example doesn't seem to actually work. Adding `preprocessFileLineNumbers` seems to fix it. I honestly have no idea why it makes a difference but @jonpas suggested it, and then hinted I should submit a PR after it worked.. 

**When merged this pull request will:**
- Change the example call in `mission_setupCompanySignals.sqf` to use `preprocessFileLineNumbers`
