### PR TITLE
Save .pdb files on CI builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 release/*
+symbols/*
 *.cache
 *.pbo
 texHeaders.bin

--- a/extensions/src/ACRE2Arma/acre/CMakeLists.txt
+++ b/extensions/src/ACRE2Arma/acre/CMakeLists.txt
@@ -34,13 +34,17 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     set_target_properties(${ACRE_EXTENSION_NAME}_static PROPERTIES LINK_SEARCH_END_STATIC 1)
 endif()
 
-# Copy to root
+
+# Copy and rename
 if(USE_64BIT_BUILD)
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../${ACRE_NAME}_x64.dll
-    )
+    set(FINAL_DLL_NAME ${ACRE_NAME}_x64.dll)
 else()
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../${ACRE_NAME}.dll
-    )
+    set(FINAL_DLL_NAME ${ACRE_NAME}.dll)
 endif()
+
+add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
+    # Copy DLL to root
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../${FINAL_DLL_NAME}
+    # Copy PDB to symbols
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:${ACRE_NAME}>/${ACRE_NAME}.pdb ${PROJECT_SOURCE_DIR}/../symbols/${ACRE_ARCH}/${ACRE_NAME}.pdb
+)

--- a/extensions/src/ACRE2Arma/arma2ts/CMakeLists.txt
+++ b/extensions/src/ACRE2Arma/arma2ts/CMakeLists.txt
@@ -10,13 +10,17 @@ file(GLOB_RECURSE SOURCES *.h *.hpp *.c *.cpp)
 add_library( ${ACRE_NAME} MODULE ${SOURCES})
 set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2Arma)
 
-# Copy to root and rename
+
+# Copy and rename
 if(USE_64BIT_BUILD)
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../ACRE2Arma_x64.dll
-    )
+    set(FINAL_DLL_NAME ACRE2Arma_x64.dll)
 else()
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../ACRE2Arma.dll
-    )
+    set(FINAL_DLL_NAME ACRE2Arma.dll)
 endif()
+
+add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
+    # Copy DLL to root
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../${FINAL_DLL_NAME}
+    # Copy PDB to symbols
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:${ACRE_NAME}>/${ACRE_NAME}.pdb ${PROJECT_SOURCE_DIR}/../symbols/${ACRE_ARCH}/${ACRE_NAME}.pdb
+)

--- a/extensions/src/ACRE2Steam/CMakeLists.txt
+++ b/extensions/src/ACRE2Steam/CMakeLists.txt
@@ -10,13 +10,17 @@ file(GLOB_RECURSE SOURCES *.h *.hpp *.c *.cpp)
 add_library( ${ACRE_NAME} MODULE ${SOURCES})
 set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2)
 
-# Copy to root
+
+# Copy and rename
 if(USE_64BIT_BUILD)
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../${ACRE_NAME}_x64.dll
-    )
+    set(FINAL_DLL_NAME ${ACRE_NAME}_x64.dll)
 else()
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../${ACRE_NAME}.dll
-    )
+    set(FINAL_DLL_NAME ${ACRE_NAME}.dll)
 endif()
+
+add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
+    # Copy DLL to root
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../${FINAL_DLL_NAME}
+    # Copy PDB to symbols
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:${ACRE_NAME}>/${ACRE_NAME}.pdb ${PROJECT_SOURCE_DIR}/../symbols/${ACRE_ARCH}/${ACRE_NAME}.pdb
+)

--- a/extensions/src/ACRE2TS/CMakeLists.txt
+++ b/extensions/src/ACRE2TS/CMakeLists.txt
@@ -13,13 +13,17 @@ add_library( ${ACRE_NAME} MODULE ${SOURCES})
 target_link_libraries(${ACRE_NAME} ACRE2Core ACRE2Shared x3daudio)
 set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2)
 
-# Copy to plugin folder and rename
+
+# Copy and rename
 if(USE_64BIT_BUILD)
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../plugin/acre2_win64.dll
-    )
+    set(FINAL_DLL_NAME acre2_win64.dll)
 else()
-    add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../plugin/acre2_win32.dll
-    )
+    set(FINAL_DLL_NAME acre2_win32.dll)
 endif()
+
+add_custom_command(TARGET ${ACRE_NAME} POST_BUILD
+    # Copy DLL to plugins
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${ACRE_NAME}> ${PROJECT_SOURCE_DIR}/../plugin/${FINAL_DLL_NAME}
+    # Copy PDB to symbols
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:${ACRE_NAME}>/${ACRE_NAME}.pdb ${PROJECT_SOURCE_DIR}/../symbols/${ACRE_ARCH}/${ACRE_NAME}.pdb
+)

--- a/extensions/src/Wav2B64/CMakeLists.txt
+++ b/extensions/src/Wav2B64/CMakeLists.txt
@@ -8,7 +8,11 @@ file(GLOB_RECURSE SOURCES *.h *.hpp *.c *.cpp)
 add_executable(Wav2B64 ${SOURCES})
 set_target_properties(Wav2B64 PROPERTIES FOLDER Extras)
 
-# Copy to extras folder
+
+# Copy to extras folder and symbols
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    # Copy DLL to extras
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PROJECT_NAME}> ${PROJECT_SOURCE_DIR}/../../../extras/$<TARGET_FILE_NAME:${PROJECT_NAME}>
+    # Copy PDB to symbols
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:${PROJECT_NAME}>/${PROJECT_NAME}.pdb ${PROJECT_SOURCE_DIR}/../../../symbols/${ACRE_ARCH}/${PROJECT_NAME}.pdb
 )

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,13 @@
                     "remote_path": "dev.idi-systems.com/release/acre2_{major}.{minor}.{patch}.{build}.zip"
                 },
                 {
+                    "type": "sftp",
+                    "cred_file": "acre_release_sftp.json",
+                    "hostname": "dev.idi-systems.com",
+                    "local_path": "P:\\idi\\acre\\release\\acre2_{major}.{minor}.{patch}.{build}_symbols.zip",
+                    "remote_path": "dev.idi-systems.com/symbols/acre2_{major}.{minor}.{patch}.{build}_symbols.zip"
+                },
+                {
                     "type": "github",
                     "account": "IDI-Systems/acre2",
                     "tag_name": "v{major}.{minor}.{patch}.{build}",
@@ -61,6 +68,13 @@
                     "hostname": "dev.idi-systems.com",
                     "local_path": "P:\\idi\\acre\\release\\acre2_{major}.{minor}.{patch}.{build}.zip",
                     "remote_path": "dev.idi-systems.com/dev/acre2_{major}.{minor}.{patch}.{build}.zip"
+                },
+                {
+                    "type": "sftp",
+                    "cred_file": "acre_release_sftp.json",
+                    "hostname": "dev.idi-systems.com",
+                    "local_path": "P:\\idi\\acre\\release\\acre2_{major}.{minor}.{patch}.{build}_symbols.zip",
+                    "remote_path": "dev.idi-systems.com/symbols/acre2_{major}.{minor}.{patch}.{build}_symbols.zip"
                 }
             ]
         }

--- a/tools/make.py
+++ b/tools/make.py
@@ -1590,8 +1590,6 @@ See the make.cfg file for additional build options.
 
     # Make release
     if make_release_zip:
-        release_name = "{}_{}".format(zipPrefix, project_version)
-
         try:
             # Delete all log files
             for root, dirs, files in os.walk(os.path.join(release_dir, project, "addons")):
@@ -1605,6 +1603,7 @@ See the make.cfg file for additional build options.
                     os.remove(os.path.join(release_dir, file))
 
             # Create a zip with the contents of release folder in it
+            release_name = "{}_{}".format(zipPrefix, project_version)
             print_blue("\nMaking release: {}.zip ...".format(release_name))
             print("Packing...")
             release_zip = shutil.make_archive("{}".format(release_name), "zip", release_dir)
@@ -1612,6 +1611,17 @@ See the make.cfg file for additional build options.
             # Move release zip to release folder
             shutil.copy(release_zip, release_dir)
             os.remove(release_zip)
+
+            # Create a zip with symbols if symbols folder exists
+            if os.path.isdir(os.path.join(module_root_parent, "symbols")):
+                release_name_symbols = "{}_symbols".format(release_name)
+                print_blue("\nArchiving symbols: {}.zip ...".format(release_name_symbols))
+                print("Packing...")
+                symbols_zip = shutil.make_archive("{}".format(release_name_symbols), "zip", os.path.join(module_root_parent, "symbols"))
+
+                # Move symbols zip to release folder
+                shutil.copy(symbols_zip, release_dir)
+                os.remove(symbols_zip)
         except:
             raise
             print_error("Could not make release.")


### PR DESCRIPTION
**When merged this pull request will:**
- Close #288 
- Copy `.pdb` files (only ones we build on CI and publish) to root `symbols` directory on CMake post-build step
- Cleanup CMake post-build copy and rename DLL step
- Archive `symbols` directory and copy it to `release` directory
- Add SFTP upload on CI for symbols archive