### PR TITLE
Limit open radio

### DIFF
--- a/addons/sys_external/fnc_initRadio.sqf
+++ b/addons/sys_external/fnc_initRadio.sqf
@@ -20,5 +20,5 @@ params ["_radioId"];
 [_radioId, false] call FUNC(allowExternalUse);
 [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
 
-// To prevent the GUI from being simultaneously opened.
+// To prevent the GUI from being simultaneously opened
 [_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_external/fnc_initRadio.sqf
+++ b/addons/sys_external/fnc_initRadio.sqf
@@ -19,3 +19,6 @@ params ["_radioId"];
 
 [_radioId, false] call FUNC(allowExternalUse);
 [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
+
+// To prevent the GUI from being simultaneously opened.
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_prc117f/fnc_closeGui.sqf
+++ b/addons/sys_prc117f/fnc_closeGui.sqf
@@ -18,6 +18,8 @@
 
 TRACE_1("", _this);
 
+params ["_radioId", "", "", "", ""];
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc117f/fnc_openGui.sqf
+++ b/addons/sys_prc117f/fnc_openGui.sqf
@@ -27,6 +27,8 @@ GVAR(currentRadioId) = _radioId;
 createDialog "Prc117f_RadioDialog";
 [] call FUNC(clearDisplay);
 
+[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
 
 _onState = [GVAR(currentRadioId), "getOnOffState"] call EFUNC(sys_data,dataEvent);
 if (_onState >= 1) then {

--- a/addons/sys_prc148/fnc_closeGui.sqf
+++ b/addons/sys_prc148/fnc_closeGui.sqf
@@ -16,6 +16,9 @@
  */
 #include "script_component.hpp"
 
+params ["_radioId", "", "", "", ""];
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
 [GVAR(PFHId)] call CBA_fnc_removePerFrameHandler;
 GVAR(currentRadioId) = nil;
 true

--- a/addons/sys_prc148/fnc_openGui.sqf
+++ b/addons/sys_prc148/fnc_openGui.sqf
@@ -24,5 +24,8 @@ if (!([_radioId] call EFUNC(sys_radio,canOpenRadio))) exitWith { false };
 disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC148_RadioDialog";
+[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
 GVAR(PFHId) = ADDPFH(DFUNC(PFH), 0.33, []);
+
 true

--- a/addons/sys_prc152/fnc_closeGui.sqf
+++ b/addons/sys_prc152/fnc_closeGui.sqf
@@ -18,8 +18,9 @@
 
 TRACE_1("", _this);
 
+params ["_radioId", "", "", "", ""];
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
-
 
 true

--- a/addons/sys_prc152/fnc_openGui.sqf
+++ b/addons/sys_prc152/fnc_openGui.sqf
@@ -26,6 +26,7 @@ disableSerialization;
 
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC152_RadioDialog";
+[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 _onState = [GVAR(currentRadioId), "getOnOffState"] call EFUNC(sys_data,dataEvent);
 

--- a/addons/sys_prc343/radio/fnc_closeGui.sqf
+++ b/addons/sys_prc343/radio/fnc_closeGui.sqf
@@ -3,7 +3,7 @@
  * Close radio GUI. Event raised by onUnload (PRC343_RadioDialog).
  *
  * Arguments:
- * 0: Radio ID <STRING> (Unused)
+ * 0: Radio ID <STRING>
  * 1: Event: "closeGui" <STRING> (Unused)
  * 2: Event data <NUMBER> (Unused)
  * 3: Radio data <HASH> (Unused)
@@ -18,6 +18,9 @@
  * Public: No
  */
 #include "script_component.hpp"
+
+params ["_radioId", "", "", "", ""];
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc343/radio/fnc_openGui.sqf
+++ b/addons/sys_prc343/radio/fnc_openGui.sqf
@@ -30,5 +30,6 @@ if (!([_radioId] call EFUNC(sys_radio,canOpenRadio))) exitWith { false };
 disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC343_RadioDialog";
+[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 true

--- a/addons/sys_prc77/radio/fnc_closeGui.sqf
+++ b/addons/sys_prc77/radio/fnc_closeGui.sqf
@@ -3,7 +3,7 @@
  * Close radio GUI. Event raised by onUnload (PRC77_RadioDialog).
  *
  * Arguments:
- * 0: Radio ID <STRING> (Unused)
+ * 0: Radio ID <STRING>
  * 1: Event: "closeGui" <STRING> (Unused)
  * 2: Event data <NUMBER> (Unused)
  * 3: Radio data <HASH> (Unused)
@@ -20,6 +20,9 @@
 #include "script_component.hpp"
 
 TRACE_1("", _this);
+
+params ["_radioId", "", "", "", ""];
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = nil;
 

--- a/addons/sys_prc77/radio/fnc_openGui.sqf
+++ b/addons/sys_prc77/radio/fnc_openGui.sqf
@@ -26,4 +26,6 @@ disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC77_RadioDialog";
 
+[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
 true

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -13,6 +13,9 @@
             <English>Radio used externally. Only owner may configure.</English>
             <Japanese>無線機は外部で使われています。オーナーのみが設定可能です。</Japanese>
         </Key>
+        <Key ID="STR_ACRE_sys_radio_alreadyOpenRadio">
+            <English>Radio interface is opened by another player.</English>
+        </Key>
         <Key ID="STR_ACRE_sys_rack_unmountRadio">
             <English>Unmount Radio (%1)</English>
             <Japanese>無線機を降ろす (%1)</Japanese>

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -9,13 +9,6 @@
             <English>Unmountable (Locked)</English>
             <Japanese>搭載不可 (ロック済)</Japanese>
         </Key>
-        <Key ID="STR_ACRE_sys_radio_noGuiExternal">
-            <English>Radio used externally. Only owner may configure.</English>
-            <Japanese>無線機は外部で使われています。オーナーのみが設定可能です。</Japanese>
-        </Key>
-        <Key ID="STR_ACRE_sys_radio_alreadyOpenRadio">
-            <English>Radio interface is opened by another player.</English>
-        </Key>
         <Key ID="STR_ACRE_sys_rack_unmountRadio">
             <English>Unmount Radio (%1)</English>
             <Japanese>無線機を降ろす (%1)</Japanese>

--- a/addons/sys_radio/fnc_canOpenRadio.sqf
+++ b/addons/sys_radio/fnc_canOpenRadio.sqf
@@ -33,6 +33,11 @@ if (_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS || _radioId in ACRE_HEARABLE_RACK_RA
     };
 };
 
+if ([_radioId, "getState", "isGuiOpened"] call EFUNC(sys_data,dataEvent)) then {
+    _canOpenRadio = false;
+    [localize LSTRING(alreadyOpenRadio), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+};
+
 if (!_canOpenRadio) then {
     GVAR(currentRadioDialog) = "";  // Reset current radio gui that was initialised during the EFUNC(sys_data,interactEvent) call
 };

--- a/addons/sys_radio/fnc_canOpenRadio.sqf
+++ b/addons/sys_radio/fnc_canOpenRadio.sqf
@@ -24,7 +24,7 @@ if ((toLower _radioId) in ACRE_ACCESSIBLE_RACK_RADIOS && {isTurnedOut acre_playe
     [localize LSTRING(noGuiTurnedOut), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
 };
 
-if (_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS || _radioId in ACRE_HEARABLE_RACK_RADIOS) then {
+if ((_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS && !([_radioId] call FUNC(isManpackRadio))) || _radioId in ACRE_HEARABLE_RACK_RADIOS) then {
     _canOpenRadio = false;
     if (_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS) then {
         [localize LSTRING(noGuiExternal), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);

--- a/addons/sys_radio/fnc_initDefaultRadio.sqf
+++ b/addons/sys_radio/fnc_initDefaultRadio.sqf
@@ -22,5 +22,8 @@ params ["_radioId", ["_preset", "default"]];
 
 private _baseName = BASECLASS(_radioId);
 [_radioId, "initializeComponent", [_baseName, _preset]] call EFUNC(sys_data,dataEvent);
+
+// External radio use
 [_radioId] call EFUNC(sys_external,initRadio);
+
 TRACE_1("", _baseName);

--- a/addons/sys_radio/stringtable.xml
+++ b/addons/sys_radio/stringtable.xml
@@ -10,6 +10,7 @@
             <English>Radio used externally. Only owner may configure.</English>
             <Japanese>無線機は外部で使用されます。オーナーのみが設定可能です。</Japanese>
         </Key>
+
         <Key ID="STR_ACRE_sys_radio_noGuiTurnedOut">
             <English>Radio rack not configurable while turned out.</English>
             <Japanese>無線機ラックは顔を外に出していると設定できません。</Japanese>
@@ -29,6 +30,9 @@
         <Key ID="STR_ACRE_sys_radio_alreadyTransmitting">
             <English>Radio already transmitting.</English>
              <Japanese>無線機は既に送信中。</Japanese>
+        </Key>
+        <Key ID="STR_ACRE_sys_radio_alreadyOpenRadio">
+            <English>Radio is being configured by another player.</English>
         </Key>
     </Package>
 </Project>

--- a/addons/sys_sem52sl/radio/fnc_closeGui.sqf
+++ b/addons/sys_sem52sl/radio/fnc_closeGui.sqf
@@ -37,6 +37,9 @@
  *      true
 */
 
+params ["_radioId", "", "", "", ""];
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
 GVAR(currentRadioId) = -1;
 
 true

--- a/addons/sys_sem52sl/radio/fnc_openGui.sqf
+++ b/addons/sys_sem52sl/radio/fnc_openGui.sqf
@@ -53,6 +53,7 @@ if (([GVAR(currentRadioId), "getState", "channelKnobPosition"] call EFUNC(sys_da
 };
 GVAR(lastAction) = time;
 createDialog "SEM52SL_RadioDialog";
+[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 // Use this to turn off the backlight display//also to save last channel
 

--- a/addons/sys_sem70/radio/fnc_closeGui.sqf
+++ b/addons/sys_sem70/radio/fnc_closeGui.sqf
@@ -37,6 +37,9 @@
  *      true
 */
 
+params ["_radioId", "", "", "", ""];
+[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
 GVAR(currentRadioId) = -1;
 
 true

--- a/addons/sys_sem70/radio/fnc_openGui.sqf
+++ b/addons/sys_sem70/radio/fnc_openGui.sqf
@@ -48,6 +48,7 @@ disableSerialization;
 GVAR(currentRadioId) = _radioId;
 GVAR(lastAction) = time;
 createDialog "SEM70_RadioDialog";
+[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 TRACE_2("OpenGui",GVAR(currentRadioId),GVAR(lastAction));
 


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent two or more players from opening the same radio GUI. This is important for radio racks and man-pack radios.
- Allow external manpack radios to be configured by both owner and external user.