### PR TITLE
Removes extra include causing make error

### DIFF
--- a/addons/sys_sem70/CfgAcreRadios.hpp
+++ b/addons/sys_sem70/CfgAcreRadios.hpp
@@ -1,5 +1,3 @@
-#include "script_component.hpp"
-
 class CfgAcreComponents {
     class ACRE_BaseRadio;
 

--- a/addons/sys_sem70/sem70_RadioDialog.hpp
+++ b/addons/sys_sem70/sem70_RadioDialog.hpp
@@ -1,5 +1,3 @@
-#include "script_component.hpp"
-
 #define CODE_SPACING 0.0245
 
 #define CONTROL_SetRelativePos(xpos,ypos) x = H_OFFSET + (xpos * 0.001); y = H_OFFSET + (ypos * 0.001);


### PR DESCRIPTION
**When merged this pull request will:**
- Removes ```#include "script_component.hpp"``` from sys_sem70\CfgAcreRadios.hpp which causes an error when building with make.py
