### PR TITLE
Open radio on base action point in addition to sub-action

### DIFF
--- a/addons/ace_interact/fnc_radioChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioChildrenActions.sqf
@@ -34,6 +34,11 @@ if (_spatial == "RIGHT") then {
 private _action = ["acre_spatial_radio", _txt, "", {}, {true}, {_this call FUNC(generateSpatialChildrenActions);}, _params + [_spatial]] call ace_interact_menu_fnc_createAction;
 _actions pushBack [_action, [], _target];
 
+if (!((_radio in ACRE_ACCESSIBLE_RACK_RADIOS && {isTurnedOut acre_player}) || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)) then {
+    _action = ["acre_open_radio", localize ELSTRING(sys_list,OpenRadio), "", {[((_this select 2) select 0)] call EFUNC(sys_radio,openRadio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+    _actions pushBack [_action, [], _target];
+};
+
 _action = ["acre_make_active", localize LSTRING(setAsActive), "", {[(_this select 2) select 0] call EFUNC(api,setCurrentRadio)}, {!((_this select 2) select 1)}, {},_params] call ace_interact_menu_fnc_createAction;
 _actions pushBack [_action, [], _target];
 

--- a/addons/ace_interact/fnc_radioChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioChildrenActions.sqf
@@ -33,10 +33,7 @@ if (_spatial == "RIGHT") then {
 
 private _action = ["acre_spatial_radio", _txt, "", {}, {true}, {_this call FUNC(generateSpatialChildrenActions);}, _params + [_spatial]] call ace_interact_menu_fnc_createAction;
 _actions pushBack [_action, [], _target];
-if (!((_radio in ACRE_ACCESSIBLE_RACK_RADIOS && {isTurnedOut acre_player}) || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)) then {
-    _action = ["acre_open_radio", localize ELSTRING(sys_list,OpenRadio), "", {[((_this select 2) select 0)] call EFUNC(sys_radio,openRadio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-    _actions pushBack [_action, [], _target];
-};
+
 _action = ["acre_make_active", localize LSTRING(setAsActive), "", {[(_this select 2) select 0] call EFUNC(api,setCurrentRadio)}, {!((_this select 2) select 1)}, {},_params] call ace_interact_menu_fnc_createAction;
 _actions pushBack [_action, [], _target];
 

--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -53,10 +53,7 @@ private _radioList = [] call EFUNC(api,getCurrentRadioList);
         {
             [(_this select 2) select 0] call EFUNC(sys_radio,openRadio)
         },
-        {
-            (_this select 2) params ["_radio"];
-            !((_radio in ACRE_ACCESSIBLE_RACK_RADIOS && {isTurnedOut acre_player}) || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)
-        },
+        {true},
         {_this call FUNC(radioChildrenActions)},
         [_x, _isActive, _pttAssign]
     ] call ace_interact_menu_fnc_createAction;

--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -46,9 +46,22 @@ private _radioList = [] call EFUNC(api,getCurrentRadioList);
     private _picture = getText (_item >> "picture");
     private _isActive = _x isEqualTo _currentRadio;
 
-    private _action = [_x, _displayName, _picture, {}, {true}, {_this call FUNC(radioChildrenActions)}, [_x, _isActive, _pttAssign]] call ace_interact_menu_fnc_createAction;
+    private _action = [
+        _x,
+        _displayName,
+        _picture,
+        {
+            [(_this select 2) select 0] call EFUNC(sys_radio,openRadio)
+        },
+        {
+            (_this select 2) params ["_radio"];
+            !((_radio in ACRE_ACCESSIBLE_RACK_RADIOS && {isTurnedOut acre_player}) || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)
+        },
+        {_this call FUNC(radioChildrenActions)},
+        [_x, _isActive, _pttAssign]
+    ] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
-} forEach (_radioList);
+} forEach _radioList;
 
 if (count _radioList > 0) then {
     private _text = localize LSTRING(lowerHeadset);

--- a/addons/sys_rack/fnc_rackChildrenActions.sqf
+++ b/addons/sys_rack/fnc_rackChildrenActions.sqf
@@ -61,7 +61,7 @@ if ([_rackClassName, _unit] call FUNC(isRackAccessible)) then {
             _actions pushBack [_action, [], _target];
 
             private _pttAssign = [] call EFUNC(api,getMultiPushToTalkAssignment);
-            private _radioActions = [_target, _unit, [_mountedRadio, (_mountedRadio isEqualTo ACRE_ACTIVE_RADIO), _pttAssign]] call FUNC(radioChildrenActions);
+            private _radioActions = [_target, _unit, [_mountedRadio, (_mountedRadio isEqualTo ACRE_ACTIVE_RADIO), _pttAssign]] call EFUNC(ace_interact,radioChildrenActions);
             _actions append _radioActions;
         } else {
             // Use


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Close #281 
- Fix rack radio actions (all the actions that you can do on personal radios didn't show up, such as spatial... etc.)

Opening radio on base action should be done for racks as well, there is currently no way apart from keybind (which is broken from where this was branched off). I will leave that to @TheMagnetar as he knows the code.

~~I think there is no need for an "Open" text either, should be pretty self-explanatory that the radio icon opens the radio.~~ Changed to action on both nodes.