### PR TITLE
Fix reserved variable error in currentSpeakingRadio

### DIFF
--- a/addons/sys_core/fnc_processRadioSpeaker.sqf
+++ b/addons/sys_core/fnc_processRadioSpeaker.sqf
@@ -15,13 +15,15 @@
  * Public: No
  */
 #include "script_component.hpp"
+
 BEGIN_COUNTER(process_radio_speaker);
+
 private ["_okRadios", "_functionName"];
 
 params ["_unit","_playerRadios"];
 TRACE_2("",_unit,_playerRadios);
 
-private _radioId = _unit getVariable QGVAR(currentSpeakingRadio);
+private _radioId = _unit getVariable [QGVAR(currentSpeakingRadio), ""];
 if (_radioId == "") exitWith { false };
 // @todo if Underwater Radios are implemented
 //if (ACRE_LISTENER_DIVE == 1) exitWith { false };


### PR DESCRIPTION
**When merged this pull request will:**
- Title

This function apparently can run before the variable gets set in `FUNC(speaking)` causing it to default to `any` due to no default variable.

Considering this only happens in a few frames and is very rare, this should not have any side effects apart from fixing the script error. However, it might not be a fix for an underlying issue in case there is one.