### PR TITLE
Make API difficulty setting functions block CBA settings if called directly

### DIFF
--- a/addons/api/fnc_ignoreAntennaDirection.sqf
+++ b/addons/api/fnc_ignoreAntennaDirection.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Enable ignoring of antenna direction (omnidirectional radios) <BOOL>
+ * 1: CBA Settings Call <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -15,13 +16,21 @@
  */
 #include "script_component.hpp"
 
-INFO_2("%1 called with: %2",QFUNC(ignoreAntennaDirection),_this);
-
 if (!hasInterface) exitWith {false};
 
-params ["_value"];
+// @todo remove backwards compatibility in 2.7.0 (including second argument) and move function to sys_core
+params ["_value", ["_CBASettingCall", false]];
 
-// input boolean
+// Backwards compatibility - block CBA settings if API function called directly
+if (_CBASettingCall && {!isNil QGVAR(ignoreAntennaDirectionBlockCBASetting)}) exitWith {};
+
+if (!_CBASettingCall) then {
+    GVAR(ignoreAntennaDirectionBlockCBASetting) = true;
+    ACRE_DEPRECATED(QFUNC(ignoreAntennaDirection),"2.7.0","CBA Settings");
+    WARNING_1("%1 has been called directly and CBA Setting for it has been blocked!",QFUNC(ignoreAntennaDirection));
+};
+
+// Set
 EGVAR(sys_signal,omnidirectionalRadios) = parseNumber _value;
 
 INFO_5("Difficulty changed. Interference: %1 - Duplex: %2 - Terrain Loss: %3 - Omni-directional: %4 - AI Hearing: %5",EGVAR(sys_core,interference),EGVAR(sys_core,fullDuplex),EGVAR(sys_signal,terrainScaling),EGVAR(sys_signal,omnidirectionalRadios),EGVAR(sys_core,revealToAI));

--- a/addons/api/fnc_setFullDuplex.sqf
+++ b/addons/api/fnc_setFullDuplex.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Enable full duplex <BOOL>
+ * 1: CBA Settings Call <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -15,12 +16,21 @@
  */
 #include "script_component.hpp"
 
-INFO_2("%1 called with: %2",QFUNC(setFullDuplex),_this);
-
 if (!hasInterface) exitWith {false};
 
-params ["_value"];
+// @todo remove backwards compatibility in 2.7.0 (including second argument) and move function to sys_core
+params ["_value", ["_CBASettingCall", false]];
 
+// Backwards compatibility - block CBA settings if API function called directly
+if (_CBASettingCall && {!isNil QGVAR(fullDuplexBlockCBASetting)}) exitWith {};
+
+if (!_CBASettingCall) then {
+    GVAR(fullDuplexBlockCBASetting) = true;
+    ACRE_DEPRECATED(QFUNC(setFullDuplex),"2.7.0","CBA Settings");
+    WARNING_1("%1 has been called directly and CBA Setting for it has been blocked!",QFUNC(setFullDuplex));
+};
+
+// Set
 EGVAR(sys_core,fullDuplex) = _value;
 
 INFO_5("Difficulty changed. Interference: %1 - Duplex: %2 - Terrain Loss: %3 - Omni-directional: %4 - AI Hearing: %5",EGVAR(sys_core,interference),EGVAR(sys_core,fullDuplex),EGVAR(sys_signal,terrainScaling),EGVAR(sys_signal,omnidirectionalRadios),EGVAR(sys_core,revealToAI));

--- a/addons/api/fnc_setInterference.sqf
+++ b/addons/api/fnc_setInterference.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Enable interference <BOOL>
+ * 1: CBA Settings Call <BOOL> (default: false)
  *
  * Return Value:
  * None
@@ -15,12 +16,21 @@
  */
 #include "script_component.hpp"
 
-INFO_2("%1 called with: %2",QFUNC(setInterference),_this);
-
 if (!hasInterface) exitWith {false};
 
-params ["_value"];
+// @todo remove backwards compatibility in 2.7.0 (including second argument) and move function to sys_core
+params ["_value", ["_CBASettingCall", false]];
 
+// Backwards compatibility - block CBA settings if API function called directly
+if (_CBASettingCall && {!isNil QGVAR(interferenceBlockCBASetting)}) exitWith {};
+
+if (!_CBASettingCall) then {
+    GVAR(interferenceBlockCBASetting) = true;
+    ACRE_DEPRECATED(QFUNC(setInterference),"2.7.0","CBA Settings");
+    WARNING_1("%1 has been called directly and CBA Setting for it has been blocked!",QFUNC(setInterference));
+};
+
+// Set
 EGVAR(sys_core,interference) = _value;
 
 INFO_5("Difficulty changed. Interference: %1 - Duplex: %2 - Terrain Loss: %3 - Omni-directional: %4 - AI Hearing: %5",EGVAR(sys_core,interference),EGVAR(sys_core,fullDuplex),EGVAR(sys_signal,terrainScaling),EGVAR(sys_signal,omnidirectionalRadios),EGVAR(sys_core,revealToAI));

--- a/addons/api/fnc_setLossModelScale.sqf
+++ b/addons/api/fnc_setLossModelScale.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Terrain loss scale (value between 0 and 1) <NUMBER>
+ * 1: CBA Settings Call <BOOL> (default: false)
  *
  * Return Value:
  * Terrain loss scale <NUMBER>
@@ -15,14 +16,22 @@
  */
 #include "script_component.hpp"
 
-INFO_2("%1 called with: %2",QFUNC(setLossModelScale),_this);
-
 if (!hasInterface) exitWith {false};
 
-params ["_scale"];
+// @todo remove backwards compatibility in 2.7.0 (including second argument) and move function to sys_core
+params ["_scale", ["_CBASettingCall", false]];
 
+// Backwards compatibility - block CBA settings if API function called directly
+if (_CBASettingCall && {!isNil QGVAR(terrainLossBlockCBASetting)}) exitWith {};
+
+if (!_CBASettingCall) then {
+    GVAR(terrainLossBlockCBASetting) = true;
+    ACRE_DEPRECATED(QFUNC(setLossModelScale),"2.7.0","CBA Settings");
+    WARNING_1("%1 has been called directly and CBA Setting for it has been blocked!",QFUNC(setLossModelScale));
+};
+
+// Set
 _scale = _scale max 0;
-
 EGVAR(sys_signal,terrainScaling) = _scale;
 
 INFO_5("Difficulty changed. Interference: %1 - Duplex: %2 - Terrain Loss: %3 - Omni-directional: %4 - AI Hearing: %5",EGVAR(sys_core,interference),EGVAR(sys_core,fullDuplex),EGVAR(sys_signal,terrainScaling),EGVAR(sys_signal,omnidirectionalRadios),EGVAR(sys_core,revealToAI));

--- a/addons/api/fnc_setRevealToAI.sqf
+++ b/addons/api/fnc_setRevealToAI.sqf
@@ -5,6 +5,7 @@
  *
  * Arguments:
  * 0: Reveal players to AI that speak <BOOL>
+ * 1: CBA Settings Call <BOOL> (default: false)
  *
  * Return Value:
  * Are players that speak revealed to AI <BOOL>
@@ -16,12 +17,21 @@
  */
 #include "script_component.hpp"
 
-INFO_2("%1 called with: %2",QFUNC(setRevealToAI),_this);
-
 if (!hasInterface) exitWith {false};
 
-params ["_var"];
+// @todo remove backwards compatibility in 2.7.0 (including second argument) and move function to sys_core
+params ["_var", ["_CBASettingCall", false]];
 
+// Backwards compatibility - block CBA settings if API function called directly
+if (_CBASettingCall && {!isNil QGVAR(revealToAIBlockCBASetting)}) exitWith {};
+
+if (!_CBASettingCall) then {
+    GVAR(revealToAIBlockCBASetting) = true;
+    ACRE_DEPRECATED(QFUNC(setRevealToAI),"2.7.0","CBA Settings");
+    WARNING_1("%1 has been called directly and CBA Setting for it has been blocked!",QFUNC(setRevealToAI));
+};
+
+// Set
 if !(_var isEqualType false) exitWith { false };
 
 if (!EGVAR(sys_core,revealToAI) && _var) then {

--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -47,7 +47,7 @@
     "ACRE2",
     true,
     true,
-    {[_this] call EFUNC(api,setInterference)}
+    {[_this, true] call EFUNC(api,setInterference)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;
 
 // Full duplex
@@ -58,7 +58,7 @@
     "ACRE2",
     false,
     true,
-    {[_this] call EFUNC(api,setFullDuplex)}
+    {[_this, true] call EFUNC(api,setFullDuplex)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;
 
 // Antena direction
@@ -69,7 +69,7 @@
     "ACRE2",
     false,
     true,
-    {[_this] call EFUNC(api,ignoreAntennaDirection)}
+    {[_this, true] call EFUNC(api,ignoreAntennaDirection)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;
 
 // Terrain loss
@@ -80,7 +80,7 @@
     "ACRE2",
     [0, 1, 1, 2],
     true,
-    {[_this] call EFUNC(api,setLossModelScale)}
+    {[_this, true] call EFUNC(api,setLossModelScale)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;
 
 // Reveal to AI
@@ -91,10 +91,11 @@
     "ACRE2",
     true,
     true,
-    {[_this] call EFUNC(api,setRevealToAI)}
+    {[_this, true] call EFUNC(api,setRevealToAI)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;
 
 
+// @todo remove in 2.7.0
 // Module settings
 // Applies the difficulty module settings over CBA settings. If the module is not present, this function has no effect.
 ["CBA_beforeSettingsInitialized", {


### PR DESCRIPTION
**When merged this pull request will:**
- Assures backwards compatibility for API difficulty setting functions
- Close #202 
- Deprecate API difficulty setting functions