### PR TITLE
External radio improvements and fixes

### DIFF
--- a/addons/ace_interact/fnc_radioChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioChildrenActions.sqf
@@ -22,70 +22,75 @@ _params params ["_radio", "", "_pttAssign"];
 
 private _actions = [];
 
-private _spatial = [_radio] call EFUNC(api,getRadioSpatial);
-private _txt = localize LSTRING(bothEars);
-if (_spatial == "LEFT") then {
-    _txt = localize LSTRING(leftEar);
-};
-if (_spatial == "RIGHT") then {
-    _txt = localize LSTRING(rightEar);
-};
+if (!(_radio in ACRE_EXTERNALLY_USED_PERSONAL_RADIOS)) then {
+    private _spatial = [_radio] call EFUNC(api,getRadioSpatial);
+    private _txt = localize LSTRING(bothEars);
+    if (_spatial == "LEFT") then {
+        _txt = localize LSTRING(leftEar);
+    };
+    if (_spatial == "RIGHT") then {
+        _txt = localize LSTRING(rightEar);
+    };
 
-private _action = ["acre_spatial_radio", _txt, "", {}, {true}, {_this call FUNC(generateSpatialChildrenActions);}, _params + [_spatial]] call ace_interact_menu_fnc_createAction;
-_actions pushBack [_action, [], _target];
-
-if (!((_radio in ACRE_ACCESSIBLE_RACK_RADIOS && {isTurnedOut acre_player}) || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)) then {
-    _action = ["acre_open_radio", localize ELSTRING(sys_list,OpenRadio), "", {[((_this select 2) select 0)] call EFUNC(sys_radio,openRadio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+    private _action = ["acre_spatial_radio", _txt, "", {}, {true}, {_this call FUNC(generateSpatialChildrenActions);}, _params + [_spatial]] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
-};
 
-_action = ["acre_make_active", localize LSTRING(setAsActive), "", {[(_this select 2) select 0] call EFUNC(api,setCurrentRadio)}, {!((_this select 2) select 1)}, {},_params] call ace_interact_menu_fnc_createAction;
-_actions pushBack [_action, [], _target];
+    if (!((_radio in ACRE_ACCESSIBLE_RACK_RADIOS && {isTurnedOut acre_player}) || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)) then {
+        _action = ["acre_open_radio", localize ELSTRING(sys_list,OpenRadio), "", {[((_this select 2) select 0)] call EFUNC(sys_radio,openRadio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+    };
 
-// External radios. Show only options to share/stop sharing the radio if you are the actual owner and not an external user.
-if (!(_radio in ACRE_ACTIVE_EXTERNAL_RADIOS || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)) then {
-    _action = ["acre_share_radio", localize ELSTRING(sys_external,shareRadio), "", {[(_this select 2) select 0, true] call EFUNC(sys_external,allowExternalUse)}, {!([(_this select 2) select 0] call EFUNC(sys_external,isRadioShared))}, {}, _params] call ace_interact_menu_fnc_createAction;
+    _action = ["acre_make_active", localize LSTRING(setAsActive), "", {[(_this select 2) select 0] call EFUNC(api,setCurrentRadio)}, {!((_this select 2) select 1)}, {},_params] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
-    _action = ["acre_retrieve_radio", localize ELSTRING(sys_external,unshareRadio), "", {[(_this select 2) select 0, false] call EFUNC(sys_external,allowExternalUse)}, {[(_this select 2) select 0] call EFUNC(sys_external,isRadioShared)}, {}, _params] call ace_interact_menu_fnc_createAction;
-    _actions pushBack [_action, [], _target];
-};
 
-// Rack radios in intercom, RX/TX functionality
-if ((toLower _radio) in ACRE_ACCESSIBLE_RACK_RADIOS || (toLower _radio) in ACRE_ACCESSIBLE_RACK_RADIOS) then {
-    private _functionality = [_radio, vehicle acre_player, acre_player] call EFUNC(sys_intercom,getRxTxCapabilities);
-    switch (_functionality) do {
-        case RACK_NO_MONITOR: {
-            WARNING_1("Entered no monitor in ace interaction menu for radio %1", _radio);
-        };
-        case RACK_RX_ONLY: {
-            _action = ["acre_trans_only", localize ELSTRING(sys_intercom,transOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_TX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
-            _action = ["acre_rec_and_trans", localize ELSTRING(sys_intercom,recAndTrans), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_AND_TX] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
-        };
-        case RACK_TX_ONLY: {
-            _action = ["acre_rec_only", localize ELSTRING(sys_intercom,recOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
-            _action = ["acre_rec_and_trans", localize ELSTRING(sys_intercom,recAndTrans), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_AND_TX] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
-        };
-        case RACK_RX_AND_TX: {
-            _action = ["acre_rec_only", localize ELSTRING(sys_intercom,recOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
-            _action = ["acre_trans_only", localize ELSTRING(sys_intercom,transOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_TX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
+    // External radios. Show only options to share/stop sharing the radio if you are the actual owner and not an external user.
+    if (!(_radio in ACRE_ACTIVE_EXTERNAL_RADIOS || (toLower _radio) in ACRE_HEARABLE_RACK_RADIOS)) then {
+        _action = ["acre_share_radio", localize ELSTRING(sys_external,shareRadio), "", {[(_this select 2) select 0, true] call EFUNC(sys_external,allowExternalUse)}, {!([(_this select 2) select 0] call EFUNC(sys_external,isRadioShared))}, {}, _params] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+        _action = ["acre_retrieve_radio", localize ELSTRING(sys_external,unshareRadio), "", {[(_this select 2) select 0, false] call EFUNC(sys_external,allowExternalUse)}, {[(_this select 2) select 0] call EFUNC(sys_external,isRadioShared)}, {}, _params] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+    };
+
+    // Rack radios in intercom, RX/TX functionality
+    if ((toLower _radio) in ACRE_ACCESSIBLE_RACK_RADIOS || (toLower _radio) in ACRE_ACCESSIBLE_RACK_RADIOS) then {
+        private _functionality = [_radio, vehicle acre_player, acre_player] call EFUNC(sys_intercom,getRxTxCapabilities);
+        switch (_functionality) do {
+            case RACK_NO_MONITOR: {
+                WARNING_1("Entered no monitor in ace interaction menu for radio %1", _radio);
+            };
+            case RACK_RX_ONLY: {
+                _action = ["acre_trans_only", localize ELSTRING(sys_intercom,transOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_TX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+                _actions pushBack [_action, [], _target];
+                _action = ["acre_rec_and_trans", localize ELSTRING(sys_intercom,recAndTrans), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_AND_TX] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+                _actions pushBack [_action, [], _target];
+            };
+            case RACK_TX_ONLY: {
+                _action = ["acre_rec_only", localize ELSTRING(sys_intercom,recOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+                _actions pushBack [_action, [], _target];
+                _action = ["acre_rec_and_trans", localize ELSTRING(sys_intercom,recAndTrans), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_AND_TX] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+                _actions pushBack [_action, [], _target];
+            };
+            case RACK_RX_AND_TX: {
+                _action = ["acre_rec_only", localize ELSTRING(sys_intercom,recOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_RX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+                _actions pushBack [_action, [], _target];
+                _action = ["acre_trans_only", localize ELSTRING(sys_intercom,transOnly), "", {[(_this select 2) select 0, vehicle acre_player, acre_player, RACK_TX_ONLY] call EFUNC(sys_intercom,setRxTxCapabilities)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+                _actions pushBack [_action, [], _target];
+            };
         };
     };
-};
 
-private _idx = _pttAssign find _radio;
-_txt = localize LSTRING(bindMultiPushToTalk);
-if ((_idx > -1) and (_idx < 3)) then {
-    _txt = format [localize LSTRING(multiPushToTalk), (_idx + 1)];
-};
+    private _idx = _pttAssign find _radio;
+    _txt = localize LSTRING(bindMultiPushToTalk);
+    if ((_idx > -1) and (_idx < 3)) then {
+        _txt = format [localize LSTRING(multiPushToTalk), (_idx + 1)];
+    };
 
-_action = ["acre_mptt_assign", _txt, "", {}, {true}, {_this call FUNC(radioPTTChildrenActions);}, _params] call ace_interact_menu_fnc_createAction;
-_actions pushBack [_action, [], _target];
+    _action = ["acre_mptt_assign", _txt, "", {}, {true}, {_this call FUNC(radioPTTChildrenActions);}, _params] call ace_interact_menu_fnc_createAction;
+    _actions pushBack [_action, [], _target];
+} else {
+    private _action = ["acre_open_radio", localize ELSTRING(sys_list,OpenRadio), "", {[((_this select 2) select 0)] call EFUNC(sys_radio,openRadio)}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+    _actions pushBack [_action, [], _target];
+};
 
 if (GVAR(connectorsEnabled)) then {
     _action = ["acre_connectors", "Connectors", "\idi\acre\addons\ace_interact\data\icons\connector4.paa", {}, {true}, {_this call FUNC(generateConnectors);}, _params] call ace_interact_menu_fnc_createAction;

--- a/addons/sys_core/XEH_preInit.sqf
+++ b/addons/sys_core/XEH_preInit.sqf
@@ -78,11 +78,11 @@ DGVAR(languages) = [];
 DVAR(ACRE_TEST_OCCLUSION) = true;
 DVAR(ACRE_SIGNAL_DEBUGGING) = 0;
 
-DVAR(ACRE_ACTIVE_EXTERNAL_RADIOS) = [];          // Radios not in player's inventory.
-DVAR(ACRE_EXTERNALLY_USED_MANPACK_RADIOS) = [];  // Manpack radios in player's inventory that are being used externally.
-DVAR(ACRE_EXTERNALLY_USED_PERSONAL_RADIOS) = []; // Personal radios in player's inventory that are being used externally.
-DVAR(ACRE_ACCESSIBLE_RACK_RADIOS) = [];          // Extra radios that a player can use, should be used for radios that are racked.
-DVAR(ACRE_HEARABLE_RACK_RADIOS) = [];            // Extra rack radios that a player can use.
+DVAR(ACRE_ACTIVE_EXTERNAL_RADIOS) = [];          // Radios not in player's inventory
+DVAR(ACRE_EXTERNALLY_USED_MANPACK_RADIOS) = [];  // Manpack radios in player's inventory that are being used externally
+DVAR(ACRE_EXTERNALLY_USED_PERSONAL_RADIOS) = []; // Personal radios in player's inventory that are being used externally
+DVAR(ACRE_ACCESSIBLE_RACK_RADIOS) = [];          // Extra radios that a player can use, should be used for radios that are racked
+DVAR(ACRE_HEARABLE_RACK_RADIOS) = [];            // Extra rack radios that a player can use
 DVAR(ACRE_BLOCKED_TRANSMITTING_RADIOS) = [];
 
 acre_player = player;

--- a/addons/sys_core/XEH_preInit.sqf
+++ b/addons/sys_core/XEH_preInit.sqf
@@ -78,10 +78,11 @@ DGVAR(languages) = [];
 DVAR(ACRE_TEST_OCCLUSION) = true;
 DVAR(ACRE_SIGNAL_DEBUGGING) = 0;
 
-DVAR(ACRE_ACTIVE_EXTERNAL_RADIOS) = [];
-DVAR(ACRE_EXTERNALLY_USED_MANPACK_RADIOS) = [];
-DVAR(ACRE_ACCESSIBLE_RACK_RADIOS) = []; // Extra radios that a player can use, should be used for radios that are racked.
-DVAR(ACRE_HEARABLE_RACK_RADIOS) = []; // Extra rack radios that a player can receive but not transmit.
+DVAR(ACRE_ACTIVE_EXTERNAL_RADIOS) = [];          // Radios not in player's inventory.
+DVAR(ACRE_EXTERNALLY_USED_MANPACK_RADIOS) = [];  // Manpack radios in player's inventory that are being used externally.
+DVAR(ACRE_EXTERNALLY_USED_PERSONAL_RADIOS) = []; // Personal radios in player's inventory that are being used externally.
+DVAR(ACRE_ACCESSIBLE_RACK_RADIOS) = [];          // Extra radios that a player can use, should be used for radios that are racked.
+DVAR(ACRE_HEARABLE_RACK_RADIOS) = [];            // Extra rack radios that a player can use.
 DVAR(ACRE_BLOCKED_TRANSMITTING_RADIOS) = [];
 
 acre_player = player;

--- a/addons/sys_core/XEH_preInit.sqf
+++ b/addons/sys_core/XEH_preInit.sqf
@@ -79,7 +79,7 @@ DVAR(ACRE_TEST_OCCLUSION) = true;
 DVAR(ACRE_SIGNAL_DEBUGGING) = 0;
 
 DVAR(ACRE_ACTIVE_EXTERNAL_RADIOS) = [];
-DVAR(ACRE_PASSIVE_EXTERNAL_RADIOS) = [];
+DVAR(ACRE_EXTERNALLY_USED_MANPACK_RADIOS) = [];
 DVAR(ACRE_ACCESSIBLE_RACK_RADIOS) = []; // Extra radios that a player can use, should be used for radios that are racked.
 DVAR(ACRE_HEARABLE_RACK_RADIOS) = []; // Extra rack radios that a player can receive but not transmit.
 DVAR(ACRE_BLOCKED_TRANSMITTING_RADIOS) = [];

--- a/addons/sys_data/fnc_getPlayerRadioList.sqf
+++ b/addons/sys_data/fnc_getPlayerRadioList.sqf
@@ -27,6 +27,11 @@ if (!ACRE_IS_SPECTATOR) then {
         _radioList pushBackUnique _x;
     } forEach ACRE_ACTIVE_EXTERNAL_RADIOS;
 
+    // Radios in the inventory of the player that are being used externally but cannot be used by the player (receive/transmit). They can still be configured, e.g. manpack radios
+    {
+        _radioList pushBackUnique _x;
+    } forEach ACRE_EXTERNALLY_USED_PERSONAL_RADIOS;
+
     // Radios in the inventory of the player that are being used externally but can still be used by the player, e.g. manpack radios
     {
         _radioList pushBackUnique _x;

--- a/addons/sys_data/fnc_getPlayerRadioList.sqf
+++ b/addons/sys_data/fnc_getPlayerRadioList.sqf
@@ -37,7 +37,7 @@ if (!ACRE_IS_SPECTATOR) then {
         _radioList pushBackUnique _x;
     } forEach ACRE_EXTERNALLY_USED_MANPACK_RADIOS;
 
-    // Auxilary radios are for radios not in inventory like racked radios.
+    // Auxilary radios are for radios not in inventory like racked radios
     {
         _radioList pushBackUnique _x;
     } forEach ACRE_ACCESSIBLE_RACK_RADIOS;

--- a/addons/sys_data/fnc_getPlayerRadioList.sqf
+++ b/addons/sys_data/fnc_getPlayerRadioList.sqf
@@ -27,11 +27,17 @@ if (!ACRE_IS_SPECTATOR) then {
         _radioList pushBackUnique _x;
     } forEach ACRE_ACTIVE_EXTERNAL_RADIOS;
 
-    //Auxilary radios are for radios not in inventory like racked radios.
+    // Radios in the inventory of the player that are being used externally but can still be used by the player, e.g. manpack radios
+    {
+        _radioList pushBackUnique _x;
+    } forEach ACRE_EXTERNALLY_USED_MANPACK_RADIOS;
+
+    // Auxilary radios are for radios not in inventory like racked radios.
     {
         _radioList pushBackUnique _x;
     } forEach ACRE_ACCESSIBLE_RACK_RADIOS;
 
+    // Racked radios that cannot be physically accessed but are connected to the same intercom as the player
     {
         _radioList pushBackUnique _x;
     } forEach ACRE_HEARABLE_RACK_RADIOS;

--- a/addons/sys_external/XEH_postInit.sqf
+++ b/addons/sys_external/XEH_postInit.sqf
@@ -1,3 +1,60 @@
 #include "script_component.hpp"
 
 ADDPFH(FUNC(externalRadioPFH), 0.91, []);
+
+if (!hasInterface) exitWith {};
+
+[
+	QGVAR(startUsingRadioLocal),
+	{
+    	params ["_message", "_radioId"];
+
+    	if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {    // If it is the active radio.
+
+	        // Otherwise cleanup
+	        if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {
+		        // simulate a key up event to end the current transmission
+				[] call EFUNC(sys_core,handleMultiPttKeyPressUp);
+	        };
+	        
+	        [1] call EFUNC(sys_list,cycleRadios); // Change active radio
+        };
+
+    	// Manpack radios can also be used by the owner if they are not rack radios
+    	if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {   
+    		ACRE_EXTERNALLY_USED_MANPACK_RADIOS pushBackUnique _radioId; 
+    	} else {
+    		ACRE_EXTERNALLY_USED_PERSONAL_RADIOS pushBackUnique _radioId;
+    	};
+
+        [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+          
+    }
+] call CBA_fnc_addEventHandler;
+
+[
+	QGVAR(stopUsingRadioLocal),
+	{
+    	params ["_message", "_radioId"];
+    	
+    	// Manpack radios can also be used by the owner if they are not rack radios
+    	if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
+        	ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
+        } else {
+        	ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
+    	};
+
+        [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+    }
+] call CBA_fnc_addEventHandler;
+
+[
+	QGVAR(giveRadioLocal),
+	{
+    	params ["_message"];
+
+        [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+    }
+] call CBA_fnc_addEventHandler;
+
+[QGVAR(giveRadioAction), {_this call FUNC(startUsingExternalRadio)}] call CBA_fnc_addEventHandler;

--- a/addons/sys_external/XEH_postInit.sqf
+++ b/addons/sys_external/XEH_postInit.sqf
@@ -5,27 +5,27 @@ ADDPFH(FUNC(externalRadioPFH), 0.91, []);
 if (!hasInterface) exitWith {};
 
 [
-	QGVAR(startUsingRadioLocal),
-	{
-    	params ["_message", "_radioId"];
+    QGVAR(startUsingRadioLocal),
+    {
+        params ["_message", "_radioId"];
 
-    	if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {    // If it is the active radio.
+        if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {    // If it is the active radio.
 
-	        // Otherwise cleanup
-	        if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {
-		        // simulate a key up event to end the current transmission
-				[] call EFUNC(sys_core,handleMultiPttKeyPressUp);
-	        };
-	        
-	        [1] call EFUNC(sys_list,cycleRadios); // Change active radio
+            // Otherwise cleanup
+            if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {
+                // simulate a key up event to end the current transmission
+                [] call EFUNC(sys_core,handleMultiPttKeyPressUp);
+            };
+
+            [1] call EFUNC(sys_list,cycleRadios); // Change active radio
         };
 
-    	// Manpack radios can also be used by the owner if they are not rack radios
-    	if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {   
-    		ACRE_EXTERNALLY_USED_MANPACK_RADIOS pushBackUnique _radioId; 
-    	} else {
-    		ACRE_EXTERNALLY_USED_PERSONAL_RADIOS pushBackUnique _radioId;
-    	};
+        // Manpack radios can also be used by the owner if they are not rack radios
+        if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {   
+            ACRE_EXTERNALLY_USED_MANPACK_RADIOS pushBackUnique _radioId; 
+        } else {
+            ACRE_EXTERNALLY_USED_PERSONAL_RADIOS pushBackUnique _radioId;
+        };
 
         [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
           
@@ -33,25 +33,25 @@ if (!hasInterface) exitWith {};
 ] call CBA_fnc_addEventHandler;
 
 [
-	QGVAR(stopUsingRadioLocal),
-	{
-    	params ["_message", "_radioId"];
-    	
-    	// Manpack radios can also be used by the owner if they are not rack radios
-    	if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
-        	ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
+    QGVAR(stopUsingRadioLocal),
+    {
+        params ["_message", "_radioId"];
+        
+        // Manpack radios can also be used by the owner if they are not rack radios
+        if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
+            ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
         } else {
-        	ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
-    	};
+            ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
+        };
 
         [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
     }
 ] call CBA_fnc_addEventHandler;
 
 [
-	QGVAR(giveRadioLocal),
-	{
-    	params ["_message"];
+    QGVAR(giveRadioLocal),
+    {
+        params ["_message"];
 
         [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
     }

--- a/addons/sys_external/XEH_postInit.sqf
+++ b/addons/sys_external/XEH_postInit.sqf
@@ -4,57 +4,46 @@ ADDPFH(FUNC(externalRadioPFH), 0.91, []);
 
 if (!hasInterface) exitWith {};
 
-[
-    QGVAR(startUsingRadioLocal),
-    {
-        params ["_message", "_radioId"];
+[QGVAR(startUsingRadioLocal), {
+    params ["_message", "_radioId"];
 
-        if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {    // If it is the active radio.
-
-            // Otherwise cleanup
-            if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {
-                // simulate a key up event to end the current transmission
-                [] call EFUNC(sys_core,handleMultiPttKeyPressUp);
-            };
-
-            [1] call EFUNC(sys_list,cycleRadios); // Change active radio
+    // If it is the active radio
+    if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {
+        // Otherwise cleanup
+        if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {
+            // Simulate a key up event to end the current transmission
+            [] call EFUNC(sys_core,handleMultiPttKeyPressUp);
         };
+        // Change active radio
+        [1] call EFUNC(sys_list,cycleRadios);
+    };
 
-        // Manpack radios can also be used by the owner if they are not rack radios
-        if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {   
-            ACRE_EXTERNALLY_USED_MANPACK_RADIOS pushBackUnique _radioId; 
-        } else {
-            ACRE_EXTERNALLY_USED_PERSONAL_RADIOS pushBackUnique _radioId;
-        };
+    // Manpack radios can also be used by the owner if they are not rack radios
+    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
+        ACRE_EXTERNALLY_USED_MANPACK_RADIOS pushBackUnique _radioId;
+    } else {
+        ACRE_EXTERNALLY_USED_PERSONAL_RADIOS pushBackUnique _radioId;
+    };
 
-        [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
-          
-    }
-] call CBA_fnc_addEventHandler;
+    [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+}] call CBA_fnc_addEventHandler;
 
-[
-    QGVAR(stopUsingRadioLocal),
-    {
-        params ["_message", "_radioId"];
-        
-        // Manpack radios can also be used by the owner if they are not rack radios
-        if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
-            ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
-        } else {
-            ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
-        };
+[QGVAR(stopUsingRadioLocal), {
+    params ["_message", "_radioId"];
 
-        [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
-    }
-] call CBA_fnc_addEventHandler;
+    // Manpack radios can also be used by the owner if they are not rack radios
+    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
+        ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
+    } else {
+        ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
+    };
 
-[
-    QGVAR(giveRadioLocal),
-    {
-        params ["_message"];
+    [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+}] call CBA_fnc_addEventHandler;
 
-        [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
-    }
-] call CBA_fnc_addEventHandler;
+[QGVAR(giveRadioLocal), {
+    params ["_message"];
+    [_message, ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+}] call CBA_fnc_addEventHandler;
 
 [QGVAR(giveRadioAction), {_this call FUNC(startUsingExternalRadio)}] call CBA_fnc_addEventHandler;

--- a/addons/sys_external/fnc_childrenActions.sqf
+++ b/addons/sys_external/fnc_childrenActions.sqf
@@ -25,9 +25,13 @@ private _actions = [];
 private _playerOwnsRadio = acre_player == [_radio] call FUNC(getExternalRadioOwner);
 
 if (_playerOwnsRadio) then {
+    private _string =  localize LSTRING(giveHeadset);
+    if ([_radio] call EFUNC(sys_radio,isManpackRadio)) then {
+        _string = localize LSTRING(giveHandset)
+    };
     private _action = [
         "acre_give_externalRadio",
-        localize LSTRING(giveHeadset),
+        _string,
         "",
         {[(_this select 2) select 0, _target] call FUNC(stopUsingExternalRadio)},
         {!([(_this select 2) select 0] call FUNC(isExternalRadioUsed))},
@@ -36,9 +40,13 @@ if (_playerOwnsRadio) then {
     ] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
 } else {
+    private _string =  localize LSTRING(takeHeadset);
+    if ([_radio] call EFUNC(sys_radio,isManpackRadio)) then {
+        _string =  localize LSTRING(takeHandset)
+    };
     private _action = [
         "acre_use_externalRadio",
-        localize LSTRING(takeHeadset),
+        _string,
         "",
         {[(_this select 2) select 0, acre_player] call FUNC(startUsingExternalRadio)},
         {!([(_this select 2) select 0] call FUNC(isExternalRadioUsed))},
@@ -50,9 +58,13 @@ if (_playerOwnsRadio) then {
 
 // Check if we are giving or returning the headset
 if ([(_this select 2) select 0, _target] call FUNC(checkReturnGive)) then {
+    private _string =  localize LSTRING(returnHeadset);
+    if ([_radio] call EFUNC(sys_radio,isManpackRadio)) then {
+        _string =  localize LSTRING(returnHandset)
+    };
     private _action = [
         "acre_return_externalRadio",
-        localize LSTRING(returnHeadset),
+        _string,
         "",
         {[(_this select 2) select 0, _target] call FUNC(stopUsingExternalRadio)},
         {[(_this select 2) select 0] call FUNC(isExternalRadioUsed)},
@@ -61,9 +73,13 @@ if ([(_this select 2) select 0, _target] call FUNC(checkReturnGive)) then {
     ] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
 } else {
+    private _string =  localize LSTRING(giveHeadset);
+    if ([_radio] call EFUNC(sys_radio,isManpackRadio)) then {
+        _string = localize LSTRING(giveHandset)
+    };
     private _action = [
         "acre_give_externalRadio",
-        localize LSTRING(giveHeadset),
+        _string,
         "",
         {[(_this select 2) select 0, _target] call FUNC(stopUsingExternalRadio)},
         {[(_this select 2) select 0] call FUNC(isExternalRadioUsed)},

--- a/addons/sys_external/fnc_listChildrenActions.sqf
+++ b/addons/sys_external/fnc_listChildrenActions.sqf
@@ -26,7 +26,6 @@ private _sharedRadios = [_target] call FUNC(getSharedExternalRadios);
 } forEach ACRE_ACTIVE_EXTERNAL_RADIOS;
 
 // Add player's radios that are shared
-
 private _ownSharedRadios = [acre_player] call FUNC(getSharedExternalRadios);
 {
     _sharedRadios pushBackUnique _x;

--- a/addons/sys_external/fnc_startUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_startUsingExternalRadio.sqf
@@ -27,7 +27,7 @@ if (!([_radioId] call FUNC(isExternalRadioUsed))) then {
     [_radioId, "setState", ["isUsedExternally", [true, _endUser]]] call EFUNC(sys_data,dataEvent);
 
     // Manpack radios can also be used by the owner if they are not rack radios
-    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) != "")) then {
+    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
         [
             [_owner, _displayName, _radioId],
             {

--- a/addons/sys_external/fnc_startUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_startUsingExternalRadio.sqf
@@ -32,7 +32,6 @@ if (!([_radioId] call FUNC(isExternalRadioUsed))) then {
             [_owner, _displayName, _radioId],
             {
                 params ["_endUser", "_displayName", "_radioId"];
-                systemChat format ["RadioID %1", _radioId];
                 if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {    // If it is the active radio.
                     // Otherwise cleanup
                     if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {
@@ -47,8 +46,25 @@ if (!([_radioId] call FUNC(isExternalRadioUsed))) then {
             }
         ] remoteExecCall ["bis_fnc_call", _owner];
     } else {
-        // Show a hint to the actual owner that the radio was given to another player
-        [format [localize LSTRING(hintTakeOwner), _endUser, _displayName]] remoteExecCall [QEFUNC(sys_core,displayNotification), _owner];
+        // Personal radios can only be opened. There are no RX/TX capabilities.
+        [
+            [_owner, _displayName, _radioId],
+            {
+                params ["_endUser", "_displayName", "_radioId"];
+                systemChat format ["RadioID %1", _radioId];
+                if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {    // If it is the active radio.
+                    // Otherwise cleanup
+                    if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {
+                        // simulate a key up event to end the current transmission
+                        [] call EFUNC(sys_core,handleMultiPttKeyPressUp);
+                    };
+                    [1] call EFUNC(sys_list,cycleRadios); // Change active radio
+                };
+
+                [format [localize LSTRING(hintTakeOwner), _endUser, _displayName]] call EFUNC(sys_core,displayNotification);
+                ACRE_EXTERNALLY_USED_PERSONAL_RADIOS pushBackUnique _radioId;
+            }
+        ] remoteExecCall ["bis_fnc_call", _owner];
     };
 };
 

--- a/addons/sys_external/fnc_startUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_startUsingExternalRadio.sqf
@@ -51,7 +51,7 @@ if (!([_radioId] call FUNC(isExternalRadioUsed))) then {
             [_owner, _displayName, _radioId],
             {
                 params ["_endUser", "_displayName", "_radioId"];
-                systemChat format ["RadioID %1", _radioId];
+
                 if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {    // If it is the active radio.
                     // Otherwise cleanup
                     if (ACRE_ACTIVE_RADIO == ACRE_BROADCASTING_RADIOID) then {

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -31,7 +31,7 @@ ACRE_ACTIVE_EXTERNAL_RADIOS = ACRE_ACTIVE_EXTERNAL_RADIOS - [_radioId];
 
 private _baseRadio =  [_radioId] call EFUNC(api,getBaseRadio);
 private _displayName = getText (ConfigFile >> "CfgWeapons" >> _baseRadio >> "displayName");
-[format [localize LSTRING(hintReturn), _displayName, name _owner]] call EFUNC(sys_core,displayNotification);
+[format [localize LSTRING(hintReturn), _displayName, name _owner], ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
 
 if (_target == _owner) then {
     // Handle remote owner

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -34,29 +34,29 @@ private _displayName = getText (ConfigFile >> "CfgWeapons" >> _baseRadio >> "dis
 [format [localize LSTRING(hintReturn), _displayName, name _owner]] call EFUNC(sys_core,displayNotification);
 
 if (_target == _owner) then {
-    // Give radio back to the owner
-    [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
-
     // Manpack radios can also be used by the owner if they are not rack radios
     if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
         [
-            [_owner, _displayName, _radioId],
+            [_displayName, _radioId],
             {
-                params ["_owner", "_displayName", "_radioId"];
+                params ["_displayName", "_radioId"];
                 ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
                 [format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName]] call EFUNC(sys_core,displayNotification);
             }
         ] remoteExecCall ["bis_fnc_call", _owner];
     } else {
         [
-            [_owner, _displayName, _radioId],
+            [_displayName, _radioId],
             {
-                params ["_owner", "_displayName", "_radioId"];
+                params ["_displayName", "_radioId"];
                 ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
                 [format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName]] call EFUNC(sys_core,displayNotification);
             }
         ] remoteExecCall ["bis_fnc_call", _owner];
     };
+
+    // Give radio back to the owner
+    [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
 } else {
     // Show a hint to the actual owner that the radio was given to another player
     [format [localize LSTRING(hintGiveOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName, name _target]] remoteExecCall [QEFUNC(sys_core,displayNotification), _owner];

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -36,7 +36,22 @@ private _displayName = getText (ConfigFile >> "CfgWeapons" >> _baseRadio >> "dis
 if (_target == _owner) then {
     // Give radio back to the owner
     [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
+
+    // Manpack radios can also be used by the owner if they are not rack radios
+    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) != "")) then {
+        [
+            [_owner, _displayName, _radioId],
+            {
+                params ["_owner", "_displayName", "_radioId"];
+                ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
+                [format [localize LSTRING(hintReturnOwner), name _owner, _displayName]] call EFUNC(sys_core,displayNotification);
+            }
+        ] remoteExecCall ["bis_fnc_call", _owner];
+    };
 } else {
+    // Show a hint to the actual owner that the radio was given to another player
+    [format [localize LSTRING(hintGiveOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName, name _target]] remoteExecCall [QEFUNC(sys_core,displayNotification), _owner];
+
     // Give radio to another player
     [_radioId, _target] remoteExecCall [QFUNC(startUsingExternalRadio), _target, false];
 };

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -38,13 +38,13 @@ if (_target == _owner) then {
     [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
 
     // Manpack radios can also be used by the owner if they are not rack radios
-    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) != "")) then {
+    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
         [
             [_owner, _displayName, _radioId],
             {
                 params ["_owner", "_displayName", "_radioId"];
                 ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
-                [format [localize LSTRING(hintReturnOwner), name _owner, _displayName]] call EFUNC(sys_core,displayNotification);
+                [format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName]] call EFUNC(sys_core,displayNotification);
             }
         ] remoteExecCall ["bis_fnc_call", _owner];
     };

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -47,6 +47,15 @@ if (_target == _owner) then {
                 [format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName]] call EFUNC(sys_core,displayNotification);
             }
         ] remoteExecCall ["bis_fnc_call", _owner];
+    } else {
+        [
+            [_owner, _displayName, _radioId],
+            {
+                params ["_owner", "_displayName", "_radioId"];
+                ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
+                [format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName]] call EFUNC(sys_core,displayNotification);
+            }
+        ] remoteExecCall ["bis_fnc_call", _owner];
     };
 } else {
     // Show a hint to the actual owner that the radio was given to another player

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -34,33 +34,17 @@ private _displayName = getText (ConfigFile >> "CfgWeapons" >> _baseRadio >> "dis
 [format [localize LSTRING(hintReturn), _displayName, name _owner]] call EFUNC(sys_core,displayNotification);
 
 if (_target == _owner) then {
-    // Manpack radios can also be used by the owner if they are not rack radios
-    if ([_radioId] call EFUNC(sys_radio,isManpackRadio) && ([_radioId] call EFUNC(sys_rack,getRackFromRadio) == "")) then {
-        [
-            [_displayName, _radioId],
-            {
-                params ["_displayName", "_radioId"];
-                ACRE_EXTERNALLY_USED_MANPACK_RADIOS = ACRE_EXTERNALLY_USED_MANPACK_RADIOS - [_radioId];
-                [format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName]] call EFUNC(sys_core,displayNotification);
-            }
-        ] remoteExecCall ["bis_fnc_call", _owner];
-    } else {
-        [
-            [_displayName, _radioId],
-            {
-                params ["_displayName", "_radioId"];
-                ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
-                [format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName]] call EFUNC(sys_core,displayNotification);
-            }
-        ] remoteExecCall ["bis_fnc_call", _owner];
-    };
-
+    // Handle remote owner
+    private _message = format [localize LSTRING(hintReturnOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName];
+    [QGVAR(stopUsingRadioLocal), [_message, _radioId], _owner] call CBA_fnc_targetEvent;
+   
     // Give radio back to the owner
     [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
 } else {
     // Show a hint to the actual owner that the radio was given to another player
-    [format [localize LSTRING(hintGiveOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName, name _target]] remoteExecCall [QEFUNC(sys_core,displayNotification), _owner];
+    private _message = format [localize LSTRING(hintGiveOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName, name _target];
+    [QGVAR(giveRadioLocal), [_message, _radioId], _owner] call CBA_fnc_targetEvent;
 
     // Give radio to another player
-    [_radioId, _target] remoteExecCall [QFUNC(startUsingExternalRadio), _target, false];
+    [QGVAR(giveRadioAction), [_radioId, _target], _target] call CBA_fnc_targetEvent;
 };

--- a/addons/sys_external/stringtable.xml
+++ b/addons/sys_external/stringtable.xml
@@ -25,6 +25,9 @@
             <Russian>Забрать рацию</Russian>
             <Polish>Wył. udostępnianie</Polish>
         </Key>
+        <Key ID="STR_ACRE_sys_external_takeHandset">
+            <English>Take Handset</English>
+        </Key>
         <Key ID="STR_ACRE_sys_external_takeHeadset">
             <English>Take Headset</English>
             <Spanish>Coger transmisor</Spanish>
@@ -32,6 +35,9 @@
             <Japanese>ヘッドセットを取る</Japanese>
             <Russian>Взять наушники</Russian>
             <Polish>Weź słuchawkę</Polish>
+        </Key>
+        <Key ID="STR_ACRE_sys_external_returnHandset">
+            <English>Return Handset</English>
         </Key>
         <Key ID="STR_ACRE_sys_external_returnHeadset">
             <English>Return Headset</English>
@@ -41,6 +47,9 @@
             <Russian>Вернуть наушники</Russian>
             <Polish>Odłóż słuchawkę</Polish>
         </Key>
+        <Key ID="STR_ACRE_sys_external_giveHandset">
+            <English>Give Handset</English>
+        </Key>
         <Key ID="STR_ACRE_sys_external_giveHeadset">
             <English>Give Headset</English>
             <Spanish>Dar transmisor</Spanish>
@@ -49,17 +58,26 @@
             <Russian>Дать наушники</Russian>
             <Polish>Podaj słuchawkę</Polish>
         </Key>
-        <Key ID="STR_ACRE_sys_external_hintTake">
-            <English>Start using %1 from %2</English>
-            <Japanese>%1 を %2 から使用する</Japanese>
-            <Russian>Начать использовать %1 из %2</Russian>
-            <Polish>Używasz %1 od %2</Polish>
+        <Key ID="STR_ACRE_sys_external_hintGiveOwner">
+            <English>%1 gave your %2 to %3</English>
         </Key>
         <Key ID="STR_ACRE_sys_external_hintReturn">
             <English>Stop using %1 from %2</English>
             <Japanese>%1 を %2 から使用停止する</Japanese>
             <Russian>Перестать использовать %1 из %2</Russian>
             <Polish>Przestałeś używać %1 od %2</Polish>
+        </Key>
+        <Key ID="STR_ACRE_sys_external_hintReturnOwner">
+            <English>%1 stopped using your %2</English>
+        </Key>
+        <Key ID="STR_ACRE_sys_external_hintTake">
+            <English>Start using %1 from %2</English>
+            <Japanese>%1 を %2 から使用する</Japanese>
+            <Russian>Начать использовать %1 из %2</Russian>
+            <Polish>Używasz %1 od %2</Polish>
+        </Key>
+        <Key ID="STR_ACRE_sys_external_hintTakeOwner">
+            <English>%1 started using your %2</English>
         </Key>
     </Package>
 </Project>

--- a/addons/sys_radio/fnc_canUnitReceive.sqf
+++ b/addons/sys_radio/fnc_canUnitReceive.sqf
@@ -34,4 +34,8 @@ if (_vehicle != acre_player) then {
     };
 };
 
+if (_canReceive && {_radioId in ACRE_EXTERNALLY_USED_PERSONAL_RADIOS}) then {
+    _canReceive = false;
+};
+
 _canReceive

--- a/addons/sys_radio/fnc_canUnitTransmit.sqf
+++ b/addons/sys_radio/fnc_canUnitTransmit.sqf
@@ -34,11 +34,6 @@ if (_vehicle != acre_player) then {
     };
 };
 
-if (_canTransmit && {_radioId in ACRE_PASSIVE_EXTERNAL_RADIOS}) then {
-    _canTransmit = false;
-    [localize LSTRING(noTransmitExternal), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
-};
-
 if (_canTransmit && {(toLower _radioId) in ACRE_BLOCKED_TRANSMITTING_RADIOS}) then {
     _canTransmit = false;
     [localize LSTRING(alreadyTransmitting), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);

--- a/addons/sys_radio/fnc_canUnitTransmit.sqf
+++ b/addons/sys_radio/fnc_canUnitTransmit.sqf
@@ -34,6 +34,11 @@ if (_vehicle != acre_player) then {
     };
 };
 
+if (_canTransmit && {_radioId in ACRE_EXTERNALLY_USED_PERSONAL_RADIOS}) then {
+    _canTransmit = false;
+    [localize LSTRING(noTransmitExternal), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+};
+
 if (_canTransmit && {(toLower _radioId) in ACRE_BLOCKED_TRANSMITTING_RADIOS}) then {
     _canTransmit = false;
     [localize LSTRING(alreadyTransmitting), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);


### PR DESCRIPTION
**When merged this pull request will:**
- [Fix] Allow the actual owner of the radio to open it if it is externally used for Personal radios (152, 148,...)
- [Improvement] Manpack radios can be used simultaneously by both owner and external user. Only one can transmit at the same time.
- [Improvement] More notifications.