### PR TITLE
Implement event caching

### DIFF
--- a/addons/sys_data/XEH_preInit.sqf
+++ b/addons/sys_data/XEH_preInit.sqf
@@ -6,16 +6,19 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
-DGVAR(radioPresets) = HASH_CREATE;
-DGVAR(radioData) = HASH_CREATE;
-DGVAR(radioPresets) = HASH_CREATE;
-DGVAR(assignedRadioPresets) = HASH_CREATE;
-DGVAR(currentRadioStates) = HASH_CREATE;
-DGVAR(eventQueue) = [];
-DGVAR(pendingNetworkEvents) = [];
-DGVAR(pendingSyncEvents) = [];
-DGVAR(radioScratchData) = HASH_CREATE;
-DGVAR(forceHighPriorityIds) = [];
+GVAR(radioPresets) = HASH_CREATE;
+GVAR(radioData) = HASH_CREATE;
+GVAR(radioPresets) = HASH_CREATE;
+GVAR(assignedRadioPresets) = HASH_CREATE;
+GVAR(currentRadioStates) = HASH_CREATE;
+GVAR(eventQueue) = [];
+GVAR(pendingNetworkEvents) = [];
+GVAR(pendingSyncEvents) = [];
+GVAR(radioScratchData) = HASH_CREATE;
+GVAR(forceHighPriorityIds) = [];
+
+GVAR(sysEventCache) = HASH_CREATE;
+GVAR(radioEventCache) = HASH_CREATE;
 
 DVAR(ACRE_DATA_SYNCED) = false;
 
@@ -24,14 +27,14 @@ DVAR(ACRE_DEBUG_ECOUNT) = 0;
 DVAR(ACRE_DEBUG_CTIME) = 0;
 DVAR(ACRE_DEBUG_CALLLIST) = [];
 
-DGVAR(serverNetworkIdCounter) = 0;
+GVAR(serverNetworkIdCounter) = 0;
 
 ACREc = "";
 ACREs = "";
 ACREjipc = "";
 ACREjips = "";
 
-DGVAR(validStates) = HASH_CREATE;
+GVAR(validStates) = HASH_CREATE;
 
 DFUNC(_hashSerialize) = {
     private _hash = _this;

--- a/addons/sys_data/fnc_processRadioEvent.sqf
+++ b/addons/sys_data/fnc_processRadioEvent.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_data_fnc_processRadioEvent
  *
  * Public: No
  */
@@ -19,6 +19,7 @@
 #define DEBUG_MODE_REBUILD
 
 params ["_eventKind","_radioId","_event",["_data",[]],["_remote",false]];
+private _return = nil;
 
 if (!HASH_HASKEY(GVAR(radioData), _radioId)) exitWith {
     WARNING_2("Non-existent radio '%1' called %2 radio event!",_radioId,_event);
@@ -27,17 +28,22 @@ if (!HASH_HASKEY(GVAR(radioData), _radioId)) exitWith {
 
 private _radioData = HASH_GET(GVAR(radioData), _radioId);
 
-//_return = nil;
+private _cachekey = _eventKind+":"+_radioId+":"+_event;
+private _handlerFunction = HASH_GET(GVAR(radioEventCache),_cacheKey);
+if (isNil "_handlerFunction") then {
+    private _radioBaseClass = getText(configFile >> "CfgWeapons" >> _radioId >> "acre_baseClass");
 
-private _radioBaseClass = getText(configFile >> "CfgWeapons" >> _radioId >> "acre_baseClass");
-
-private _interfaceClass = getText(configFile >> "CfgAcreComponents" >> _radioBaseClass >> "InterfaceClasses" >> _eventKind);
-if (_interfaceClass == "") then {
-    _interfaceClass = "DefaultInterface";
+    private _interfaceClass = getText(configFile >> "CfgAcreComponents" >> _radioBaseClass >> "InterfaceClasses" >> _eventKind);
+    if (_interfaceClass == "") then {
+        _interfaceClass = "DefaultInterface";
+    };
+    _handlerFunction = (getText (configFile >> "CfgAcreComponents" >> _radioBaseClass >> "Interfaces" >> _eventKind >> _event));
+    HASH_SET(GVAR(radioEventCache),_cachekey,_handlerFunction);
 };
-private _handlerFunction = (getText (configFile >> "CfgAcreComponents" >> _radioBaseClass >> "Interfaces" >> _eventKind >> _event));
 
-private _return = [_radioId, _event, _data, _radioData, _remote] call (missionNamespace getVariable [_handlerFunction, FUNC(noApiFunction)]);
+if (_handlerFunction != "") then {
+    _return = [_radioId, _event, _data, _radioData, _remote] call (missionNamespace getVariable [_handlerFunction, FUNC(noApiFunction)]);
+};
 
 if (isNil "_return") exitWith { nil };
 _return;

--- a/addons/sys_data/fnc_processSysEvent.sqf
+++ b/addons/sys_data/fnc_processSysEvent.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_data_fnc_processSysEvent
  *
  * Public: No
  */
@@ -27,15 +27,22 @@ if (!HASH_HASKEY(GVAR(radioData), _radioId)) exitWith {
     WARNING_2("Non-existent radio '%1' called %2 system event!",_radioId,_event);
     nil
 };
+
 private _radioData = HASH_GET(GVAR(radioData), _radioId);
 
-private _radioBaseClass = getText(configFile >> "CfgWeapons" >> _radioId >> "acre_baseClass");
+private _cachekey = _eventKind+":"+_radioId+":"+_event;
+private _handlerFunction = HASH_GET(GVAR(sysEventCache),_cacheKey);
+if (isNil "_handlerFunction") then {
+    private _radioBaseClass = getText(configFile >> "CfgWeapons" >> _radioId >> "acre_baseClass");
 
-private _interfaceClass = getText(configFile >> "CfgAcreComponents" >> _radioBaseClass >> "InterfaceClasses" >> _eventKind);
-if (_interfaceClass == "") then {
-    _interfaceClass = "DefaultInterface";
+    private _interfaceClass = getText(configFile >> "CfgAcreComponents" >> _radioBaseClass >> "InterfaceClasses" >> _eventKind);
+    if (_interfaceClass == "") then {
+        _interfaceClass = "DefaultInterface";
+    };
+    _handlerFunction = getText(configFile >> _eventKind >> _interfaceClass >> _event >> "handler");
+    HASH_SET(GVAR(sysEventCache),_cachekey,_handlerFunction);
 };
-private _handlerFunction = getText(configFile >> _eventKind >> _interfaceClass >> _event >> "handler");
+
 if (_handlerFunction != "") then {
     _return = [_radioId, _event, _data, _radioData, _eventKind, _remote] call (missionNamespace getVariable [_handlerFunction, FUNC(noApiSystemFunction)]);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- The event system is used extensively throughout ACRE when handling radio data. This caches the config lookups to determine which function calls to make. The initial calls will still suffer worst case but repetitive calls are common throughout.
- Example (using the debug console performance tester):
```sqf
["CfgAcreDataInterface","acre_prc343_id_1","getChannelDescription",1] call acre_sys_data_fnc_acreEvent;
```
```sqf
before: 0.490436 ms 
after: 0.140865 ms
```