### PR TITLE
Fix auto-copy plugin paths

### DIFF
--- a/extensions/src/ACRE2Steam/CallExt_DllMain.cpp
+++ b/extensions/src/ACRE2Steam/CallExt_DllMain.cpp
@@ -337,6 +337,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
                 }
                 else {
                     ts_locations.push_back(rootkey);
+                    ts_delete_locations.push_back(rootkey + "\\config");
                 }
             }
 
@@ -350,6 +351,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function) {
                 }
                 else {
                     ts_locations.push_back(rootkey);
+                    ts_delete_locations.push_back(rootkey + "\\config");
                 }
             }
 


### PR DESCRIPTION
**When merged this pull request will:**
- Auto plugin-copy will clear the config folder for all cases of `configLocation=1`
