### PR TITLE
Fix acre_api_fnc_isBaseRadio function

### DIFF
--- a/addons/api/fnc_isBaseRadio.sqf
+++ b/addons/api/fnc_isBaseRadio.sqf
@@ -18,5 +18,3 @@
 params ["_weapon"];
 
 _weapon call EFUNC(sys_radio,isBaseClassRadio);
-
-false

--- a/addons/sys_radio/fnc_isBaseClassRadio.sqf
+++ b/addons/sys_radio/fnc_isBaseClassRadio.sqf
@@ -15,12 +15,14 @@
  */
 #include "script_component.hpp"
 
-if (HASH_HASKEY(GVAR(radioBaseClassCache),_this)) exitWith {
-    HASH_GET(GVAR(radioBaseClassCache),_this);
+params ["_radio"];
+
+if (HASH_HASKEY(GVAR(radioBaseClassCache),_radio)) exitWith {
+    HASH_GET(GVAR(radioBaseClassCache),_radio);
 };
 
-private _configEntry = configFile >> "CfgWeapons" >> _this;
+private _configEntry = configFile >> "CfgWeapons" >> _radio;
 private _isBaseClassRadio = (getNumber(_configEntry >> "acre_hasUnique") == 1) && {getNumber(_configEntry >> "acre_isRadio") == 1};
-HASH_SET(GVAR(radioBaseClassCache),_this,_isBaseClassRadio);
+HASH_SET(GVAR(radioBaseClassCache),_radio,_isBaseClassRadio);
 
 _isBaseClassRadio


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `acre_api_fnc_isBaseRadio` function which was in turn breaking `acre_api_fnc_isInitialized`.
- Improve input checking for `acre_sys_radio_fnc_isBaseClassRadio`.
