### PR TITLE
Fix rack/external radios when no radios are present

### DIFF
--- a/addons/sys_list/fnc_cycleRadios.sqf
+++ b/addons/sys_list/fnc_cycleRadios.sqf
@@ -34,7 +34,7 @@ if (!dialog) then {
         } else {
             _realRadio = [_radioRack] call EFUNC(sys_rack,getRackBaseClassname);
         };
-        private _typeName = getText (configFile >> "CfgAcreComponents" >> _realRadio >> "name");   
+        private _typeName = getText (configFile >> "CfgAcreComponents" >> _realRadio >> "name");
         private _radio = [_typeName, _listInfo, _radioClass];
         TRACE_2("heh", _radioClass, ACRE_ACTIVE_RADIO);
         if (_radioClass == ACRE_ACTIVE_RADIO) then {
@@ -68,6 +68,8 @@ if (!dialog) then {
         //diag_log "GO GO GOGO";
         //diag_log text format["'%1'", _activateRadio];
         [(_activateRadio select 0), (_activateRadio select 1), "", 1] call FUNC(displayHint);
+    } else {
+        [""] call EFUNC(sys_radio,setActiveRadio);
     };
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes the current situation if no radio was  in the inventory:
  - The player was able to use rack radios outside the vehicle.
  - The player was able to use shared radios without taking into account distance limitations.
