### PR TITLE
Prevent switch channel fast to change between groups

### DIFF
--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -35,6 +35,10 @@ if (_isManpack == 0) then {
         case ("ACRE_PRC152"): {
             _channel = (_channel + _dir) min 5;
         };
+        case ("ACRE_PRC148"): {
+            private _currentGroup = floor((_channel - 1) / 16);
+            _channel = ((_channel + _dir) max (_currentGroup*16 + 1)) min ((_currentGroup + 1)*16);
+        };
         default {
             _channel = _channel + _dir;
         };

--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -28,16 +28,13 @@ if (_isManpack == 0) then {
     private _channel = [_radioId] call EFUNC(api,getRadioChannel);
 
     switch (_radioType) do {
-        case ("ACRE_PRC343"): {
+        case "ACRE_PRC343";
+        case "ACRE_PRC148": {
             private _currentBlock = floor((_channel-1) / 16);
             _channel = ((_channel + _dir) max (_currentBlock*16 + 1)) min ((_currentBlock + 1)*16);
         };
-        case ("ACRE_PRC152"): {
+        case "ACRE_PRC152": {
             _channel = (_channel + _dir) min 5;
-        };
-        case ("ACRE_PRC148"): {
-            private _currentGroup = floor((_channel - 1) / 16);
-            _channel = ((_channel + _dir) max (_currentGroup*16 + 1)) min ((_currentGroup + 1)*16);
         };
         default {
             _channel = _channel + _dir;


### PR DESCRIPTION
**When merged this pull request will:**
- Prevents the switch channel  keybind to exceed the maximum number of channels within a group.

**Issue**
- Using the Knob on the 148 one can change channels within a group only.
- PRC152 and PRC343 switch functionality only allows to change channels as turning the knob would, but not on the PRC148.