### PR TITLE
Order radio ear left/right interactions correctly

### DIFF
--- a/addons/ace_interact/fnc_generateSpatialChildrenActions.sqf
+++ b/addons/ace_interact/fnc_generateSpatialChildrenActions.sqf
@@ -20,16 +20,16 @@ params ["_target","","_params"];
 _params params ["","","","_spatial"];
 private _actions  = [];
 
-if (_spatial != "LEFT") then {
-    private _action = ["acre_audio_left", localize LSTRING(setToLeftEar), "", {(_this + [0]) call FUNC(actionSetSpatialAudio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-    _actions pushBack [_action, [], _target];
-};
 if (_spatial != "RIGHT") then {
     private _action = ["acre_audio_right", localize LSTRING(setToRightEar), "", {(_this + [1]) call FUNC(actionSetSpatialAudio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
 };
 if (_spatial != "CENTER") then {
     private _action = ["acre_audio_center", localize LSTRING(setToBothEars), "", {(_this + [2]) call FUNC(actionSetSpatialAudio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+    _actions pushBack [_action, [], _target];
+};
+if (_spatial != "LEFT") then {
+    private _action = ["acre_audio_left", localize LSTRING(setToLeftEar), "", {(_this + [0]) call FUNC(actionSetSpatialAudio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Make "Set to Left Ear" be on left (or below if list menu) and `Set to Right Ear` be on right (or above if list menu)
- "Set to Both Ears" will be in the middle (so on one side whichever current is set)