### PR TITLE
Plugin auto-copy account for another directory

### DIFF
--- a/extensions/src/ACRE2Steam/CallExt_DllMain.cpp
+++ b/extensions/src/ACRE2Steam/CallExt_DllMain.cpp
@@ -363,6 +363,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
                 }
                 else {
                     ts_locations.push_back(rootkey);
+                    ts_delete_locations.push_back(rootkey + "\\config");
                 }
             }
 
@@ -376,6 +377,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
                 }
                 else {
                     ts_locations.push_back(rootkey);
+                    ts_delete_locations.push_back(rootkey + "\\config");
                 }
             }
 


### PR DESCRIPTION
**When merged this pull request will:**
- Account for another directory for registry user key installation, as it seems the local user install permits the config subdirectory for loading TS plugins: `C:\Users\<user>\AppData\Local\TeamSpeak 3 Client\config\plugins`


