### PR TITLE
Vanilla vehicles + fixes

### DIFF
--- a/addons/sys_intercom/CfgVehicles.hpp
+++ b/addons/sys_intercom/CfgVehicles.hpp
@@ -33,8 +33,8 @@ class CfgVehicles {
         acre_passengerIntercomConnections = -1;
     };
 
-    class MRAP_02_base_F: Car_F {
-        acre_hasCrewIntercom = 1;
+    class MRAP_01_base_F: Car_F {
+        acre_hasCrewIntercom = 0;
         acre_crewIntercomPositions[] = {};
         acre_crewIntercomExceptions[] = {};
         acre_hasInfantryPhone = 0;
@@ -100,6 +100,20 @@ class CfgVehicles {
     };
 
     // OPFOR
+    class MRAP_02_base_F: Car_F {
+        acre_hasCrewIntercom = 0;
+        acre_crewIntercomPositions[] = {};
+        acre_crewIntercomExceptions[] = {};
+        acre_hasInfantryPhone = 0;
+        acre_infantryPhoneDisableRinging = 0;
+        acre_infantryPhoneCustomRinging[] = {};
+        acre_infantryPhoneIntercom[] = {};
+        acre_hasPassengerIntercom = 0;
+        acre_passengerIntercomPositions[] = {};
+        acre_passengerIntercomExceptions[] = {};
+        acre_passengerIntercomConnections = -1;
+    };
+
     class O_MBT_02_base_F;
     class O_MBT_02_cannon_F: O_MBT_02_base_F {
         acre_infantryPhonePosition[] = {1.38, -4.77, -1.1};
@@ -193,6 +207,20 @@ class CfgVehicles {
     };
 
     // INDEPENDENT
+    class MRAP_03_base_F: Car_F {
+        acre_hasCrewIntercom = 0;
+        acre_crewIntercomPositions[] = {};
+        acre_crewIntercomExceptions[] = {};
+        acre_hasInfantryPhone = 0;
+        acre_infantryPhoneDisableRinging = 0;
+        acre_infantryPhoneCustomRinging[] = {};
+        acre_infantryPhoneIntercom[] = {};
+        acre_hasPassengerIntercom = 0;
+        acre_passengerIntercomPositions[] = {};
+        acre_passengerIntercomExceptions[] = {};
+        acre_passengerIntercomConnections = -1;
+    };
+
     class Heli_Transport_02_base_F: Helicopter_Base_H {
         acre_hasPassengerIntercom = 1;
         acre_passengerIntercomPositions[] = {{"cargo", "all"}, {"ffv", "all"}};

--- a/addons/sys_rack/CfgVehicles.hpp
+++ b/addons/sys_rack/CfgVehicles.hpp
@@ -50,6 +50,57 @@ class CfgVehicles {
             };
         };
     };
+
+    class MRAP_02_base_F: Car_F {
+        class AcreRacks {
+            class Rack_1 {
+                name = "Dashboard Upper"; // Name is displayed in the interaction menu.
+                componentname = "ACRE_VRC110";
+                allowed[] = {"driver", {"cargo", 0}}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
+                disabled[] = {};
+                defaultComponents[] = {}; // Use this to attach simple components like Antennas, they will first attempt to fill empty connectors but will overide existing connectors - ACRE_13IN_UHF_BNC
+                mountedRadio = "";
+                isRadioRemovable = 1;
+                intercom[] = {};
+            };
+            class Rack_2 {
+                name = "Dashboard Lower"; // If you have multiple racks a text label helps identify the particular rack..
+                componentname = "ACRE_VRC103";
+                allowed[] = {"driver", {"cargo", 0}};
+                disabled[] = {};
+                defaultComponents[] = {};
+                mountedRadio = "ACRE_PRC117F";
+                isRadioRemovable = 0;
+                intercom[] = {};
+            };
+        };
+    };
+
+    class MRAP_03_base_F: Car_F {
+        class AcreRacks {
+            class Rack_1 {
+                name = "Dashboard Upper"; // Name is displayed in the interaction menu.
+                componentname = "ACRE_VRC110";
+                allowed[] = {"driver", {"cargo", 0}}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
+                disabled[] = {};
+                defaultComponents[] = {}; // Use this to attach simple components like Antennas, they will first attempt to fill empty connectors but will overide existing connectors - ACRE_13IN_UHF_BNC
+                mountedRadio = "";
+                isRadioRemovable = 1;
+                intercom[] = {};
+            };
+            class Rack_2 {
+                name = "Dashboard Lower"; // If you have multiple racks a text label helps identify the particular rack..
+                componentname = "ACRE_VRC103";
+                allowed[] = {"driver", {"cargo", 0}};
+                disabled[] = {};
+                defaultComponents[] = {};
+                mountedRadio = "ACRE_PRC117F";
+                isRadioRemovable = 0;
+                intercom[] = {};
+            };
+        };
+    };
+
     class Helicopter;
     class Helicopter_Base_F : Helicopter {
         class AcreRacks {
@@ -65,6 +116,23 @@ class CfgVehicles {
             };
         };
     };
+
+    class VTOL_01_base_F;
+    class VTOL_01_unarmed_base_F: VTOL_01_base_F {
+        class AcreRacks {
+            class Rack_1 {
+                name = "Dash"; // Name is displayed in the interaction menu.
+                componentname = "ACRE_VRC103";
+                allowed[] = {"driver", "copilot", {"turret", {1}, {2}}};
+                disabled[] = {};
+                defaultComponents[] = {};
+                mountedRadio = "ACRE_PRC117F";
+                isRadioRemovable = 0;
+                intercom[] = {"crew"};
+            };
+        };
+    };
+
     class Plane;
     class Plane_Base_F : Plane {
         class AcreRacks {
@@ -80,6 +148,7 @@ class CfgVehicles {
             };
         };
     };
+
     class Tank;
     class Tank_F : Tank {
          class AcreRacks {
@@ -95,6 +164,7 @@ class CfgVehicles {
             };
         };
     };
+
     //class Car_F; // defined earlier.
     class Wheeled_APC_F : Car_F {
          class AcreRacks {

--- a/addons/sys_rack/fnc_vehicleCrewPFH.sqf
+++ b/addons/sys_rack/fnc_vehicleCrewPFH.sqf
@@ -75,13 +75,16 @@ private _remove = [];
     private _rack = [_x] call FUNC(getRackFromRadio);
     if (_rack == "") then { _remove pushBackUnique _x; }; // Radio is no longer stored in a rack.
 
+    private _isRackHearable = [_rack, acre_player] call FUNC(isRackHearable);
+    private _isRackAccessible = [_rack, acre_player] call FUNC(isRackAccessible);
+
     // Check only those radios connected on intercom systems
-    if (count ([_rack] call FUNC(getWiredIntercoms))> 0) then {
+    if (count ([_rack] call FUNC(getWiredIntercoms)) > 0 && _isRackHearable) then {
         private _functionality = [_x, _vehicle, acre_player, toLower _rack] call EFUNC(sys_intercom,getRxTxCapabilities);
         if (_functionality == RACK_NO_MONITOR) then {_remove pushBackUnique _x;};
     };
 
-    if (!(([_rack, acre_player] call FUNC(isRackAccessible)) || ([_rack, acre_player] call FUNC(isRackHearable)))) then { _remove pushBackUnique _x; };
+    if (!(_isRackAccessible || _isRackHearable)) then { _remove pushBackUnique _x; };
 } forEach (ACRE_ACCESSIBLE_RACK_RADIOS + ACRE_HEARABLE_RACK_RADIOS);
 
 {


### PR DESCRIPTION
**When merged this pull request will:**
- Partially close #325 
- MRAPs for OPFOR and AAF have now racks.
- BLUFOR VTOLs have the two cabin passengers configured to have rack access despite not being in crew intercom.
- Fix case were a rack in intercom could not be used if the player was not in that intercom despite having access to it.
- MRAP for OPFOR should not have crew intercom.