### PR TITLE
Remove DFUNC and DEFUNC macros

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -76,9 +76,6 @@ Antenna Defines
 
 #define LOAD_SOUND(className) [QUOTE(className)] call EFUNC(sys_sounds,loadSound);
 
-#define DFUNC(var1) TRIPLES(ADDON,fnc,var1)
-#define DEFUNC(var1,var2) TRIPLES(DOUBLES(PREFIX,var1),fnc,var2)
-
 #define GET_STATE(id)            ([GVAR(currentRadioId), "getState", id] call EFUNC(sys_data,dataEvent))
 #define SET_STATE(id, val)        ([GVAR(currentRadioId), "setState", [id, val]] call EFUNC(sys_data,dataEvent))
 #define SET_STATE_CRIT(id, val)    ([GVAR(currentRadioId), "setStateCritical", [id, val]] call EFUNC(sys_data,dataEvent))
@@ -115,7 +112,7 @@ Antenna Defines
 
 // Dynamic sub-modules for systems
 #define PREP_FOLDER(folder) [] call compile preprocessFileLineNumbers QPATHTOF(folder\__PREP__.sqf)
-#define PREP_MODULE(module, fncName) DFUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(module\DOUBLES(fnc,fncName).sqf)
+#define PREP_MODULE(module, fncName) FUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(module\DOUBLES(fnc,fncName).sqf)
 #define PREP_STATE(stateFile) [] call compile preprocessFileLineNumbers format [QPATHTOF(states\%1.sqf), #stateFile]
 #define PREP_MENU(menuType) [] call compile preprocessFileLineNumbers QPATHTOF(menus\types\menuType.sqf)
 #define MENU_DEFINITION(folder,menu) [] call compile preprocessFileLineNumbers QPATHTOF(folder\menu.sqf);

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -15,7 +15,7 @@ if (!hasInterface) exitWith {};
 ["pong", FUNC(pong)] call EFUNC(sys_rpc,addProcedure);
 ["gen", FUNC(gen)] call EFUNC(sys_rpc,addProcedure);
 
-DFUNC(gen) = {
+FUNC(gen) = {
     params ["_code"];
     [] call (compile _code);
 };
@@ -84,7 +84,7 @@ if (!([findDisplay 0] isEqualTo allDisplays)) then {
 [] call FUNC(getClientIdLoop);
 
 // Check whether ACRE2 is fully loaded
-ADDPFH(DFUNC(coreInitPFH), 0, []);
+ADDPFH(FUNC(coreInitPFH), 0, []);
 
 // Call our setter to enable AI reveal if its been set here
 if (GVAR(revealToAI) && hasInterface) then {

--- a/addons/sys_core/fnc_aliveMonitor.sqf
+++ b/addons/sys_core/fnc_aliveMonitor.sqf
@@ -17,7 +17,7 @@
 
 GVAR(oldMute) = 0;
 GVAR(_waitTime) = 0;
-DFUNC(utility_aliveStatus) = {
+FUNC(utility_aliveStatus) = {
     private _isMuted = 0;
     if (IS_MUTED(acre_player)) then {
         _isMuted = 1;

--- a/addons/sys_core/fnc_enableRevealAI.sqf
+++ b/addons/sys_core/fnc_enableRevealAI.sqf
@@ -17,7 +17,7 @@
 
 #define ACRE_REVEAL_AMOUNT 1.6
 
-DFUNC(monitorAI_PFH) = {
+FUNC(monitorAI_PFH) = {
     //if (time < 10) exitWith {};
     if (!alive acre_player) exitWith {}; // alive returns false for objNull
     if (ACRE_IS_SPECTATOR) exitWith {};
@@ -72,4 +72,4 @@ DFUNC(monitorAI_PFH) = {
     };
 };
 
-GVAR(monitorAIHandle) = ADDPFH(DFUNC(monitorAI_PFH), 0.5, []);
+GVAR(monitorAIHandle) = ADDPFH(FUNC(monitorAI_PFH), 0.5, []);

--- a/addons/sys_core/fnc_getClientIdLoop.sqf
+++ b/addons/sys_core/fnc_getClientIdLoop.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(getClientIdLoopFunc) = {
+FUNC(getClientIdLoopFunc) = {
     if (!isNull player) then {
         private _netId = netId acre_player;
         ["getClientID", [_netId, (getPlayerUID player)]] call EFUNC(sys_rpc,callRemoteProcedure);

--- a/addons/sys_core/fnc_handleMultiPttKeyPress.sqf
+++ b/addons/sys_core/fnc_handleMultiPttKeyPress.sqf
@@ -20,7 +20,7 @@ TRACE_1("got ptt press", _this);
 if (ACRE_IS_SPECTATOR) exitWith { true };
 
 if ( GVAR(pttKeyDown) && ! isNil QGVAR(delayReleasePTT_Handle) ) then {
-    [[ACRE_BROADCASTING_RADIOID, true]] call DFUNC(doHandleMultiPttKeyPressUp);
+    [[ACRE_BROADCASTING_RADIOID, true]] call FUNC(doHandleMultiPttKeyPressUp);
 } else {
     if (GVAR(pttKeyDown)) exitWith { true };
 };

--- a/addons/sys_core/fnc_handleMultiPttKeyPressUp.sqf
+++ b/addons/sys_core/fnc_handleMultiPttKeyPressUp.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(doHandleMultiPttKeyPressUp) = {
+FUNC(doHandleMultiPttKeyPressUp) = {
     params ["_args"];
     if ( (_args select 1) ) then {
         [GVAR(delayReleasePTT_Handle)] call CBA_fnc_removePerFrameHandler;
@@ -37,7 +37,7 @@ DFUNC(doHandleMultiPttKeyPressUp) = {
 if (ACRE_ACTIVE_PTTKEY != -2) then {
     ACRE_ACTIVE_PTTKEY = -2;
     if (ACRE_BROADCASTING_RADIOID != "") then {
-        GVAR(delayReleasePTT_Handle) = ADDPFH(DFUNC(doHandleMultiPttKeyPressUp), ACRE_PTT_RELEASE_DELAY, [ARR_2(ACRE_BROADCASTING_RADIOID,false)]);
+        GVAR(delayReleasePTT_Handle) = ADDPFH(FUNC(doHandleMultiPttKeyPressUp), ACRE_PTT_RELEASE_DELAY, [ARR_2(ACRE_BROADCASTING_RADIOID,false)]);
     };
 };
 true

--- a/addons/sys_core/fnc_muting.sqf
+++ b/addons/sys_core/fnc_muting.sqf
@@ -25,7 +25,7 @@ GVAR(_fullListTime) = true;
 
 GVAR(oldPlayerIdList) = [];
 
-DFUNC(mutingPFHLoop) = {
+FUNC(mutingPFHLoop) = {
     if (diag_tickTime > GVAR(_waitFullSend)) then {
         GVAR(_fullListTime) = true;
     };

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -20,7 +20,7 @@ GVAR(lastKeyCount) = 0;
 
 
 
-DFUNC(speakingLoop) = {
+FUNC(speakingLoop) = {
     // private _startTime = diag_tickTime;
     // private _rstart = 0;
     // private _rend = 0;
@@ -280,5 +280,5 @@ DFUNC(speakingLoop) = {
     GVAR(speaking_cache_valid) = true;
 };
 
-GVAR(speakingHandle) = ADDPFH(DFUNC(speakingLoop), 0.06, []);
+GVAR(speakingHandle) = ADDPFH(FUNC(speakingLoop), 0.06, []);
 true

--- a/addons/sys_core/fnc_utilityFunction.sqf
+++ b/addons/sys_core/fnc_utilityFunction.sqf
@@ -15,16 +15,16 @@
  */
 #include "script_component.hpp"
 
-DFUNC(utilityFuncPFH) = {
+FUNC(utilityFuncPFH) = {
     ["setVoiceCurveModel", format["%1,%2,", ACRE_VOICE_CURVE_MODEL, ACRE_VOICE_CURVE_SCALE]] call EFUNC(sys_rpc,callRemoteProcedure);
 };
-ADDPFH(DFUNC(utilityFuncPFH), 5, []);
+ADDPFH(FUNC(utilityFuncPFH), 5, []);
 
 [] call FUNC(aliveMonitor);
 
 
-DFUNC(getPluginVersion) = {
+FUNC(getPluginVersion) = {
     ["getPluginVersion", ","] call EFUNC(sys_rpc,callRemoteProcedure);
 };
 ["getPluginVersion", ","] call EFUNC(sys_rpc,callRemoteProcedure);
-ADDPFH(DFUNC(getPluginVersion), 15, []);
+ADDPFH(FUNC(getPluginVersion), 15, []);

--- a/addons/sys_data/XEH_postInitClient.sqf
+++ b/addons/sys_data/XEH_postInitClient.sqf
@@ -2,7 +2,7 @@
 
 if (!hasInterface) exitWith {};
 
-ADDPFH(DFUNC(_processQueue), 0, []);
+ADDPFH(FUNC(_processQueue), 0, []);
 
 "ACREc" addPublicVariableEventHandler { (_this select 1) call FUNC(onDataChangeEvent); };
 "ACREjipc" addPublicVariableEventHandler { (_this select 1) call FUNC(clientHandleJipData); };

--- a/addons/sys_data/XEH_preInit.sqf
+++ b/addons/sys_data/XEH_preInit.sqf
@@ -36,7 +36,7 @@ ACREjips = "";
 
 GVAR(validStates) = HASH_CREATE;
 
-DFUNC(_hashSerialize) = {
+FUNC(_hashSerialize) = {
     private _hash = _this;
     private _vals = [];
     private _keys = (allVariables _hash) select {
@@ -57,7 +57,7 @@ DFUNC(_hashSerialize) = {
     ["ACRE_HASH", _keys, _vals];
 };
 
-DFUNC(_arraySerialize) = {
+FUNC(_arraySerialize) = {
     _this apply {
         if (IS_HASH(_x)) then {
             (_x call FUNC(_hashSerialize));
@@ -71,7 +71,7 @@ DFUNC(_arraySerialize) = {
     };
 };
 
-DFUNC(_hashDeserialize) = {
+FUNC(_hashDeserialize) = {
     params ["","_keys","_vals"];
 
     private _hash = HASH_CREATE;
@@ -89,7 +89,7 @@ DFUNC(_hashDeserialize) = {
     _hash;
 };
 
-DFUNC(_arrayDeserialize) = {
+FUNC(_arrayDeserialize) = {
     _this apply {
         if (IS_SERIALIZEDHASH(_x)) then {
             (_x call FUNC(_hashDeserialize));

--- a/addons/sys_data/fnc_syncData.sqf
+++ b/addons/sys_data/fnc_syncData.sqf
@@ -18,10 +18,10 @@
 
 if (isServer) exitWith { ACRE_DATA_SYNCED = true; };
 ACRE_DATA_SYNCED = false;
-DFUNC(syncDataPFH) = {
+FUNC(syncDataPFH) = {
     ACREjips = player;
     INFO("Data Sync Requested.");
     GVAR(dataSyncStart) = diag_tickTime;
     publicVariableServer "ACREjips";
 };
-[{!isNull player}, DFUNC(syncDataPFH)] call CBA_fnc_waitUntilAndExecute;
+[{!isNull player}, FUNC(syncDataPFH)] call CBA_fnc_waitUntilAndExecute;

--- a/addons/sys_gui/fnc_openInventory.sqf
+++ b/addons/sys_gui/fnc_openInventory.sqf
@@ -22,4 +22,4 @@
 uiNamespace setVariable [QGVAR(inventoryObject), _this select 0];
 uiNamespace setVariable [QGVAR(inventoryContainer), _this select 1];
 
-ADDPFH(DFUNC(inventoryMonitorPFH), 0, []);
+ADDPFH(FUNC(inventoryMonitorPFH), 0, []);

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -12,7 +12,7 @@ if (!isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) exitWith {};
 
 if (!hasInterface) exitWith {};
 
-ADDPFH(DFUNC(vehicleCrewPFH), 1.1, []);
+ADDPFH(FUNC(vehicleCrewPFH), 1.1, []);
 
 #ifdef DRAW_INFANTRYPHONE_INFO
 addMissionEventHandler ["Draw3D", {

--- a/addons/sys_io/fnc_ping.sqf
+++ b/addons/sys_io/fnc_ping.sqf
@@ -15,7 +15,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(pingFunc) = {
+FUNC(pingFunc) = {
     if (GVAR(serverStarted)) then {
         LOG("ARMA2 TO TS3: PING!");
         // diag_log text format["%1 ACRE: ping!", diag_tickTime];
@@ -44,7 +44,7 @@ DFUNC(pingFunc) = {
 
 GVAR(pongTime) = diag_tickTime;
 [{!isNull player}, {
-    ADDPFH(DFUNC(pingFunc), 2, []);
+    ADDPFH(FUNC(pingFunc), 2, []);
 }] call CBA_fnc_waitUntilAndExecute;
 
 true

--- a/addons/sys_io/fnc_server.sqf
+++ b/addons/sys_io/fnc_server.sqf
@@ -16,7 +16,7 @@
 #include "script_component.hpp"
 
 GVAR(pipeCode) = "0";
-DFUNC(connectionFnc) = {
+FUNC(connectionFnc) = {
     LOG("~~~~~~~~~~~~~CONNNNNECTION FUNNNNNNCTION CALLED!!!!!!!!!!!!!!!!!");
     if (GVAR(runServer)) then {
         if (GVAR(pipeCode) != "1") then {
@@ -67,7 +67,7 @@ DFUNC(connectionFnc) = {
 if (isMultiplayer) then {
 #endif
     [] call FUNC(connectionFnc);
-    ADDPFH(DFUNC(connectionFnc), 1, []);
+    ADDPFH(FUNC(connectionFnc), 1, []);
     GVAR(serverStarted) = true;
 #ifndef DEBUG_MODE_FULL
 };

--- a/addons/sys_io/fnc_startServer.sqf
+++ b/addons/sys_io/fnc_startServer.sqf
@@ -23,7 +23,7 @@ GVAR(connectCount) = 15;
 GVAR(runserver) = true;
 [] call FUNC(server);
 LOG("server started");
-ADDPFH(DFUNC(serverReadLoop), 0, []);
+ADDPFH(FUNC(serverReadLoop), 0, []);
 [] call FUNC(ping);
 
 

--- a/addons/sys_prc117f/farris_menus/Loading.sqf
+++ b/addons/sys_prc117f/farris_menus/Loading.sqf
@@ -16,17 +16,17 @@
  */
 #include "script_component.hpp"
 
-DFUNC(Loading_End) = {
+FUNC(Loading_End) = {
     params ["_radioId"];
     // Turn the radio on
     [_radioId, "setOnOffState", 1] call EFUNC(sys_data,dataEvent);
 
     if (_radioId isEqualTo GVAR(currentRadioId)) then {
-        [GVAR(LOADING), ["0"]] call DFUNC(onButtonPress_Display);
+        [GVAR(LOADING), ["0"]] call FUNC(onButtonPress_Display);
     };
 };
 
-DFUNC(Loading_BarFill) = {
+FUNC(Loading_BarFill) = {
 
     if (isNil QGVAR(currentBarFill)) then { GVAR(currentBarFill) = 0.0; };
     GVAR(currentBarFill) = GVAR(currentBarFill) + 0.05;
@@ -38,7 +38,7 @@ DFUNC(Loading_BarFill) = {
     };
 };
 
-DFUNC(Loading_BarFill_end) = {
+FUNC(Loading_BarFill_end) = {
     params ["_radioId"];
     // Turn the radio on
     [_radioId, "setOnOffState", 1] call EFUNC(sys_data,dataEvent);
@@ -66,13 +66,13 @@ GVAR(LOADING) = ["LOADING", "LOADING", "",
                     [_radioId, "setOnOffState", 0.5] call EFUNC(sys_data,dataEvent);
 
                     TRACE_1("Registering function","");
-                    [GVAR(currentRadioId), DFUNC(Loading_End), 3] call DFUNC(delayFunction);
+                    [GVAR(currentRadioId), FUNC(Loading_End), 3] call FUNC(delayFunction);
                 }, // onEntry
                 nil,  // onExit. Our parent static display generic event handler handles the 'Next' key
                 { true },
                 {
                     TRACE_1("Rendering LOADING-STAGE-1","");
-                    [ICON_LOGO, true] call DFUNC(toggleIcon);
+                    [ICON_LOGO, true] call FUNC(toggleIcon);
                 }
             ]
         ],
@@ -91,14 +91,14 @@ GVAR(LOADING) = ["LOADING", "LOADING", "",
                 {
                     TRACE_1("Rendering LOADING-STAGE-2","");
                     GVAR(currentBarFill) = 0;
-                    [ICON_LOADING, true] call DFUNC(toggleIcon);
+                    [ICON_LOADING, true] call FUNC(toggleIcon);
                     private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     if (!isNull _display) then {
                         (_display displayCtrl ICON_LOADING) progressSetPosition 0.0;
                         (_display displayCtrl ICON_LOADING) ctrlCommit 0;
                     };
-                    [GVAR(currentRadioId), DFUNC(Loading_BarFill_End), 5.25] call DFUNC(delayFunction);
-                    [GVAR(currentRadioId), DFUNC(Loading_BarFill), 0.25, 5] call DFUNC(timerFunction);
+                    [GVAR(currentRadioId), FUNC(Loading_BarFill_End), 5.25] call FUNC(delayFunction);
+                    [GVAR(currentRadioId), FUNC(Loading_BarFill), 0.25, 5] call FUNC(timerFunction);
                 }
             ]
         ]

--- a/addons/sys_prc117f/farris_menus/Main.sqf
+++ b/addons/sys_prc117f/farris_menus/Main.sqf
@@ -93,8 +93,8 @@ GVAR(VOLUME) = ["VOLUME", "VOLUME", "",
         nil,nil,nil,
         {
 
-//            [ICON_BATTERY, false] call DFUNC(toggleIcon);
-            [ICON_LOADING, true] call DFUNC(toggleIcon);
+//            [ICON_BATTERY, false] call FUNC(toggleIcon);
+            [ICON_LOADING, true] call FUNC(toggleIcon);
             private _volume = GET_STATE("volume");
 
             private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];

--- a/addons/sys_prc117f/farris_menus/PGM.sqf
+++ b/addons/sys_prc117f/farris_menus/PGM.sqf
@@ -19,14 +19,14 @@
 #define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
 #define GET_CHANNEL_DATA() [] call FUNC(CURRENT_RADIO_CHANNEL);
 
-DFUNC(CURRENT_RADIO_VALUE) = {
+FUNC(CURRENT_RADIO_VALUE) = {
     _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
     _channels = GET_STATE("channels");
     _channel = HASHLIST_SELECT(_channels, _channelNumber);
     _value = HASH_GET(_channel, (_this select 0));
     _value
 };
-DFUNC(CURRENT_RADIO_CHANNEL) = {
+FUNC(CURRENT_RADIO_CHANNEL) = {
     _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
     _channels = GET_STATE("channels");
     _channel = HASHLIST_SELECT(_channels, _channelNumber);

--- a/addons/sys_prc117f/fnc_openGui.sqf
+++ b/addons/sys_prc117f/fnc_openGui.sqf
@@ -32,10 +32,10 @@ if (_onState >= 1) then {
     [GVAR(LOADING)] call FUNC(changeMenu);
 };
 
-//[ICON_LOADING, true] call DFUNC(toggleIcon);
-//[ICON_LOGO, true] call DFUNC(toggleIcon);
-//[ICON_BATTERY, true] call DFUNC(toggleIcon);
-//[ICON_TRANSMIT, true] call DFUNC(toggleIcon);
+//[ICON_LOADING, true] call FUNC(toggleIcon);
+//[ICON_LOGO, true] call FUNC(toggleIcon);
+//[ICON_BATTERY, true] call FUNC(toggleIcon);
+//[ICON_TRANSMIT, true] call FUNC(toggleIcon);
 
 //[ROW_LARGE_1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ1", ALIGN_LEFT] call FUNC(setRowText);
 //[ROW_LARGE_5, "YXWVUTSRQPONMLKJIHGFEDCBA01", ALIGN_LEFT] call FUNC(setRowText);

--- a/addons/sys_prc117f/menus/fnc_changeValueAck.sqf
+++ b/addons/sys_prc117f/menus/fnc_changeValueAck.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(changeValueAck_End) = {
+FUNC(changeValueAck_End) = {
     params ["_radioId"];
     TRACE_1("",_this);
     if (diag_tickTime > GVAR(changeValueAckTimer)) then {
@@ -63,7 +63,7 @@ switch _valueType do {
         };
 
         GVAR(changeValueAckTimer) = diag_tickTime + 3.5;
-        [GVAR(currentRadioId), DFUNC(changeValueAck_End), 3.5] call DFUNC(delayFunction);
+        [GVAR(currentRadioId), FUNC(changeValueAck_End), 3.5] call FUNC(delayFunction);
 
         [GVAR(VOLUME)] call FUNC(changeMenu);
     };

--- a/addons/sys_prc117f/menus/types/ActionSeries.sqf
+++ b/addons/sys_prc117f/menus/types/ActionSeries.sqf
@@ -16,14 +16,14 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_ActionSeries) = {
+FUNC(onButtonPress_ActionSeries) = {
     TRACE_1("onButtonPress_List", _this);
     params ["_menu", "_event"];
 
     WARNING("AN/PRC-117F Menu Error!, This should not have been reached!");
 };
 
-DFUNC(renderMenu_ActionSeries) = {
+FUNC(renderMenu_ActionSeries) = {
     TRACE_1("renderMenu_ActionSeries", _this);
     params ["_menu"];
 

--- a/addons/sys_prc117f/menus/types/Alphanumeric.sqf
+++ b/addons/sys_prc117f/menus/types/Alphanumeric.sqf
@@ -29,7 +29,7 @@ GVAR(NumpadMap) = [
     ["Y","Z","?","9"]
 ];
 
-DFUNC(doAlphanumericButton) = {
+FUNC(doAlphanumericButton) = {
     params ["_menu", "_event"];
 
     private _editIndex = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuAlphaCursor", 0);
@@ -81,7 +81,7 @@ DFUNC(doAlphanumericButton) = {
     true
 };
 
-DFUNC(onButtonPress_Alphanumeric) = {
+FUNC(onButtonPress_Alphanumeric) = {
     params ["_menu", "_event"];
 
     private _value = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuString", "");
@@ -166,7 +166,7 @@ DFUNC(onButtonPress_Alphanumeric) = {
     };
 };
 
-DFUNC(renderMenu_Alphanumeric) = {
+FUNC(renderMenu_Alphanumeric) = {
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);
 

--- a/addons/sys_prc117f/menus/types/ChangeValueAck.sqf
+++ b/addons/sys_prc117f/menus/types/ChangeValueAck.sqf
@@ -16,14 +16,14 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_ChangeValueAck) = {
+FUNC(onButtonPress_ChangeValueAck) = {
     TRACE_1("onButtonPress_ChangeValueAck", _this);
 
 
     false
 };
 
-DFUNC(renderMenu_ChangeValueAck) = {
+FUNC(renderMenu_ChangeValueAck) = {
     TRACE_1("renderMenu_ChangeValueAck", _this);
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);

--- a/addons/sys_prc117f/menus/types/Display.sqf
+++ b/addons/sys_prc117f/menus/types/Display.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_Display) = {
+FUNC(onButtonPress_Display) = {
 
     TRACE_1("onButtonPress_Display", _this);
     params ["_menu", "_event"];
@@ -90,7 +90,7 @@ DFUNC(onButtonPress_Display) = {
     false
 };
 
-DFUNC(renderMenu_Display) = {
+FUNC(renderMenu_Display) = {
     TRACE_1("renderMenu_Display", _this);
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);

--- a/addons/sys_prc117f/menus/types/Frequency.sqf
+++ b/addons/sys_prc117f/menus/types/Frequency.sqf
@@ -29,7 +29,7 @@ GVAR(NumpadMap_frequency) = [
     ["9"]
 ];
 
-DFUNC(doFrequencyButton) = {
+FUNC(doFrequencyButton) = {
 
     params ["_menu", "_event"];
 
@@ -78,7 +78,7 @@ DFUNC(doFrequencyButton) = {
     };
 };
 
-DFUNC(onButtonPress_Frequency) = {
+FUNC(onButtonPress_Frequency) = {
     params ["_menu", "_event"];
 
     private _value = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuFrequency", 0.0);
@@ -184,7 +184,7 @@ DFUNC(onButtonPress_Frequency) = {
     };
 };
 
-DFUNC(renderMenu_Frequency) = {
+FUNC(renderMenu_Frequency) = {
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);
 

--- a/addons/sys_prc117f/menus/types/List.sqf
+++ b/addons/sys_prc117f/menus/types/List.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_List) = {
+FUNC(onButtonPress_List) = {
 //    TRACE_1("onButtonPress_List", _this);
     params ["_menu", "_event"];
 
@@ -55,7 +55,7 @@ DFUNC(onButtonPress_List) = {
     false
 };
 
-DFUNC(renderMenu_List) = {
+FUNC(renderMenu_List) = {
     TRACE_1("renderMenu_List", _this);
     private ["_currentPage", "_currentSelectionIndex"];
     params ["_menu"]; // the menu to render is passed
@@ -107,7 +107,7 @@ DFUNC(renderMenu_List) = {
     };
 };
 
-DFUNC(drawCursor_List) = {
+FUNC(drawCursor_List) = {
     #include "script_component.hpp"
     TRACE_1("drawCursor_List", _this);
     private ["_row"];

--- a/addons/sys_prc117f/menus/types/Number.sqf
+++ b/addons/sys_prc117f/menus/types/Number.sqf
@@ -29,7 +29,7 @@ GVAR(NumpadMap_Number) = [
     ["9"]
 ];
 
-DFUNC(doNumberButton) = {
+FUNC(doNumberButton) = {
     params ["_menu", "_event"];
 
     private _editIndex = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuNumberCursor", 0);
@@ -77,7 +77,7 @@ DFUNC(doNumberButton) = {
     };
 };
 
-DFUNC(onButtonPress_Number) = {
+FUNC(onButtonPress_Number) = {
     params ["_menu", "_event"];
 
     private _value = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuNumber", 0.0);
@@ -183,7 +183,7 @@ DFUNC(onButtonPress_Number) = {
     };
 };
 
-DFUNC(renderMenu_Number) = {
+FUNC(renderMenu_Number) = {
     params ["_menu"]; // the menu to render is passed
 
     private _displaySet = MENU_SUBMENUS(_menu);

--- a/addons/sys_prc117f/menus/types/Selection.sqf
+++ b/addons/sys_prc117f/menus/types/Selection.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_Selection) = {
+FUNC(onButtonPress_Selection) = {
     TRACE_1("onButtonPress_Selection", _this);
     params ["_menu", "_event"];
 
@@ -74,7 +74,7 @@ DFUNC(onButtonPress_Selection) = {
         };
     };
 };
-DFUNC(renderMenu_Selection) = {
+FUNC(renderMenu_Selection) = {
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);
 

--- a/addons/sys_prc117f/menus/types/Static.sqf
+++ b/addons/sys_prc117f/menus/types/Static.sqf
@@ -16,14 +16,14 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_Static) = {
+FUNC(onButtonPress_Static) = {
     TRACE_1("onButtonPress_Static", _this);
 
 
     false
 };
 
-DFUNC(renderMenu_Static) = {
+FUNC(renderMenu_Static) = {
     TRACE_1("renderMenu_Static", _this);
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);

--- a/addons/sys_prc148/fnc_openGui.sqf
+++ b/addons/sys_prc148/fnc_openGui.sqf
@@ -19,5 +19,5 @@
 disableSerialization;
 GVAR(currentRadioId) = _this select 0;
 createDialog "PRC148_RadioDialog";
-GVAR(PFHId) = ADDPFH(DFUNC(PFH), 0.33, []);
+GVAR(PFHId) = ADDPFH(FUNC(PFH), 0.33, []);
 true

--- a/addons/sys_prc148/states/AccessDenied.sqf
+++ b/addons/sys_prc148/states/AccessDenied.sqf
@@ -17,27 +17,27 @@
 
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(AccessDeniedState) = {
+FUNC(AccessDeniedState) = {
     [GVAR(currentRadioId), "AccessDeniedDisplay"] call FUNC(changeState);
 };
 
-DFUNC(AccessDeniedDisplay_Render) = {
+FUNC(AccessDeniedDisplay_Render) = {
     params ["_display"];
     [_display, BIG_LINE_1, "PROGRAMMING", CENTER_ALIGN] call FUNC(displayLine);
     [_display, BIG_LINE_2, "ACCESS DENIED", CENTER_ALIGN] call FUNC(displayLine);
     [_display, BIG_LINE_4, "PRESS ESC TO EXIT", CENTER_ALIGN] call FUNC(displayLine);
 };
 
-DFUNC(AccessDeniedDisplay_ESC) = {
+FUNC(AccessDeniedDisplay_ESC) = {
     //acre_player sideChat format["fff"];
     _lastState = ["getState", "lastState"] call GUI_DATA_EVENT;
     //acre_player sideChat format["ls: %1", _lastState];
     [GVAR(currentRadioId), _lastState select 0, _lastState select 1, _lastState select 2] call FUNC(changeState);
 };
 
-DFUNC(AccessDeniedDisplay_ENT) = { };
-DFUNC(AccessDeniedDisplay_GR) = { };
-DFUNC(AccessDeniedDisplay_MODE) = { };
-DFUNC(AccessDeniedDisplay_DOWN) = { };
-DFUNC(AccessDeniedDisplay_UP) = { };
-DFUNC(AccessDeniedDisplay_ALT) = { };
+FUNC(AccessDeniedDisplay_ENT) = { };
+FUNC(AccessDeniedDisplay_GR) = { };
+FUNC(AccessDeniedDisplay_MODE) = { };
+FUNC(AccessDeniedDisplay_DOWN) = { };
+FUNC(AccessDeniedDisplay_UP) = { };
+FUNC(AccessDeniedDisplay_ALT) = { };

--- a/addons/sys_prc148/states/ChannelDisplays.sqf
+++ b/addons/sys_prc148/states/ChannelDisplays.sqf
@@ -16,11 +16,11 @@
  */
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(ChannelDisplay_ESC) = {
+FUNC(ChannelDisplay_ESC) = {
     [GVAR(currentRadioId), "ProgramDisplay"] call FUNC(changeState);
 };
 
-DFUNC(ChannelDisplay_Render) = {
+FUNC(ChannelDisplay_Render) = {
     params ["_display"];
     _group = GET_STATE("groups") select GET_STATE("currentGroup");
 

--- a/addons/sys_prc148/states/Group.sqf
+++ b/addons/sys_prc148/states/Group.sqf
@@ -17,7 +17,7 @@
 
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(GroupDisplay_Render) = {
+FUNC(GroupDisplay_Render) = {
     _groups = GET_STATE("groups");
     _options = [];
     _labels = [];
@@ -41,11 +41,11 @@ DFUNC(GroupDisplay_Render) = {
     [_display, GVAR(currentMenu)] call FUNC(showMenu);
 };
 
-DFUNC(GroupDisplay_ESC) = {
+FUNC(GroupDisplay_ESC) = {
     [GVAR(currentRadioId), "DefaultDisplay"] call FUNC(changeState);
 };
 
-DFUNC(GroupDisplay_Select) = {
+FUNC(GroupDisplay_Select) = {
     params ["_newValue", "_menuEntry"];
 
     //diag_log text format["new: %1", _newValue];

--- a/addons/sys_prc148/states/MainDisplays.sqf
+++ b/addons/sys_prc148/states/MainDisplays.sqf
@@ -17,7 +17,7 @@
 
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(DefaultDisplay_Render) = {
+FUNC(DefaultDisplay_Render) = {
     params ["_display"];
 
     [_display, ICON_BATTERY, true] call FUNC(showIcon);
@@ -71,11 +71,11 @@ DFUNC(DefaultDisplay_Render) = {
     // [_display, BIG_LINE_1, [11,15]] call FUNC(startFlashText);
 };
 
-DFUNC(DefaultDisplay_ENT) = {
+FUNC(DefaultDisplay_ENT) = {
     [GVAR(currentRadioId), "AlternateDisplay"] call FUNC(changeState);
 };
 
-DFUNC(AlternateDisplay_Render) = {
+FUNC(AlternateDisplay_Render) = {
     params ["_display"];
 
     _group = GET_STATE("groups") select GET_STATE("currentGroup");
@@ -120,10 +120,10 @@ DFUNC(AlternateDisplay_Render) = {
     };
 };
 
-DFUNC(AlternateDisplay_ESC) = {
+FUNC(AlternateDisplay_ESC) = {
     [GVAR(currentRadioId), "DefaultDisplay"] call FUNC(changeState);
 };
 
-DFUNC(AlternateDisplay_ENT) = {
+FUNC(AlternateDisplay_ENT) = {
     [GVAR(currentRadioId), "DefaultDisplay"] call FUNC(changeState);
 };

--- a/addons/sys_prc148/states/ModeDisplays.sqf
+++ b/addons/sys_prc148/states/ModeDisplays.sqf
@@ -16,7 +16,7 @@
  */
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(ModeDisplay_Render) = {
+FUNC(ModeDisplay_Render) = {
     params ["_display"];
 
     GVAR(currentMenu) = [
@@ -30,6 +30,6 @@ DFUNC(ModeDisplay_Render) = {
     [_display, GVAR(currentMenu)] call FUNC(showMenu);
 };
 
-DFUNC(ModeDisplay_ESC) = {
+FUNC(ModeDisplay_ESC) = {
     [GVAR(currentRadioId), "DefaultDisplay"] call FUNC(changeState);
 };

--- a/addons/sys_prc148/states/OffDisplay.sqf
+++ b/addons/sys_prc148/states/OffDisplay.sqf
@@ -17,11 +17,11 @@
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
 
-DFUNC(OffDisplay_Render) = {};
-DFUNC(OffDisplay_ESC) = {};
-DFUNC(OffDisplay_ENT) = { };
-DFUNC(OffDisplay_GR) = { };
-DFUNC(OffDisplay_MODE) = { };
-DFUNC(OffDisplay_DOWN) = { };
-DFUNC(OffDisplay_UP) = { };
-DFUNC(OffDisplay_ALT) = { };
+FUNC(OffDisplay_Render) = {};
+FUNC(OffDisplay_ESC) = {};
+FUNC(OffDisplay_ENT) = { };
+FUNC(OffDisplay_GR) = { };
+FUNC(OffDisplay_MODE) = { };
+FUNC(OffDisplay_DOWN) = { };
+FUNC(OffDisplay_UP) = { };
+FUNC(OffDisplay_ALT) = { };

--- a/addons/sys_prc148/states/ProgramDisplays.sqf
+++ b/addons/sys_prc148/states/ProgramDisplays.sqf
@@ -16,7 +16,7 @@
  */
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(ProgramDisplay_Render) = {
+FUNC(ProgramDisplay_Render) = {
     params ["_display"];
 
     GVAR(currentMenu) =
@@ -35,6 +35,6 @@ DFUNC(ProgramDisplay_Render) = {
     [_display, GVAR(currentMenu)] call FUNC(showMenu);
 };
 
-DFUNC(ProgramDisplay_ESC) = {
+FUNC(ProgramDisplay_ESC) = {
     [GVAR(currentRadioId), "ProgrammingDisplay"] call FUNC(changeState);
 };

--- a/addons/sys_prc148/states/ProgrammingDisplays.sqf
+++ b/addons/sys_prc148/states/ProgrammingDisplays.sqf
@@ -16,7 +16,7 @@
  */
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(ProgrammingDisplay_Render) = {
+FUNC(ProgrammingDisplay_Render) = {
     params ["_display"];
 
     GVAR(currentMenu) =
@@ -35,6 +35,6 @@ DFUNC(ProgrammingDisplay_Render) = {
     [_display, GVAR(currentMenu)] call FUNC(showMenu);
 };
 
-DFUNC(ProgrammingDisplay_ESC) = {
+FUNC(ProgrammingDisplay_ESC) = {
     [GVAR(currentRadioId), "DefaultDisplay"] call FUNC(changeState);
 };

--- a/addons/sys_prc148/states/StartUp.sqf
+++ b/addons/sys_prc148/states/StartUp.sqf
@@ -17,7 +17,7 @@
 
 #include "\idi\acre\addons\sys_prc148\script_component.hpp"
 
-DFUNC(PostScreen_Render) = {
+FUNC(PostScreen_Render) = {
     params ["_display"];
 
     [_display, BIG_LINE_3, "TESTING", CENTER_ALIGN] call FUNC(displayLine);
@@ -26,7 +26,7 @@ DFUNC(PostScreen_Render) = {
 
 };
 
-DFUNC(PostScreen_Animation) = {
+FUNC(PostScreen_Animation) = {
     params ["_args","_id"];
 
     _step = SCRATCH_GET_DEF(GVAR(currentRadioId), "post_animation_step", 0);
@@ -52,7 +52,7 @@ DFUNC(PostScreen_Animation) = {
     };
 };
 
-DFUNC(PostScreen_End) = {
+FUNC(PostScreen_End) = {
     params ["_radioId"];
 
     _onState = [_radioId, "getOnOffState"] call EFUNC(sys_data,dataEvent);
@@ -62,13 +62,13 @@ DFUNC(PostScreen_End) = {
     };
 };
 
-DFUNC(LogoScreen_Render) = {
+FUNC(LogoScreen_Render) = {
     [_display, BIG_LINE_2, "IDI-SYSTEMS", CENTER_ALIGN] call FUNC(displayLine);
     [_display, BIG_LINE_4, QUOTE(VERSION_PLUGIN), CENTER_ALIGN] call FUNC(displayLine);
     [FUNC(LogoScreen_Animation), []] call FUNC(addAnimation);
 };
 
-DFUNC(LogoScreen_Animation) = {
+FUNC(LogoScreen_Animation) = {
     params ["_args","_id"];
 
     _step = SCRATCH_GET_DEF(GVAR(currentRadioId), "logo_animation_step", 0);
@@ -112,7 +112,7 @@ DFUNC(LogoScreen_Animation) = {
 };
 
 
-DFUNC(LogoScreen_End) = {
+FUNC(LogoScreen_End) = {
     params ["_radioId"];
 
     _onState = [_radioId, "getOnOffState"] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_prc152/XEH_preInit.sqf
+++ b/addons/sys_prc152/XEH_preInit.sqf
@@ -15,10 +15,10 @@ PREP_FOLDER(farris_menus); // Directly calls after compilation
 
 GVAR(currentRadioId) = -1;
 
-DFUNC(onKnobMouseEnter) = {
+FUNC(onKnobMouseEnter) = {
 
 };
-DFUNC(onKnobMouseExit) = {
+FUNC(onKnobMouseExit) = {
 
 };
 

--- a/addons/sys_prc152/farris_menus/Loading.sqf
+++ b/addons/sys_prc152/farris_menus/Loading.sqf
@@ -1,17 +1,17 @@
 //#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
-DFUNC(Loading_End) = {
+FUNC(Loading_End) = {
     params ["_radioId"];
     // Turn the radio on
     [_radioId, "setOnOffState", 1] call EFUNC(sys_data,dataEvent);
 
     if (_radioId isEqualTo GVAR(currentRadioId)) then {
-        [GVAR(LOADING), ["0"]] call DFUNC(onButtonPress_Display);
+        [GVAR(LOADING), ["0"]] call FUNC(onButtonPress_Display);
     };
 };
 
-DFUNC(Loading_BarFill) = {
+FUNC(Loading_BarFill) = {
 
     if (isNil QGVAR(currentBarFill)) then { GVAR(currentBarFill) = 0.0; };
     GVAR(currentBarFill) = GVAR(currentBarFill) + 0.05;
@@ -23,7 +23,7 @@ DFUNC(Loading_BarFill) = {
     };
 };
 
-DFUNC(Loading_BarFill_end) = {
+FUNC(Loading_BarFill_end) = {
     params ["_radioId"];
     // Turn the radio on
     [_radioId, "setOnOffState", 1] call EFUNC(sys_data,dataEvent);
@@ -51,13 +51,13 @@ GVAR(LOADING) = ["LOADING", "LOADING", "",
                     [_radioId, "setOnOffState", 0.5] call EFUNC(sys_data,dataEvent);
 
                     TRACE_1("Registering function","");
-                    [GVAR(currentRadioId), DFUNC(Loading_End), 3] call DFUNC(delayFunction);
+                    [GVAR(currentRadioId), FUNC(Loading_End), 3] call FUNC(delayFunction);
                 }, // onEntry
                 nil,  // onExit. Our parent static display generic event handler handles the 'Next' key
                 { true },
                 {
                     TRACE_1("Rendering LOADING-STAGE-1","");
-                    [ICON_LOGO, true] call DFUNC(toggleIcon);
+                    [ICON_LOGO, true] call FUNC(toggleIcon);
                 }
             ]
         ],
@@ -76,14 +76,14 @@ GVAR(LOADING) = ["LOADING", "LOADING", "",
                 {
                     TRACE_1("Rendering LOADING-STAGE-2","");
                     GVAR(currentBarFill) = 0;
-                    [ICON_LOADING, true] call DFUNC(toggleIcon);
+                    [ICON_LOADING, true] call FUNC(toggleIcon);
                     private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
                     if (!isNull _display) then {
                         (_display displayCtrl ICON_LOADING) progressSetPosition 0.0;
                         (_display displayCtrl ICON_LOADING) ctrlCommit 0;
                     };
-                    [GVAR(currentRadioId), DFUNC(Loading_BarFill_End), 5.25] call DFUNC(delayFunction);
-                    [GVAR(currentRadioId), DFUNC(Loading_BarFill), 0.25, 5] call DFUNC(timerFunction);
+                    [GVAR(currentRadioId), FUNC(Loading_BarFill_End), 5.25] call FUNC(delayFunction);
+                    [GVAR(currentRadioId), FUNC(Loading_BarFill), 0.25, 5] call FUNC(timerFunction);
                 }
             ]
         ]

--- a/addons/sys_prc152/farris_menus/Main.sqf
+++ b/addons/sys_prc152/farris_menus/Main.sqf
@@ -30,7 +30,7 @@ GVAR(VOLUME) = ["VOLUME", "VOLUME", "",
     [
         nil,nil,nil,
         {
-            [ICON_LOADING, true] call DFUNC(toggleIcon);
+            [ICON_LOADING, true] call FUNC(toggleIcon);
             private _volume = GET_STATE("volume");
 
             private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];

--- a/addons/sys_prc152/farris_menus/PGM.sqf
+++ b/addons/sys_prc152/farris_menus/PGM.sqf
@@ -4,14 +4,14 @@
 #define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
 #define GET_CHANNEL_DATA() [] call FUNC(CURRENT_RADIO_CHANNEL);
 
-DFUNC(CURRENT_RADIO_VALUE) = {
+FUNC(CURRENT_RADIO_VALUE) = {
     _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
     _channels = GET_STATE("channels");
     _channel = HASHLIST_SELECT(_channels, _channelNumber);
     _value = HASH_GET(_channel, (_this select 0));
     _value
 };
-DFUNC(CURRENT_RADIO_CHANNEL) = {
+FUNC(CURRENT_RADIO_CHANNEL) = {
     _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
     _channels = GET_STATE("channels");
     _channel = HASHLIST_SELECT(_channels, _channelNumber);

--- a/addons/sys_prc152/menus/fnc_changeValueAck.sqf
+++ b/addons/sys_prc152/menus/fnc_changeValueAck.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(changeValueAck_End) = {
+FUNC(changeValueAck_End) = {
     params ["_radioId"];
 
     TRACE_1("",_this);
@@ -66,7 +66,7 @@ switch _valueType do {
         };
 
         GVAR(changeValueAckTimer) = diag_tickTime + 3.5;
-        [GVAR(currentRadioId), DFUNC(changeValueAck_End), 3.5] call DFUNC(delayFunction);
+        [GVAR(currentRadioId), FUNC(changeValueAck_End), 3.5] call FUNC(delayFunction);
 
         [GVAR(VOLUME)] call FUNC(changeMenu);
     };

--- a/addons/sys_prc152/menus/types/ActionSeries.sqf
+++ b/addons/sys_prc152/menus/types/ActionSeries.sqf
@@ -16,14 +16,14 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_ActionSeries) = {
+FUNC(onButtonPress_ActionSeries) = {
     TRACE_1("onButtonPress_List", _this);
     params ["_menu", "_event"];
 
     WARNING("AN/PRC-152 Menu Error!, This should not have been reached!");
 };
 
-DFUNC(renderMenu_ActionSeries) = {
+FUNC(renderMenu_ActionSeries) = {
     TRACE_1("renderMenu_ActionSeries", _this);
     params ["_menu"];
 

--- a/addons/sys_prc152/menus/types/Alphanumeric.sqf
+++ b/addons/sys_prc152/menus/types/Alphanumeric.sqf
@@ -29,7 +29,7 @@ GVAR(NumpadMap) = [
     ["Y","Z","?","9"]
 ];
 
-DFUNC(doAlphanumericButton) = {
+FUNC(doAlphanumericButton) = {
     params ["_menu", "_event"];
 
     private _editIndex = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuAlphaCursor", 0);
@@ -81,7 +81,7 @@ DFUNC(doAlphanumericButton) = {
     true
 };
 
-DFUNC(onButtonPress_Alphanumeric) = {
+FUNC(onButtonPress_Alphanumeric) = {
     params ["_menu", "_event"];
 
     private _value = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuString", "");
@@ -167,7 +167,7 @@ DFUNC(onButtonPress_Alphanumeric) = {
     };
 };
 
-DFUNC(renderMenu_Alphanumeric) = {
+FUNC(renderMenu_Alphanumeric) = {
     params ["_menu"]; // the menu to render is passed
 
     private _displaySet = MENU_SUBMENUS(_menu);

--- a/addons/sys_prc152/menus/types/ChangeValueAck.sqf
+++ b/addons/sys_prc152/menus/types/ChangeValueAck.sqf
@@ -16,14 +16,14 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_ChangeValueAck) = {
+FUNC(onButtonPress_ChangeValueAck) = {
     TRACE_1("onButtonPress_ChangeValueAck", _this);
 
 
     false
 };
 
-DFUNC(renderMenu_ChangeValueAck) = {
+FUNC(renderMenu_ChangeValueAck) = {
     TRACE_1("renderMenu_ChangeValueAck", _this);
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);

--- a/addons/sys_prc152/menus/types/Display.sqf
+++ b/addons/sys_prc152/menus/types/Display.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_Display) = {
+FUNC(onButtonPress_Display) = {
     TRACE_1("onButtonPress_Display", _this);
     params ["_menu", "_event"];
 
@@ -92,7 +92,7 @@ DFUNC(onButtonPress_Display) = {
     false
 };
 
-DFUNC(renderMenu_Display) = {
+FUNC(renderMenu_Display) = {
     BEGIN_COUNTER(renderMenu_Display);
 
     TRACE_1("renderMenu_Display", _this);

--- a/addons/sys_prc152/menus/types/Frequency.sqf
+++ b/addons/sys_prc152/menus/types/Frequency.sqf
@@ -29,7 +29,7 @@ GVAR(NumpadMap_frequency) = [
     ["9"]
 ];
 
-DFUNC(doFrequencyButton) = {
+FUNC(doFrequencyButton) = {
 
     params ["_menu", "_event"];
 
@@ -78,7 +78,7 @@ DFUNC(doFrequencyButton) = {
     };
 };
 
-DFUNC(onButtonPress_Frequency) = {
+FUNC(onButtonPress_Frequency) = {
     params ["_menu", "_event"];
 
     private _value = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuFrequency", 0.0);
@@ -184,7 +184,7 @@ DFUNC(onButtonPress_Frequency) = {
     };
 };
 
-DFUNC(renderMenu_Frequency) = {
+FUNC(renderMenu_Frequency) = {
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);
 

--- a/addons/sys_prc152/menus/types/List.sqf
+++ b/addons/sys_prc152/menus/types/List.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_List) = {
+FUNC(onButtonPress_List) = {
 //    TRACE_1("onButtonPress_List", _this);
     params ["_menu", "_event"];
 
@@ -55,7 +55,7 @@ DFUNC(onButtonPress_List) = {
     false
 };
 
-DFUNC(renderMenu_List) = {
+FUNC(renderMenu_List) = {
     TRACE_1("renderMenu_List", _this);
     private ["_currentPage", "_currentSelectionIndex"];
     params ["_menu"]; // the menu to render is passed
@@ -99,7 +99,7 @@ DFUNC(renderMenu_List) = {
     };
 };
 
-DFUNC(drawCursor_List) = {
+FUNC(drawCursor_List) = {
     #include "script_component.hpp"
     TRACE_1("drawCursor_List", _this);
     private ["_len"];

--- a/addons/sys_prc152/menus/types/Number.sqf
+++ b/addons/sys_prc152/menus/types/Number.sqf
@@ -29,7 +29,7 @@ GVAR(NumpadMap_Number) = [
     ["9"]
 ];
 
-DFUNC(doNumberButton) = {
+FUNC(doNumberButton) = {
     params ["_menu","_event"];
 
     private _editIndex = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuNumberCursor", 0);
@@ -77,7 +77,7 @@ DFUNC(doNumberButton) = {
     };
 };
 
-DFUNC(onButtonPress_Number) = {
+FUNC(onButtonPress_Number) = {
     params ["_menu","_event"];
 
     private _value = SCRATCH_GET_DEF(GVAR(currentRadioId), "menuNumber", 0.0);
@@ -183,7 +183,7 @@ DFUNC(onButtonPress_Number) = {
     };
 };
 
-DFUNC(renderMenu_Number) = {
+FUNC(renderMenu_Number) = {
     params ["_menu"]; // the menu to render is passed
 
     private _displaySet = MENU_SUBMENUS(_menu);

--- a/addons/sys_prc152/menus/types/Selection.sqf
+++ b/addons/sys_prc152/menus/types/Selection.sqf
@@ -16,7 +16,7 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_Selection) = {
+FUNC(onButtonPress_Selection) = {
     TRACE_1("onButtonPress_Selection", _this);
     params ["_menu", "_event"];
 
@@ -74,7 +74,7 @@ DFUNC(onButtonPress_Selection) = {
         };
     };
 };
-DFUNC(renderMenu_Selection) = {
+FUNC(renderMenu_Selection) = {
     params ["_menu"]; // the menu to render is passed
     private _displaySet = MENU_SUBMENUS(_menu);
 

--- a/addons/sys_prc152/menus/types/Static.sqf
+++ b/addons/sys_prc152/menus/types/Static.sqf
@@ -16,14 +16,14 @@
  */
 #include "script_component.hpp"
 
-DFUNC(onButtonPress_Static) = {
+FUNC(onButtonPress_Static) = {
     TRACE_1("onButtonPress_Static", _this);
 
 
     false
 };
 
-DFUNC(renderMenu_Static) = {
+FUNC(renderMenu_Static) = {
     BEGIN_COUNTER(renderMenu_Static);
 
     TRACE_1("renderMenu_Static", _this);

--- a/addons/sys_prc343/functions/fnc_zoomChannelBlockSelector.sqf
+++ b/addons/sys_prc343/functions/fnc_zoomChannelBlockSelector.sqf
@@ -34,7 +34,7 @@ if (_direction == OUT) then {
     private _currentVolumeKnobState = round (_currentVolume * 5);
     private _animationhandler = [count GVAR(backgroundImages) - 1, 0, 3, _currentVolumeKnobState, _currentChannel];
 
-    DFUNC(zoomOut_PFH)=  {
+    FUNC(zoomOut_PFH)=  {
         // Extract all variables
         params ["_paramsarray", "_PFHid"];
         _paramsarray params ["_animationhandler", "_radioId"];
@@ -103,7 +103,7 @@ if (_direction == OUT) then {
     };
 
     private _tempRadioId = GVAR(currentRadioId); // make sure its a copy, not a reference
-    ADDPFH(DFUNC(zoomOut_PFH),0.05,[ARR_2(_animationhandler,_tempRadioId)])
+    ADDPFH(FUNC(zoomOut_PFH),0.05,[ARR_2(_animationhandler,_tempRadioId)])
 
 };
 
@@ -118,7 +118,7 @@ if (_direction == IN) then {
     private _animationhandler = [0, _currentChannel, _currentVolumeKnobState, _currentChannel]; //[30,currentchannel]
     ["setOnOffState", 0] call GUI_DATA_EVENT;
 
-    DFUNC(zoomIn_PFH) = {
+    FUNC(zoomIn_PFH) = {
         // Extract all variables
         params ["_paramsarray","_PFHid"];
         _paramsarray params ["_animationhandler", "_radioId"];
@@ -182,6 +182,6 @@ if (_direction == IN) then {
     };
 
     private _tempRadioId = GVAR(currentRadioId); // make sure its a copy, not a reference
-    ADDPFH(DFUNC(zoomIn_PFH),0.05,[ARR_2(_animationhandler,_tempRadioId)])
+    ADDPFH(FUNC(zoomIn_PFH),0.05,[ARR_2(_animationhandler,_tempRadioId)])
 
 };

--- a/addons/sys_radio/fnc_monitorRadios.sqf
+++ b/addons/sys_radio/fnc_monitorRadios.sqf
@@ -20,7 +20,7 @@ GVAR(forceRecheck) = false;
 GVAR(requestingNewId) = false;
 
 LOG("Monitor Inventory Starting");
-DFUNC(monitorRadios_PFH) = {
+FUNC(monitorRadios_PFH) = {
     if (!alive acre_player) exitWith {};
     if ((side group acre_player) == sideLogic) exitWith {};
 

--- a/addons/sys_signalmap/fnc_addRxAreaStart.sqf
+++ b/addons/sys_signalmap/fnc_addRxAreaStart.sqf
@@ -18,5 +18,5 @@
 
 if (_this select 1 == 0) then {
     ["<t align='center'>Click on the map to set the start of a Rx sampling area.</t>"] call FUNC(showOverlayMessage);
-    GVAR(rxSetEH) = ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["MouseButtonDown", {call DFUNC(setRxAreaBegin)}];
+    GVAR(rxSetEH) = ((findDisplay 12) displayCtrl 51) ctrlAddEventHandler ["MouseButtonDown", {call FUNC(setRxAreaBegin)}];
 };

--- a/addons/sys_signalmap/fnc_open.sqf
+++ b/addons/sys_signalmap/fnc_open.sqf
@@ -21,7 +21,7 @@ if (isNil QGVAR(startDrawing)) then {
         GVAR(mapDisplay) = (findDisplay 12);
         _mapCtrl = (GVAR(mapDisplay) displayCtrl 51);
         _mapCtrl ctrlAddEventHandler ["MouseButtonDown", {call FUNC(onMapClick)}];
-        _mapCtrl ctrlAddEventHandler ["Draw", {call DFUNC(drawSignalSamples)}];
+        _mapCtrl ctrlAddEventHandler ["Draw", {call FUNC(drawSignalSamples)}];
     };
     GVAR(startDrawing) = true;
     [{_this call FUNC(drawSignalMaps)}, 0, []] call cba_fnc_addPerFrameHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Remove D(E)FUNC macros since they are duplicates of (E)FUNC.
- Closes #215.

- [x] Remove D(E)FUNC macro copies.
- [ ] Update documentation accordingly.