### PR TITLE
Fix acknowledgeId not working on dedicated servers.

### DIFF
--- a/addons/sys_server/fnc_acknowledgeId.sqf
+++ b/addons/sys_server/fnc_acknowledgeId.sqf
@@ -20,7 +20,7 @@ params ["_class","_player"];
 _class = toLower _class;
 
 if ((GVAR(unacknowledgedIds) find _class) != -1) then {
-    if (isServer && {hasInterface && acre_player == _player}) then {
+    if (hasInterface && {isServer && {acre_player == _player}}) then {
         private _fnc = {
             _class = _this;
             GVAR(unacknowledgedIds) = GVAR(unacknowledgedIds) - [_class];


### PR DESCRIPTION
**When merged this pull request will:**
- Previously this would silently error out as `acre_player` is `nil` on dedicated servers.
