### PR TITLE
Minor 117+152 render speed improvements and minor cleanup

### DIFF
--- a/addons/sys_prc117f/farris_menus/Loading.sqf
+++ b/addons/sys_prc117f/farris_menus/Loading.sqf
@@ -31,8 +31,8 @@ DFUNC(Loading_BarFill) = {
     if (isNil QGVAR(currentBarFill)) then { GVAR(currentBarFill) = 0.0; };
     GVAR(currentBarFill) = GVAR(currentBarFill) + 0.05;
 
-    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-    if (!isNil "_display") then {
+    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+    if (!isNull _display) then {
         (_display displayCtrl ICON_LOADING) progressSetPosition GVAR(currentBarFill);
         (_display displayCtrl ICON_LOADING) ctrlCommit 0;
     };
@@ -92,8 +92,8 @@ GVAR(LOADING) = ["LOADING", "LOADING", "",
                     TRACE_1("Rendering LOADING-STAGE-2","");
                     GVAR(currentBarFill) = 0;
                     [ICON_LOADING, true] call DFUNC(toggleIcon);
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-                    if (!isNil "_display") then {
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_LOADING) progressSetPosition 0.0;
                         (_display displayCtrl ICON_LOADING) ctrlCommit 0;
                     };

--- a/addons/sys_prc117f/farris_menus/Main.sqf
+++ b/addons/sys_prc117f/farris_menus/Main.sqf
@@ -97,10 +97,10 @@ GVAR(VOLUME) = ["VOLUME", "VOLUME", "",
             [ICON_LOADING, true] call DFUNC(toggleIcon);
             private _volume = GET_STATE("volume");
 
-            private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+            private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 
             TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-            if (!isNil "_display") then {
+            if (!isNull _display) then {
                 (_display displayCtrl ICON_LOADING) progressSetPosition _volume;
                 (_display displayCtrl ICON_LOADING) ctrlCommit 0;
             };
@@ -131,11 +131,11 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
                     //[ICON_TRANSMIT, true] call FUNC(toggleIcon);
 
                     private _volume = GET_STATE("volume");
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID), "receivingSignal", 0);
 
                     TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-                    if (!isNil "_display") then {
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_VOLUME) progressSetPosition _volume;
                         (_display displayCtrl ICON_VOLUME) ctrlCommit 0;
                         (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;
@@ -161,11 +161,11 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
                     [ICON_VOLUME, true] call FUNC(toggleIcon);
                     [ICON_TRANSMITBAR, true] call FUNC(toggleIcon);
                     //[ICON_TRANSMIT, true] call FUNC(toggleIcon);
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID), "receivingSignal", 0);
 
                     TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-                    if (!isNil "_display") then {
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;
                         (_display displayCtrl ICON_TRANSMITBAR) ctrlCommit 0;
                     };
@@ -189,11 +189,11 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
                     [ICON_VOLUME, true] call FUNC(toggleIcon);
                     [ICON_TRANSMITBAR, true] call FUNC(toggleIcon);
                     //[ICON_TRANSMIT, true] call FUNC(toggleIcon);
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID), "receivingSignal", 0);
 
                     TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-                    if (!isNil "_display") then {
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;
                         (_display displayCtrl ICON_TRANSMITBAR) ctrlCommit 0;
                     };

--- a/addons/sys_prc117f/fnc_render.sqf
+++ b/addons/sys_prc117f/fnc_render.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc117f_fnc_render
  *
  * Public: No
  */
@@ -21,11 +21,11 @@ if ((count _this) > 0) then {
     _display = _this select 0;
     uiNamespace setVariable [QGVAR(currentDisplay), _display];
 } else {
-    _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+    _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 };
 
-_knobPosition = GET_STATE_DEF("knobPosition", 1);
-_knobImageStr = [_knobPosition, 2, 0] call CBA_fnc_formatNumber;
+private _knobPosition = GET_STATE_DEF("knobPosition", 1);
+private _knobImageStr = [_knobPosition, 2, 0] call CBA_fnc_formatNumber;
 _knobImageStr = format["\idi\acre\addons\sys_prc117f\Data\knobs\switch\prc117f_ui_swtch1_%1.paa", _knobImageStr];
 TRACE_1("Setting knob image", _knobImageStr);
 

--- a/addons/sys_prc117f/menus/fnc_clearDisplay.sqf
+++ b/addons/sys_prc117f/menus/fnc_clearDisplay.sqf
@@ -10,22 +10,24 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc117f_fnc_clearDisplay
  *
  * Public: No
  */
 #include "script_component.hpp"
+
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 
 FUNC(_internalClearDisplay) = {
     params ["_row", "_columns"];
 
     for "_i" from 0 to _columns do {
         private _id = ((_row * 1000) +1) + _i;
-
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlSetBackgroundColor [0.1, 0.1, 0.1, 0];
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlSetTextColor [0.1, 0.1, 0.1, 1];
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlSetText "";
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlCommit 0;
+        private _ctrl = (_display displayCtrl _id);
+        _ctrl ctrlSetBackgroundColor [0.1, 0.1, 0.1, 0];
+        _ctrl ctrlSetTextColor [0.1, 0.1, 0.1, 1];
+        _ctrl ctrlSetText "";
+        _ctrl ctrlCommit 0;
     };
 };
 

--- a/addons/sys_prc117f/menus/fnc_defaultButtonPress.sqf
+++ b/addons/sys_prc117f/menus/fnc_defaultButtonPress.sqf
@@ -21,7 +21,7 @@ params ["_menu", "_event"];
 private _ret = false;
 
 
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 TRACE_2("defaultButtonPress", _display, _event);
 switch (_event select 0) do {
     case 'VOLUME_UP': {

--- a/addons/sys_prc117f/menus/fnc_setRowText.sqf
+++ b/addons/sys_prc117f/menus/fnc_setRowText.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc117f_fnc_setRowText
  *
  * Public: No
  */
@@ -59,22 +59,17 @@ TRACE_3("setting text", _start, _rowCount, _length);
 
 private _baseId = (_row * 1000) +1;
 
-private _i = 0;
-while { _i < _rowCount} do {
+
+for "_i" from 0 to (_rowCount -1) do {
     private _id = _baseId + _i;
-    (_display displayCtrl _id) ctrlSetText "";
-    (_display displayCtrl _id) ctrlCommit 0;
-    _i = _i + 1;
+    private _ctrl = (_display displayCtrl _id);
+    _ctrl ctrlSetText "";
+    _ctrl ctrlCommit 0;
 };
 
-
-_i = 0;
-private _tmp = _start;
-while { _tmp < _rowCount && _i < _length} do {
-    private _id = _baseId + _tmp;
-    (_display displayCtrl _id) ctrlSetText (toString [_data select _i]);
-    (_display displayCtrl _id) ctrlCommit 0;
-
-    _tmp = _tmp + 1;
-    _i = _i + 1;
+for "_i" from _start to ((_rowCount -1) min (_start+_length-1)) do {
+    private _id = _baseId + _i;
+    private _ctrl = (_display displayCtrl _id);
+    _ctrl ctrlSetText (toString [_data select (_i-_start)]);
+    _ctrl ctrlCommit 0;
 };

--- a/addons/sys_prc117f/menus/fnc_toggleButtonPressDown.sqf
+++ b/addons/sys_prc117f/menus/fnc_toggleButtonPressDown.sqf
@@ -18,10 +18,10 @@
 
 private _button = toLower (_this select 0);
 private _iconcontrol = 1000;
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-if (!isNil "_display") then {
-        private _knobImageStr = QUOTE(\idi\acre\addons\sys_prc117f\Data\knobs\prc117f_ui_) + _button + QUOTE(.paa);
-        (_display displayCtrl _iconcontrol) ctrlSetText _knobImageStr;
-        SET_STATE("pressedButton",_button);
-        _ret = [GVAR(currentRadioId), FUNC(toggleButtonPressUp), 0.15] call FUNC(delayFunction);
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+if (isNull _display) then {
+    private _knobImageStr = QUOTE(\idi\acre\addons\sys_prc117f\Data\knobs\prc117f_ui_) + _button + QUOTE(.paa);
+    (_display displayCtrl _iconcontrol) ctrlSetText _knobImageStr;
+    SET_STATE("pressedButton",_button);
+    _ret = [GVAR(currentRadioId), FUNC(toggleButtonPressUp), 0.15] call FUNC(delayFunction);
 };

--- a/addons/sys_prc117f/menus/fnc_toggleButtonPressUp.sqf
+++ b/addons/sys_prc117f/menus/fnc_toggleButtonPressUp.sqf
@@ -17,8 +17,8 @@
 #include "script_component.hpp"
 
 private _iconcontrol = 1000;
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-if (!isNil "_display") then {
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+if (!isNull _display) then {
     private _knobImageStr = QUOTE(PATHTOF(Data\knobs\prc117f_ui_keys_default.paa));
     (_display displayCtrl _iconcontrol) ctrlSetText _knobImageStr;
     SET_STATE("pressedButton",-1);

--- a/addons/sys_prc117f/menus/fnc_toggleIcon.sqf
+++ b/addons/sys_prc117f/menus/fnc_toggleIcon.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc117f_fnc_renderMenu;
  *
  * Public: No
  */
@@ -18,17 +18,17 @@
 
 params ["_iconId", "_toggle"];
 
-_display = uiNamespace getVariable QGVAR(currentDisplay);
-_type = ctrlType (_display displayCtrl _iconId);
+private _ctrl = ((uiNamespace getVariable [QGVAR(currentDisplay), displayNull]) displayCtrl _iconId);
+private _type = ctrlType _ctrl;
 
 if ((count _this) > 2) then {
-    _newPosition = _this select 2;
-    (_display displayCtrl _iconId) ctrlSetPosition _toggle;
+    private _newPosition = _this select 2;
+    _ctrl ctrlSetPosition _toggle;
 };
 
 //if (_type == 8) then {
 //    (_display displayCtrl _iconId) progressSetPosition 0.85;
 //};
 
-(_display displayCtrl _iconId) ctrlShow _toggle;
-(_display displayCtrl _iconId) ctrlCommit 0;
+_ctrl ctrlShow _toggle;
+_ctrl ctrlCommit 0;

--- a/addons/sys_prc148/menus/fnc_toggleButtonPressDown.sqf
+++ b/addons/sys_prc148/menus/fnc_toggleButtonPressDown.sqf
@@ -18,8 +18,8 @@
 
 private _button = toLower (_this select 0);
 private _iconcontrol = 99901;
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-if (!isNil "_display") then {
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+if (!isNull _display) then {
     //if (GET_STATE("pressedButton") < 0) Then {
         private _knobImageStr = QUOTE(\idi\acre\addons\sys_prc148\data\Knobs\keypad\prc148_ui_keys_) + _button + QUOTE(.paa);
         (_display displayCtrl _iconcontrol) ctrlSetText _knobImageStr;

--- a/addons/sys_prc148/menus/fnc_toggleButtonPressUp.sqf
+++ b/addons/sys_prc148/menus/fnc_toggleButtonPressUp.sqf
@@ -18,8 +18,8 @@
 
 private _button = GET_STATE("pressedButton");
 private _iconcontrol = 99901;
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-if (!isNil "_display") then {
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+if (!isNull _display) then {
     private _knobImageStr = QUOTE(PATHTOF(Data\knobs\keypad\prc148_ui_keys_default.paa));
     (_display displayCtrl _iconcontrol) ctrlSetText _knobImageStr;
     SET_STATE("pressedButton",-1);

--- a/addons/sys_prc152/farris_menus/Loading.sqf
+++ b/addons/sys_prc152/farris_menus/Loading.sqf
@@ -16,8 +16,8 @@ DFUNC(Loading_BarFill) = {
     if (isNil QGVAR(currentBarFill)) then { GVAR(currentBarFill) = 0.0; };
     GVAR(currentBarFill) = GVAR(currentBarFill) + 0.05;
 
-    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-    if (!isNil "_display") then {
+    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+    if (!isNull _display) then {
         (_display displayCtrl ICON_LOADING) progressSetPosition GVAR(currentBarFill);
         (_display displayCtrl ICON_LOADING) ctrlCommit 0;
     };
@@ -77,8 +77,8 @@ GVAR(LOADING) = ["LOADING", "LOADING", "",
                     TRACE_1("Rendering LOADING-STAGE-2","");
                     GVAR(currentBarFill) = 0;
                     [ICON_LOADING, true] call DFUNC(toggleIcon);
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-                    if (!isNil "_display") then {
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_LOADING) progressSetPosition 0.0;
                         (_display displayCtrl ICON_LOADING) ctrlCommit 0;
                     };

--- a/addons/sys_prc152/farris_menus/Main.sqf
+++ b/addons/sys_prc152/farris_menus/Main.sqf
@@ -33,10 +33,10 @@ GVAR(VOLUME) = ["VOLUME", "VOLUME", "",
             [ICON_LOADING, true] call DFUNC(toggleIcon);
             private _volume = GET_STATE("volume");
 
-            private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+            private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 
             TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-            if (!isNil "_display") then {
+            if (!isNull _display) then {
                 (_display displayCtrl ICON_LOADING) progressSetPosition _volume;
                 (_display displayCtrl ICON_LOADING) ctrlCommit 0;
             };
@@ -93,11 +93,11 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
                     [ICON_TRANSMITBAR, true] call FUNC(toggleIcon);
 
                     private _volume = GET_STATE("volume");
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID), "receivingSignal", 0);
 
                     TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-                    if (!isNil "_display") then {
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_VOLUME) progressSetPosition _volume;
                         (_display displayCtrl ICON_VOLUME) ctrlCommit 0;
                         (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;
@@ -125,11 +125,11 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
                     [ICON_TRANSMITBAR, true] call FUNC(toggleIcon);
 
                     private _volume = GET_STATE("volume");
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID), "receivingSignal", 0);
 
                     TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-                    if (!isNil "_display") then {
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_VOLUME) progressSetPosition _volume;
                         (_display displayCtrl ICON_VOLUME) ctrlCommit 0;
                         (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;
@@ -157,11 +157,11 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
                     [ICON_TRANSMITBAR, true] call FUNC(toggleIcon);
 
                     private _volume = GET_STATE("volume");
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID), "receivingSignal", 0);
 
                     TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-                    if (!isNil "_display") then {
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_VOLUME) progressSetPosition _volume;
                         (_display displayCtrl ICON_VOLUME) ctrlCommit 0;
                         (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;
@@ -187,11 +187,11 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
                     [ICON_TRANSMITBAR, true] call FUNC(toggleIcon);
 
                     private _volume = GET_STATE("volume");
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID), "receivingSignal", 0);
 
                     TRACE_2("Rendering VOLUME-STAGE-1",_volume, _display);
-                    if (!isNil "_display") then {
+                    if (!isNull _display) then {
                         (_display displayCtrl ICON_VOLUME) progressSetPosition _volume;
                         (_display displayCtrl ICON_VOLUME) ctrlCommit 0;
                         (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;

--- a/addons/sys_prc152/fnc_render.sqf
+++ b/addons/sys_prc152/fnc_render.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc152_fnc_render
  *
  * Public: No
  */
@@ -21,7 +21,7 @@ if ((count _this) > 0) then {
     _display = _this select 0;
     uiNamespace setVariable [QGVAR(currentDisplay), _display];
 } else {
-    _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+    _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 };
 
 private _knobPosition = GET_STATE_DEF("knobPosition", 1);

--- a/addons/sys_prc152/menus/fnc_clearDisplay.sqf
+++ b/addons/sys_prc152/menus/fnc_clearDisplay.sqf
@@ -10,24 +10,25 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc152_fnc_clearDisplay
  *
  * Public: No
  */
 #include "script_component.hpp"
 
 BEGIN_COUNTER(clearDisplay);
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 
 FUNC(_internalClearDisplay) = {
     params ["_row", "_columns"];
 
     for "_i" from 0 to _columns do {
         private _id = ((_row * 1000) +1) + _i;
-
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlSetBackgroundColor [0.1, 0.1, 0.1, 0];
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlSetTextColor [0.1, 0.1, 0.1, 1];
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlSetText "";
-        ((uiNamespace getVariable [QGVAR(currentDisplay), nil]) displayCtrl (_id)) ctrlCommit 0;
+        private _ctrl = (_display displayCtrl _id);
+        _ctrl ctrlSetBackgroundColor [0.1, 0.1, 0.1, 0];
+        _ctrl ctrlSetTextColor [0.1, 0.1, 0.1, 1];
+        _ctrl ctrlSetText "";
+        _ctrl ctrlCommit 0;
     };
 };
 

--- a/addons/sys_prc152/menus/fnc_defaultButtonPress.sqf
+++ b/addons/sys_prc152/menus/fnc_defaultButtonPress.sqf
@@ -29,7 +29,7 @@ if (_dir == 0) then {
     };
 };
 
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
 TRACE_2("defaultButtonPress", _display, _event);
 switch (_event select 0) do {
     case 'VOLUME': {

--- a/addons/sys_prc152/menus/fnc_setRowText.sqf
+++ b/addons/sys_prc152/menus/fnc_setRowText.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc152_fnc_setRowText
  *
  * Public: No
  */
@@ -57,24 +57,18 @@ TRACE_3("setting text", _start, _rowCount, _length);
 
 private _baseId = (_row * 1000) +1;
 
-private _i = 0;
-while { _i < _rowCount} do {
+for "_i" from 0 to (_rowCount -1) do {
     private _id = _baseId + _i;
-    (_display displayCtrl _id) ctrlSetText "";
-    (_display displayCtrl _id) ctrlCommit 0;
-    _i = _i + 1;
+    private _ctrl = (_display displayCtrl _id);
+    _ctrl ctrlSetText "";
+    _ctrl ctrlCommit 0;
 };
 
-
-_i = 0;
-private _tmp = _start;
-while { _tmp < _rowCount && _i < _length} do {
-    private _id = _baseId + _tmp;
-    (_display displayCtrl _id) ctrlSetText (toString [_data select _i]);
-    (_display displayCtrl _id) ctrlCommit 0;
-
-    _tmp = _tmp + 1;
-    _i = _i + 1;
+for "_i" from _start to ((_rowCount -1) min (_start+_length-1)) do {
+    private _id = _baseId + _i;
+    private _ctrl = (_display displayCtrl _id);
+    _ctrl ctrlSetText (toString [_data select (_i-_start)]);
+    _ctrl ctrlCommit 0;
 };
 
 END_COUNTER(setRowText);

--- a/addons/sys_prc152/menus/fnc_toggleButtonPressDown.sqf
+++ b/addons/sys_prc152/menus/fnc_toggleButtonPressDown.sqf
@@ -18,8 +18,8 @@
 
 private _button = toLower (_this select 0);
 private _iconcontrol = 1000;
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-if (!isNil "_display") then {
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+if (!isNull _display) then {
         private _knobImageStr = QUOTE(\idi\acre\addons\sys_prc152\Data\Knobs\keypad\prc152c_ui_) + _button + QUOTE(.paa);
         (_display displayCtrl _iconcontrol) ctrlSetText _knobImageStr;
         SET_STATE("pressedButton",_button);

--- a/addons/sys_prc152/menus/fnc_toggleButtonPressUp.sqf
+++ b/addons/sys_prc152/menus/fnc_toggleButtonPressUp.sqf
@@ -17,8 +17,8 @@
 #include "script_component.hpp"
 
 private _iconcontrol = 1000;
-private _display = uiNamespace getVariable [QGVAR(currentDisplay), nil];
-if (!isNil "_display") then {
+private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
+if (!isNull _display) then {
     private _knobImageStr = QUOTE(PATHTOF(Data\Knobs\keypad\prc152c_ui_default.paa));
     (_display displayCtrl _iconcontrol) ctrlSetText _knobImageStr;
     SET_STATE("pressedButton",-1);

--- a/addons/sys_prc152/menus/fnc_toggleIcon.sqf
+++ b/addons/sys_prc152/menus/fnc_toggleIcon.sqf
@@ -10,7 +10,7 @@
  * RETURN VALUE <TYPE>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [ARGUMENTS] call acre_sys_prc152_fnc_toggleIcon
  *
  * Public: No
  */
@@ -18,17 +18,17 @@
 
 params ["_iconId","_toggle"];
 
-private _display = uiNamespace getVariable QGVAR(currentDisplay);
-private _type = ctrlType (_display displayCtrl _iconId);
+private _ctrl = ((uiNamespace getVariable [QGVAR(currentDisplay), displayNull]) displayCtrl _iconId);
+private _type = ctrlType _ctrl;
 
 if ((count _this) > 2) then {
     private _newPosition = _this select 2;
-    (_display displayCtrl _iconId) ctrlSetPosition _toggle;
+    _ctrl ctrlSetPosition _toggle;
 };
 
-if (_type == 8) then {
-    (_display displayCtrl _iconId) progressSetPosition 0.5;
+if (_type isEqualTo 8) then {
+    _ctrl progressSetPosition 0.5;
 };
 
-(_display displayCtrl _iconId) ctrlShow _toggle;
-(_display displayCtrl _iconId) ctrlCommit 0;
+_ctrl ctrlShow _toggle;
+_ctrl ctrlCommit 0;


### PR DESCRIPTION
**When merged this pull request will:**
- Encourage use of displayNull over nil default value when using getVariable to retrieve displays.
- Optimise the clearDisplay, setRowText and toggleIcon functions for the 152 and 117F radios to improve the rendering speed of the radio menus