### PR TITLE
Disable ringing and custom sound

### DIFF
--- a/addons/sys_intercom/CfgVehicles.hpp
+++ b/addons/sys_intercom/CfgVehicles.hpp
@@ -24,6 +24,8 @@ class CfgVehicles {
         acre_crewIntercomPositions[] = {};
         acre_crewIntercomExceptions[] = {};
         acre_hasInfantryPhone = 0;
+        acre_infantryPhoneDisableRinging = 0;
+        acre_infantryPhoneCustomRinging[] = {};
         acre_infantryPhoneIntercom[] = {};
         acre_hasPassengerIntercom = 0;
         acre_passengerIntercomPositions[] = {};
@@ -36,6 +38,8 @@ class CfgVehicles {
         acre_crewIntercomPositions[] = {};
         acre_crewIntercomExceptions[] = {};
         acre_hasInfantryPhone = 0;
+        acre_infantryPhoneDisableRinging = 0;
+        acre_infantryPhoneCustomRinging[] = {};
         acre_infantryPhoneIntercom[] = {};
         acre_hasPassengerIntercom = 0;
         acre_passengerIntercomPositions[] = {};
@@ -49,6 +53,8 @@ class CfgVehicles {
         acre_crewIntercomPositions[] = {"default"};
         acre_crewIntercomExceptions[] = {};
         acre_hasInfantryPhone = 1;
+        acre_infantryPhoneDisableRinging = 0;
+        acre_infantryPhoneCustomRinging[] = {};
         acre_infantryPhoneIntercom[] = {};
         acre_eventInfantryPhone = QFUNC(noApiFunction);
         acre_hasPassengerIntercom = 0;
@@ -141,7 +147,9 @@ class CfgVehicles {
         acre_hasCrewIntercom = 1;
         acre_crewIntercomPositions[] = {};
         acre_crewIntercomExceptions[] = {};
-        acre_hasInfantryPhone = 0;
+        acre_hasInfantryPhone = 1;
+        acre_infantryPhoneDisableRinging = 1;
+        acre_infantryPhoneCustomRinging[] = {};
         acre_infantryPhoneIntercom[] = {};
         acre_hasPassengerIntercom = 0;
         acre_passengerIntercomPositions[] = {"default"};
@@ -198,7 +206,9 @@ class CfgVehicles {
         acre_hasCrewIntercom = 1;
         acre_crewIntercomPositions[] = {"default"};
         acre_crewIntercomExceptions[] = {};
-        acre_hasInfantryPhone = 0;
+        acre_hasInfantryPhone = 1;
+        acre_infantryPhoneDisableRinging = 1;
+        acre_infantryPhoneCustomRinging[] = {};
         acre_infantryPhoneIntercom[] = {};
         acre_hasPassengerIntercom = 0;
         acre_passengerIntercomPositions[] = {"default"};
@@ -231,6 +241,8 @@ class CfgVehicles {
         acre_crewIntercomPositions[] = {};
         acre_crewIntercomExceptions[] = {};
         acre_hasInfantryPhone = 0;
+        acre_infantryPhoneDisableRinging = 0;
+        acre_infantryPhoneCustomRinging[] = {};
         acre_infantryPhoneIntercom[] = {};
         acre_hasPassengerIntercom = 1;
         acre_passengerIntercomPositions[] = {};

--- a/addons/sys_intercom/fnc_infantryPhoneChildrenActions.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneChildrenActions.sqf
@@ -135,7 +135,7 @@ if (_target isKindOf "CAManBase") then {
             ] call ace_interact_menu_fnc_createAction;
             _actions pushBack [_action, [], _target];
         } else {
-            if (isNull _vehicleInfantryPhone) then {
+            if (isNull _vehicleInfantryPhone && {!(_target getVariable [QGVAR(infPhoneDisableRinging), false])}) then {
                 private _action = [
                     "acre_infantryTelephone_startCalling",
                     localize LSTRING(infantryPhone_startCalling),

--- a/addons/sys_intercom/fnc_infantryPhoneConfig.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneConfig.sqf
@@ -23,6 +23,8 @@ private _type = typeOf _vehicle;
 private _infantryPhoneIntercom = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneIntercom");
 private _hasCrewIntercom = getNumber (configFile >> "CfgVehicles" >> _type >> "acre_hasCrewIntercom");
 private _hasPassengerIntercom = getNumber (configFile >> "CfgVehicles" >> _type >> "acre_hasPassengerIntercom");
+private _infantryPhoneDisableRinging = (getNumber (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneDisableRinging")) == 1;
+private _infantryPhoneCustomRinging = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneCustomRinging");
 
 // Set by default to have access to all intercom networks if none was specified
 if (count _infantryPhoneIntercom ==  0) then {
@@ -51,6 +53,14 @@ if (count _infantryPhoneIntercom ==  0) then {
 };
 
 _vehicle setVariable [QGVAR(infantryPhoneIntercom), _infantryPhoneIntercom];
+_vehicle setVariable [QGVAR(infPhoneDisableRinging), _infantryPhoneDisableRinging];
+
+if (count _infantryPhoneCustomRinging > 0) then {
+    if (_infantryPhoneDisableRinging) then {
+        WARNING_2("Vehiclye type %1 has the ringing functionality disabled despite having a custom ringing tone entry %2", _type, _infantryPhoneCustomRinging);
+    };
+    _vehicle setVariable [QGVAR(infPhoneCustomRinging), _infantryPhoneCustomRinging];
+};
 
 // Hook for third party mods with actions when picking returning infantry phone
 private _eventInfantryPhone = getText (configFile >> "CfgVehicles" >> _type >> "acre_eventInfantryPhone");

--- a/addons/sys_intercom/fnc_infantryPhoneConfig.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneConfig.sqf
@@ -57,9 +57,14 @@ _vehicle setVariable [QGVAR(infPhoneDisableRinging), _infantryPhoneDisableRingin
 
 if (count _infantryPhoneCustomRinging > 0) then {
     if (_infantryPhoneDisableRinging) then {
-        WARNING_2("Vehiclye type %1 has the ringing functionality disabled despite having a custom ringing tone entry %2", _type, _infantryPhoneCustomRinging);
+        WARNING_2("Vehicle type %1 has the ringing functionality disabled despite having a custom ringing tone entry %2",_type,_infantryPhoneCustomRinging);
+    } else {
+        if (count _infantryPhoneCustomRinging != 5) then {
+            WARNING_2("Badly formatted entry acre_infantryPhoneCustomRinging for vehicle type %1. It should have 5 arguments but it has %2.",_type,count _infantryPhoneCustomRinging);
+        } else {
+            _vehicle setVariable [QGVAR(infPhoneCustomRinging), _infantryPhoneCustomRinging];
+        };
     };
-    _vehicle setVariable [QGVAR(infPhoneCustomRinging), _infantryPhoneCustomRinging];
 };
 
 // Hook for third party mods with actions when picking returning infantry phone

--- a/addons/sys_intercom/fnc_infantryPhoneRingingPFH.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneRingingPFH.sqf
@@ -33,15 +33,16 @@ if ((isNull _unitInfantryPhone) && {_isCalling} && {alive _vehicle} && {!_noCrew
     private _position = AGLToASL (_vehicle modelToWorld _infantryPhonePosition); // ACRE_LISTENER_POS is in ASL coordinates
     TRACE_4("Infantry Phone Calling PFH Check",_vehicle,acre_player,_position,_volume);
 
-    private _soundFile = QPATHTO_R(sounds\Cellphone_Ring.wss);
-    private _volume = 3.16;
-    private _soundPitch = 1;
-    private _distance = 75;
-    if (count (_vehicle getVariable [QGVAR(infPhoneCustomRinging), []]) > 0) then {
-        _soundFile = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 0;
-        _volume = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 2;
-        _soundPitch = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 3;
-        _distance = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 4;
+    private _soundFile = INFANTRY_PHONE_SOUNDFILE;
+    private _volume = INFANTRY_PHONE_VOLUME;
+    private _soundPitch = INFANTRY_PHONE_SOUNDPITCH;
+    private _distance = INFANTRY_PHONE_MAX_DISTANCE;
+    private _customSound = _vehicle getVariable [QGVAR(infPhoneCustomRinging), []];
+    if (count _customSound > 0) then {
+        _soundFile = _customSound select 0;
+        _volume = _customSound select 2;
+        _soundPitch = _customSound select 3;
+        _distance = _customSound select 4;
     };
     playSound3D [_soundFile, objNull, false, _position, _volume*10, _soundPitch, _distance];
 } else {

--- a/addons/sys_intercom/fnc_infantryPhoneRingingPFH.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneRingingPFH.sqf
@@ -37,13 +37,13 @@ if ((isNull _unitInfantryPhone) && {_isCalling} && {alive _vehicle} && {!_noCrew
     private _volume = 3.16;
     private _soundPitch = 1;
     private _distance = 75;
-    if (!isNil (_vehicle getVariable [QGVAR(infPhoneCustomRinging), nil])) then {
+    if (count (_vehicle getVariable [QGVAR(infPhoneCustomRinging), []]) > 0) then {
         _soundFile = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 0;
         _volume = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 2;
         _soundPitch = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 3;
         _distance = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 4;
     };
-    playSound3D [_soundFile, objNull, false, _position, _volume, _soundPitch, _distance];
+    playSound3D [_soundFile, objNull, false, _position, _volume*10, _soundPitch, _distance];
 } else {
     // A unit picked up the phone. Reset isCalling variable
     if (_isCalling) then {

--- a/addons/sys_intercom/fnc_infantryPhoneRingingPFH.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneRingingPFH.sqf
@@ -32,7 +32,18 @@ if (count _crew == 0) then {
 if ((isNull _unitInfantryPhone) && {_isCalling} && {alive _vehicle} && {!_noCrew}) then {
     private _position = AGLToASL (_vehicle modelToWorld _infantryPhonePosition); // ACRE_LISTENER_POS is in ASL coordinates
     TRACE_4("Infantry Phone Calling PFH Check",_vehicle,acre_player,_position,_volume);
-    playSound3D [QPATHTO_R(sounds\Cellphone_Ring.wss), objNull, false, _position, 3.16, 1, 75];
+
+    private _soundFile = QPATHTO_R(sounds\Cellphone_Ring.wss);
+    private _volume = 3.16;
+    private _soundPitch = 1;
+    private _distance = 75;
+    if (!isNil (_vehicle getVariable [QGVAR(infPhoneCustomRinging), nil])) then {
+        _soundFile = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 0;
+        _volume = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 2;
+        _soundPitch = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 3;
+        _distance = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 4;
+    };
+    playSound3D [_soundFile, objNull, false, _position, _volume, _soundPitch, _distance];
 } else {
     // A unit picked up the phone. Reset isCalling variable
     if (_isCalling) then {

--- a/addons/sys_intercom/fnc_infantryPhoneSoundCall.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneSoundCall.sqf
@@ -22,4 +22,9 @@ params ["_vehicle"];
 // The infantry phone of the vehicle is ringing
 _vehicle setVariable [QGVAR(isInfantryPhoneCalling), true, true];
 
-[FUNC(infantryPhoneRingingPFH), 2.25, [_vehicle, _infantryPhonePosition]] call CBA_fnc_addPerFrameHandler;
+private _duration = 2.25;
+if (!isNil (_vehicle getVariable [QGVAR(infPhoneCustomRinging), nil])) then {
+    _duration = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 1;
+};
+
+[FUNC(infantryPhoneRingingPFH), _duration, [_vehicle, _infantryPhonePosition]] call CBA_fnc_addPerFrameHandler;

--- a/addons/sys_intercom/fnc_infantryPhoneSoundCall.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneSoundCall.sqf
@@ -23,7 +23,7 @@ params ["_vehicle"];
 _vehicle setVariable [QGVAR(isInfantryPhoneCalling), true, true];
 
 private _duration = 2.25;
-if (!isNil (_vehicle getVariable [QGVAR(infPhoneCustomRinging), nil])) then {
+if (count (_vehicle getVariable [QGVAR(infPhoneCustomRinging), []]) > 0) then {
     _duration = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 1;
 };
 

--- a/addons/sys_intercom/fnc_infantryPhoneSoundCall.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneSoundCall.sqf
@@ -22,9 +22,10 @@ params ["_vehicle"];
 // The infantry phone of the vehicle is ringing
 _vehicle setVariable [QGVAR(isInfantryPhoneCalling), true, true];
 
-private _duration = 2.25;
-if (count (_vehicle getVariable [QGVAR(infPhoneCustomRinging), []]) > 0) then {
-    _duration = (_vehicle getVariable QGVAR(infPhoneCustomRinging)) select 1;
+private _duration = INFANTRY_PHONE_SOUND_PFH_DURATION;
+private _customSound = _vehicle getVariable [QGVAR(infPhoneCustomRinging), []];
+if (count _customSound > 0) then {
+    _duration = _customSound select 1;
 };
 
 [FUNC(infantryPhoneRingingPFH), _duration, [_vehicle, _infantryPhonePosition]] call CBA_fnc_addPerFrameHandler;

--- a/addons/sys_intercom/fnc_intercomConfig.sqf
+++ b/addons/sys_intercom/fnc_intercomConfig.sqf
@@ -38,7 +38,7 @@ if (getNumber (configFile >> "CfgVehicles" >> _type >> "acre_hasPassengerInterco
 // Exit if object has no infantry phone
 if (getNumber (configFile >> "CfgVehicles" >> _type >> "acre_hasInfantryPhone") == 1) then {
     [_target] call FUNC(infantryPhoneConfig);
-    if (hasInterface && {_target getVariable [QGVAR(infPhoneDisableRinging), false]}) then {
+    if (hasInterface) then {
         [_target] call FUNC(infantryPhoneAction);
     };
 };

--- a/addons/sys_intercom/fnc_intercomConfig.sqf
+++ b/addons/sys_intercom/fnc_intercomConfig.sqf
@@ -38,7 +38,7 @@ if (getNumber (configFile >> "CfgVehicles" >> _type >> "acre_hasPassengerInterco
 // Exit if object has no infantry phone
 if (getNumber (configFile >> "CfgVehicles" >> _type >> "acre_hasInfantryPhone") == 1) then {
     [_target] call FUNC(infantryPhoneConfig);
-    if (hasInterface) then {
+    if (hasInterface && {_target getVariable [QGVAR(infPhoneDisableRinging), false]}) then {
         [_target] call FUNC(infantryPhoneAction);
     };
 };

--- a/addons/sys_intercom/script_component.hpp
+++ b/addons/sys_intercom/script_component.hpp
@@ -25,4 +25,10 @@
 #define CREW_INTERCOM 1
 #define PASSENGER_INTERCOM 2
 
+// Infantry phone default configuration (fnc_infantryPhoneRingingPFH.sqf)
+#define INFANTRY_PHONE_SOUNDFILE QPATHTO_R(sounds\Cellphone_Ring.wss);
+#define INFANTRY_PHONE_VOLUME 3.16
+#define INFANTRY_PHONE_SOUNDPITCH 1
+#define INFANTRY_PHONE_MAX_DISTANCE 75
+
 #define CREW_STRING "str_a3_rscdisplaygarage_tab_crew"

--- a/addons/sys_intercom/script_component.hpp
+++ b/addons/sys_intercom/script_component.hpp
@@ -27,6 +27,7 @@
 
 // Infantry phone default configuration (fnc_infantryPhoneRingingPFH.sqf)
 #define INFANTRY_PHONE_SOUNDFILE QPATHTO_R(sounds\Cellphone_Ring.wss);
+#define INFANTRY_PHONE_SOUND_PFH_DURATION 2.25
 #define INFANTRY_PHONE_VOLUME 3.16
 #define INFANTRY_PHONE_SOUNDPITCH 1
 #define INFANTRY_PHONE_MAX_DISTANCE 75

--- a/docs/wiki/frameworks/vehicle-intercom.md
+++ b/docs/wiki/frameworks/vehicle-intercom.md
@@ -118,7 +118,36 @@ class CfgVehicles {
     class MyVehicle: ParentVehicle {
         acre_hasInfantryPhone = 1; // 1 - enabled, 0 -
         // Intercom the infantry phone can connect to. If left empty, the infantry phone is able to connect to all available intercom networks. Supported entries are "crew" and "passenger".
+        acre_infantryPhoneDisableRinging = 0;   // If set to 1, the ringing funtionality will not be available.
+        acre_infantryPhoneCustomRinging[] = {}; // An array used in order to override the default sound for the ringing functionality.
         acre_infantryPhoneIntercom[] = {"crew", "passenger"};
+        // Here a custom function can be defined that is called when the infantry phone is picked up, put back, given to another unit or the intercom network is switched.
+        acre_eventInfantryPhone = QFUNC(noApiFunction);
+    };
+};
+```
+{% endraw %}
+
+### Ringing and ringing sound
+
+The infantry phone has the ringing functionality configured by default. However, it can be disabled by setting `acre_infantryPhoneDisableRinging` to 1. In addition, the default ringing sound in ACRE2 can be also overwritten, on a class basis, through the `acre_infantryPhoneCustomRinging` entry. This entry consists of an array of five elements and it will do nothing if left blank. The five entries are mandatory in order for the function `playSound3D` to work as intended in ACRE2.
+
+- 0: Path to sound file <STRING>
+- 1: Duration (sound is a PFH so we need to specify a duration) <NUMBER>
+- 2: Volume the sound plays at <NUMBER>
+- 3: Sound pitch <NUMBER>
+- 4: How far the sound is audible <NUMBER>
+
+{% raw %}
+```cpp
+class CfgVehicles {
+    class ParentVehicle;
+    class MyVehicle: ParentVehicle {
+        acre_hasInfantryPhone = 1; // 1 - enabled, 0 -
+        // Intercom the infantry phone can connect to. If left empty, the infantry phone is able to connect to all available intercom networks. Supported entries are "crew" and "passenger".
+        acre_infantryPhoneDisableRinging = 0;   // If set to 1, the ringing funtionality will not be available.
+        acre_infantryPhoneCustomRinging[] = "A3\Sounds_F\sfx\alarm_independent.wss", 5.0, 1.0, 1.0, 50}; // The alarm sound will be played every 5 seconds and will be audible until 50m. Volume and sound pitch are both set to 1.
+        acre_infantryPhoneIntercom[] = {"crew"};
         // Here a custom function can be defined that is called when the infantry phone is picked up, put back, given to another unit or the intercom network is switched.
         acre_eventInfantryPhone = QFUNC(noApiFunction);
     };
@@ -205,6 +234,8 @@ class CfgVehicles {
         acre_hasInfantryPhone = 1;
         acre_infantryPhoneIntercom[] = {"crew", "passenger"};
         acre_infantryPhonePosition[] = {-1.1, -4.86, -0.82};
+        acre_infantryPhoneDisableRinging = 0;   // If set to 1, the ringing funtionality will not be available.
+        acre_infantryPhoneCustomRinging[] = {"A3\Sounds_F\sfx\alarm_independent.wss", 5.0, 1.0, 1.0, 50}; // The alarm sound will be played every 5 seconds and will be audible until 50m. Volume and sound pitch are both set to 1.
     };
 };
 ```

--- a/docs/wiki/frameworks/vehicle-intercom.md
+++ b/docs/wiki/frameworks/vehicle-intercom.md
@@ -234,7 +234,7 @@ class CfgVehicles {
         acre_hasInfantryPhone = 1;
         acre_infantryPhoneIntercom[] = {"crew", "passenger"};
         acre_infantryPhonePosition[] = {-1.1, -4.86, -0.82};
-        acre_infantryPhoneDisableRinging = 0;   // If set to 1, the ringing funtionality will not be available.
+        acre_infantryPhoneDisableRinging = 0; // If set to 1, the ringing funtionality will not be available.
         acre_infantryPhoneCustomRinging[] = {"A3\Sounds_F\sfx\alarm_independent.wss", 5.0, 1.0, 1.0, 50}; // The alarm sound will be played every 5 seconds and will be audible until 50m. Volume and sound pitch are both set to 1.
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Adds the possibility to disable ringing through the config entry `acre_infantryPhoneDisableRinging`
- Adds the possibility of defining a custom sound through the config entry `acre_infantryPhoneCustomRinging`. This is an array with the following entries (PlaySound3D):
  - 0: Path to sound file:
  - 1: Duration (sound is a PFH so we need to specify a duration).
  - 2: Volume the sound plays at.
  - 3: Sound pitch.
  - 4: Distance.