### PR TITLE
Fix ctrlSetEventHandler - back to quotes as in #241

### DIFF
--- a/addons/sys_gui/fnc_inventoryMonitorPFH.sqf
+++ b/addons/sys_gui/fnc_inventoryMonitorPFH.sqf
@@ -23,32 +23,32 @@ if (!isNull INVENTORY_DISPLAY) then {
     (INVENTORY_DISPLAY displayCtrl IDC_RADIOSLOT) ctrlCommit 0;
 
     /* Unused MTT...
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_UNIFORM_CONTAINER) ctrlSetEventHandler["MouseButtonDown", {["uniform", _this] call FUNC(handleContextMenu)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_VEST_CONTAINER) ctrlSetEventHandler ["MouseButtonDown", {["vest", _this] call FUNC(handleContextMenu)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_BACKPACK_CONTAINER) ctrlSetEventHandler ["MouseButtonDown", {["backpack", _this] call FUNC(handleContextMenu)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_UNIFORM_CONTAINER) ctrlSetEventHandler["MouseButtonDown", QUOTE([ARR_2('uniform',_this)] call FUNC(handleContextMenu))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_VEST_CONTAINER) ctrlSetEventHandler ["MouseButtonDown", QUOTE([ARR_2('vest',_this)] call FUNC(handleContextMenu))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_BACKPACK_CONTAINER) ctrlSetEventHandler ["MouseButtonDown", QUOTE([ARR_2('backpack',_this)] call FUNC(handleContextMenu))];
     */
 
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_UNIFORM_CONTAINER) ctrlSetEventHandler["LBDblClick", {[1, "uniform", _this] call FUNC(onInventoryAction)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_VEST_CONTAINER) ctrlSetEventHandler ["LBDblClick", {[1, "vest",_this] call FUNC(onInventoryAction)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_BACKPACK_CONTAINER) ctrlSetEventHandler ["LBDblClick", {[1, "backpack", _this] call FUNC(onInventoryAction)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_UNIFORM_CONTAINER) ctrlSetEventHandler ["LBDblClick", QUOTE([ARR_3(1, 'uniform', _this)] call FUNC(onInventoryAction))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_VEST_CONTAINER) ctrlSetEventHandler ["LBDblClick", QUOTE([ARR_3(1, 'vest',_this)] call FUNC(onInventoryAction))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_BACKPACK_CONTAINER) ctrlSetEventHandler ["LBDblClick", QUOTE([ARR_3(1, 'backpack', _this)] call FUNC(onInventoryAction))];
 
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_UNIFORM_CONTAINER) ctrlSetEventHandler ["LBSelChanged", {[0, "uniform", _this] call FUNC(onInventoryAction)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_VEST_CONTAINER) ctrlSetEventHandler ["LBSelChanged", {[0, "vest", _this] call FUNC(onInventoryAction)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_BACKPACK_CONTAINER) ctrlSetEventHandler ["LBSelChanged", {[0, "backpack", _this] call FUNC(onInventoryAction)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_UNIFORM_CONTAINER) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'uniform', _this)] call FUNC(onInventoryAction))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_VEST_CONTAINER) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'vest', _this)] call FUNC(onInventoryAction))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_BACKPACK_CONTAINER) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'backpack', _this)] call FUNC(onInventoryAction))];
 
     // Ground
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseDown)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseUp)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseDown))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseUp))];
 
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlSetEventHandler ["LBDblClick", {[1, "remote", _this] call FUNC(onInventoryAction)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlSetEventHandler ["LBSelChanged", {[0, "remote", _this] call FUNC(onInventoryAction)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlSetEventHandler ["LBDblClick", QUOTE([ARR_3(1, 'remote', _this)] call FUNC(onInventoryAction))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'remote', _this)] call FUNC(onInventoryAction))];
 
     // Container
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseDown)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseUp)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseDown))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseUp))];
 
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlSetEventHandler ["LBDblClick", {[1, "remote", _this] call FUNC(onInventoryAction)}];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlSetEventHandler ["LBSelChanged", {[0, "remote", _this] call FUNC(onInventoryAction)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlSetEventHandler ["LBDblClick", QUOTE([ARR_3(1, 'remote', _this)] call FUNC(onInventoryAction))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'remote', _this)] call FUNC(onInventoryAction))];
 
     [_this select 1] call CBA_fnc_removePerFrameHandler;
 };

--- a/addons/sys_gui/fnc_inventoryMonitorPFH.sqf
+++ b/addons/sys_gui/fnc_inventoryMonitorPFH.sqf
@@ -37,15 +37,15 @@ if (!isNull INVENTORY_DISPLAY) then {
     (INVENTORY_DISPLAY displayCtrl IDC_FG_BACKPACK_CONTAINER) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'backpack', _this)] call FUNC(onInventoryAction))];
 
     // Ground
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseDown))];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseUp))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseDown)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseUp)}];
 
     (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlSetEventHandler ["LBDblClick", QUOTE([ARR_3(1, 'remote', _this)] call FUNC(onInventoryAction))];
     (INVENTORY_DISPLAY displayCtrl IDC_FG_GROUND_ITEMS) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'remote', _this)] call FUNC(onInventoryAction))];
 
     // Container
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseDown))];
-    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", QUOTE(_this call FUNC(inventoryListMouseUp))];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseDown)}];
+    (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(inventoryListMouseUp)}];
 
     (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlSetEventHandler ["LBDblClick", QUOTE([ARR_3(1, 'remote', _this)] call FUNC(onInventoryAction))];
     (INVENTORY_DISPLAY displayCtrl IDC_FG_CHOSEN_CONTAINER) ctrlSetEventHandler ["LBSelChanged", QUOTE([ARR_3(0, 'remote', _this)] call FUNC(onInventoryAction))];

--- a/addons/sys_gui/fnc_onVolumeControlKeyPress.sqf
+++ b/addons/sys_gui/fnc_onVolumeControlKeyPress.sqf
@@ -29,7 +29,7 @@ disableSerialization;
 _slider = (GVAR(VolumeControlDialog) select 0) displayCtrl 1900;
 _slider sliderSetRange [-2, 2];
 
-_slider ctrlSetEventHandler ["SliderPosChanged", {call FUNC(onVolumeControlSliderChanged)}];
+_slider ctrlSetEventHandler ["SliderPosChanged", QUOTE(_this call FUNC(onVolumeControlSliderChanged))];
 _slider sliderSetPosition GVAR(VolumeControl_Level);
 call FUNC(setVolumeSliderColor);
 

--- a/addons/sys_gui/fnc_openVolumeControl.sqf
+++ b/addons/sys_gui/fnc_openVolumeControl.sqf
@@ -22,7 +22,7 @@ disableSerialization;
 private _slider = (GVAR(VolumeControlDialog) select 0) displayCtrl 1900;
 _slider sliderSetRange [-2, 2];
 
-_slider ctrlSetEventHandler ["SliderPosChanged", {call FUNC(onVolumeControlSliderChanged)}];
+_slider ctrlSetEventHandler ["SliderPosChanged", QUOTE(_this call FUNC(onVolumeControlSliderChanged))];
 
 _slider sliderSetPosition GVAR(VolumeControl_Level);
 call FUNC(setVolumeSliderColor);

--- a/addons/sys_signalmap/fnc_doProcess.sqf
+++ b/addons/sys_signalmap/fnc_doProcess.sqf
@@ -173,14 +173,14 @@ with uiNamespace do {
                     GVAR(modifyButton) ctrlSetPosition [0.05, 0.055*10, 0.4, 0.045];
                     GVAR(modifyButton) ctrlSetBackgroundColor [0,0,0,0.25];
                     GVAR(modifyButton) ctrlSetText "Modify";
-                    GVAR(modifyButton) ctrlSetEventHandler ["MouseButtonUp", {call FUNC(modify)}];
+                    GVAR(modifyButton) ctrlSetEventHandler ["MouseButtonUp", QUOTE([] call FUNC(modify))];
                     GVAR(modifyButton) ctrlCommit 0;
 
                     CTRLOVERLAY(GVAR(clearButton), "RscButton");
                     GVAR(clearButton) ctrlSetPosition [0.05, 0.055*11, 0.4, 0.045];
                     GVAR(clearButton) ctrlSetBackgroundColor [0,0,0,0.25];
                     GVAR(clearButton) ctrlSetText "Clear";
-                    GVAR(clearButton) ctrlSetEventHandler ["MouseButtonUp", {call FUNC(clear)}];
+                    GVAR(clearButton) ctrlSetEventHandler ["MouseButtonUp", QUOTE([] call FUNC(clear))];
                     GVAR(clearButton) ctrlCommit 0;
 
                     with missionNamespace do {

--- a/addons/sys_signalmap/fnc_drawMenu.sqf
+++ b/addons/sys_signalmap/fnc_drawMenu.sqf
@@ -225,7 +225,7 @@ with uiNamespace do {
     GVAR(setTxPosButton) ctrlSetPosition [0.05, 0.055*8, 0.4, 0.045];
     GVAR(setTxPosButton) ctrlSetBackgroundColor [0,0,0,0.25];
     GVAR(setTxPosButton) ctrlSetText "Set Tx Position";
-    GVAR(setTxPosButton) ctrlSetEventHandler ["MouseButtonUp", {call FUNC(setTxPositionStart)}];
+    GVAR(setTxPosButton) ctrlSetEventHandler ["MouseButtonUp", QUOTE(_this call FUNC(setTxPositionStart))];
     GVAR(setTxPosButton) ctrlCommit 0;
 
     CTRL(GVAR(txPositionTxt), "RscEdit");
@@ -243,7 +243,7 @@ with uiNamespace do {
     GVAR(addRxAreaButton) ctrlSetPosition [0.05, 0.055*10, 0.4, 0.045];
     GVAR(addRxAreaButton) ctrlSetBackgroundColor [0,0,0,0.25];
     GVAR(addRxAreaButton) ctrlSetText "Add Rx Area";
-    GVAR(addRxAreaButton) ctrlSetEventHandler ["MouseButtonUp", {call FUNC(addRxAreaStart)}];
+    GVAR(addRxAreaButton) ctrlSetEventHandler ["MouseButtonUp", QUOTE(_this call FUNC(addRxAreaStart))];
     GVAR(addRxAreaButton) ctrlCommit 0;
 
     CTRL(GVAR(rxAreaList), "RscCombo");
@@ -264,14 +264,14 @@ with uiNamespace do {
     GVAR(addRxAreaButton) ctrlSetPosition [0.355, 0.055*11, 0.095, 0.045];
     GVAR(addRxAreaButton) ctrlSetBackgroundColor [0,0,0,0.25];
     GVAR(addRxAreaButton) ctrlSetText "Delete";
-    GVAR(addRxAreaButton) ctrlSetEventHandler ["MouseButtonUp", {call FUNC(deleteRxArea)}];
+    GVAR(addRxAreaButton) ctrlSetEventHandler ["MouseButtonUp", QUOTE(_this call FUNC(deleteRxArea))];
     GVAR(addRxAreaButton) ctrlCommit 0;
 
     CTRL(GVAR(addRxAreaButton), "RscButton");
     GVAR(addRxAreaButton) ctrlSetPosition [0.05, 0.055*12.5, 0.4, 0.045];
     GVAR(addRxAreaButton) ctrlSetBackgroundColor [0,0,0,0.25];
     GVAR(addRxAreaButton) ctrlSetText "Process";
-    GVAR(addRxAreaButton) ctrlSetEventHandler ["MouseButtonUp", {call FUNC(doProcess)}];
+    GVAR(addRxAreaButton) ctrlSetEventHandler ["MouseButtonUp", QUOTE(_this call FUNC(doProcess))];
     GVAR(addRxAreaButton) ctrlCommit 0;
 
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Reverts `ctrlSetEventHandler` to take strings instead of code as arguments after #241 