### PR TITLE
Fix access violation crash in antenna gain map on x64

### DIFF
--- a/extensions/src/ACRE2Arma/signal/antenna/antenna.cpp
+++ b/extensions/src/ACRE2Arma/signal/antenna/antenna.cpp
@@ -76,8 +76,8 @@ float acre::signal::antenna::_get_gain(float f_, float dir_, float elev_)
     uint32_t dir_index_min = (uint32_t)std::floor(dir_ / _direction_step);
     uint32_t dir_index_max = (uint32_t)std::floor((dir_ + _direction_step) / _direction_step);
 
-    uint32_t elev_index_min = (uint32_t)std::floor(elev_ / _elevation_step) - 1;
-    uint32_t elev_index_max = (uint32_t)std::floor((elev_ + _elevation_step) / _elevation_step) - 1;
+    uint32_t elev_index_min = (uint32_t)std::floor(elev_ / _elevation_step);
+    uint32_t elev_index_max = (uint32_t)std::floor((elev_ + _elevation_step) / _elevation_step);
     if (dir_index_max > _height - 1) {
         dir_index_max = 0;
     }

--- a/extensions/src/ACRE2Arma/signal/antenna/antenna.cpp
+++ b/extensions/src/ACRE2Arma/signal/antenna/antenna.cpp
@@ -30,36 +30,36 @@ float acre::signal::antenna::gain(const glm::vec3 dir_antenna_, const glm::vec3 
         return -1000.0f;
 
     glm::vec3 dir_antenna_v = glm::normalize(dir_antenna_);
-    float elev_antenna = asin(dir_antenna_v.z)*57.2957795f;
-    float dir_antenna = atan2(dir_antenna_v.x, dir_antenna_v.y)*57.2957795f;
+    float elev_antenna = asinf(dir_antenna_v.z)*57.2957795f;
+    float dir_antenna = atan2f(dir_antenna_v.x, dir_antenna_v.y)*57.2957795f;
 
     glm::vec3 dir_signal_v = glm::normalize(dir_signal_);
-    float elev_signal = asin(dir_signal_v.z)*57.2957795f;
-    float dir_signal = atan2(dir_signal_v.x, dir_signal_v.y)*57.2957795f;
+    float elev_signal = asinf(dir_signal_v.z)*57.2957795f;
+    float dir_signal = atan2f(dir_signal_v.x, dir_signal_v.y)*57.2957795f;
 
-    float dir = std::fmod(dir_antenna + dir_signal, 360.0f);
+    float dir = fmodf(dir_antenna + dir_signal, 360.0f);
     float elev = elev_antenna + elev_signal;
 
     if (elev > 90.0f || elev < -90.0f) {
-        dir = std::fmod(dir + 180.0f, 360.0f);
+        dir = fmodf(dir + 180.0f, 360.0f);
         if (elev < -90.0f) {
-            elev = -90 + (std::abs(elev) - 90.0f);
+            elev = -90.0f + (std::fabs(elev) - 90.0f);
         }
         else {
-            elev = 90 - (elev - 90.0f);
+            elev = 90.0f - (elev - 90.0f);
         }
     }
 
-    if (dir < 0) {
+    if (dir < 0.0f) {
         dir = dir + 360.0f;
     }
-    
-    elev = 90.0f - std::abs(elev);
+
+    elev = 90.0f - std::fabs(elev);
 
     float lower_freq_gain = _get_gain(f_, dir, elev);
     float upper_freq_gain = _get_gain(f_ + _frequency_step, dir, elev);
 
-    float lower_freq = f_ - fmod(f_, _frequency_step);
+    float lower_freq = f_ - fmodf(f_, _frequency_step);
     float upper_freq = lower_freq + _frequency_step;
 
     float total_gain = _interp(f_, lower_freq, upper_freq, lower_freq_gain, upper_freq_gain);
@@ -92,10 +92,10 @@ float acre::signal::antenna::_get_gain(float f_, float dir_, float elev_)
     float gain_d_max_e_min = _gain_map[f_index * (_width * _height) + (dir_index_max * _width) + elev_index_min].v;
     float gain_d_max_e_max = _gain_map[f_index * (_width * _height) + (dir_index_max * _width) + elev_index_max].v;
 
-    float dir_min = dir_ - fmod(dir_, _direction_step);
+    float dir_min = dir_ - fmodf(dir_, _direction_step);
     float dir_max = dir_min + _direction_step;
 
-    float elev_min = elev_ - fmod(elev_, _elevation_step);
+    float elev_min = elev_ - fmodf(elev_, _elevation_step);
     float elev_max = elev_min + _elevation_step;
 
     float elev_lower_gain = _interp(dir_, dir_min, dir_max, gain_d_min_e_min, gain_d_max_e_min);

--- a/extensions/src/ACRE2Arma/signal/signal.hpp
+++ b/extensions/src/ACRE2Arma/signal/signal.hpp
@@ -103,7 +103,7 @@ namespace acre {
                     result = "[]";
                     return true;
                 }
-                
+
                 int logging = args_.as_int(19);
                 bool omnidirectional = args_.as_int(20);
 
@@ -133,7 +133,7 @@ namespace acre {
                 float f = args_.as_float(15);
                 float power = args_.as_float(16);
                 float scale = args_.as_float(17);
-                
+
                 acre::signal::result signal_result;
 
                 _signal_processor.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, f, power, scale, omnidirectional);
@@ -146,7 +146,7 @@ namespace acre {
                 ss.precision(16);
                 ss << "[\"" << id << "\"," << std::fixed << signal_result.result_dbm << "," << std::fixed << signal_result.result_v << ",\"" << filename.str() << "\"]";
                 result = ss.str();
-#else    
+#else
                 std::stringstream ss;
                 ss.precision(16);
                 ss << "[\"" << id << "\"," << std::fixed << signal_result.result_dbm << "," << std::fixed << signal_result.result_v << "]";
@@ -157,7 +157,7 @@ namespace acre {
                 }
 
 #endif
-#ifdef DEBUG_OUTPUT            
+#ifdef DEBUG_OUTPUT
                 ss << ",[" << tx_pos.x << "," << tx_pos.y << "," << tx_pos.z << "],[" << rx_pos.x << "," << rx_pos.y << "," << rx_pos.z << "],[";
                 for (acre::signal::reflection reflection : signal_result.reflect_points) {
                     ss << "[" << "[" << reflection.point.x << "," << reflection.point.y << "," << reflection.point.z << "],"
@@ -168,7 +168,7 @@ namespace acre {
                 ss << "[]]";
                 demo_file << "[" << ss.str() << "]";
                 demo_file.close();
-#endif        
+#endif
                 return true;
             }
 
@@ -233,7 +233,7 @@ namespace acre {
                 std::string tx_antenna_name = args_.as_string();
                 std::string rx_antenna_name = args_.as_string();
 
-                
+
                 float f = args_.as_float();
                 float power = args_.as_float();
 
@@ -261,7 +261,7 @@ namespace acre {
 
                 _total_signal_map_steps = count_x * count_y;
 
-                
+
 
                 acre::signal::antenna_p tx_antenna;
                 acre::signal::antenna_p rx_antenna;
@@ -330,7 +330,7 @@ namespace acre {
                 state.encoder.auto_convert = false;
                 std::vector<unsigned char> png;
                 unsigned error = lodepng::encode(png, png_data, 4096, 4096, state);
-                
+
                 char path[FILENAME_MAX];
                 _getcwd(path, sizeof(path));
                 std::string output_path = std::string(path);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #274
- Make float compliant

`elev_index_min` was negative on x86 as well, but as per @BlackHawkPL's test, it seems MSVC just eats that without a crash, in x64 however it causes a crash.