### PR TITLE
Missing private in PRC343, SEM70 and SEM52SL

### DIFF
--- a/addons/sys_prc343/radio/fnc_initializeRadio.sqf
+++ b/addons/sys_prc343/radio/fnc_initializeRadio.sqf
@@ -27,7 +27,7 @@ params ["_radioId", "_event", "_eventData", "_radioData", ""];
 _eventData params ["_baseName", "_preset"];
 private _presetData = [_baseName, _preset] call EFUNC(sys_data,getPresetData);
 private _channels = HASH_GET(_presetData,"channels");
-_currentChannels = HASH_GET(_radioData,"channels");
+private _currentChannels = HASH_GET(_radioData,"channels");
 
 SCRATCH_SET(_radioId, "currentTransmissions", []);
 
@@ -37,7 +37,7 @@ if (isNil "_currentChannels") then {
 };
 
 for "_i" from 0 to (count _channels)-1 do {
-    _channelData = HASH_COPY(_channels select _i);
+    private _channelData = HASH_COPY(_channels select _i);
     TRACE_1("Setting PRC-343 Init Channel Data", _channelData);
     PUSH(_currentChannels, _channelData);
 };

--- a/addons/sys_sem52sl/radio/fnc_initializeRadio.sqf
+++ b/addons/sys_sem52sl/radio/fnc_initializeRadio.sqf
@@ -64,14 +64,14 @@ private _channels = HASH_GET(_presetData,"channels");
 
 SCRATCH_SET(_radioId, "currentTransmissions", []);
 
-_currentChannels = HASH_GET(_radioData,"channels");
+private _currentChannels = HASH_GET(_radioData,"channels");
 if (isNil "_currentChannels") then {
     _currentChannels = [];
     HASH_SET(_radioData,"channels",_currentChannels);
 };
 
 for "_i" from 0 to (count _channels)-1 do {
-    _channelData = HASH_COPY(_channels select _i);
+    private _channelData = HASH_COPY(_channels select _i);
     TRACE_1("Setting " + QUOTE(RADIONAME) + " Init Channel Data", _channelData);
     PUSH(_currentChannels, _channelData);
 };

--- a/addons/sys_sem70/radio/fnc_initializeRadio.sqf
+++ b/addons/sys_sem70/radio/fnc_initializeRadio.sqf
@@ -64,14 +64,14 @@ private _channels = HASH_GET(_presetData,"channels");
 
 SCRATCH_SET(_radioId, "currentTransmissions", []);
 
-_currentChannels = HASH_GET(_radioData,"channels");
+private _currentChannels = HASH_GET(_radioData,"channels");
 if (isNil "_currentChannels") then {
     _currentChannels = [];
     HASH_SET(_radioData,"channels",_currentChannels);
 };
 
 for "_i" from 0 to (count _channels)-1 do {
-    _channelData = HASH_COPY(_channels select _i);
+    private _channelData = HASH_COPY(_channels select _i);
     TRACE_1("Setting " + QUOTE(RADIONAME) + " Init Channel Data", _channelData);
     PUSH(_currentChannels, _channelData);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Missing private  keyword in fnc_initializeRadio.sqf for PRC343, SEM70 and SEM52SL.
