### PR TITLE
Inf. phones should not use ANY racks

### DIFF
--- a/addons/sys_rack/fnc_isRackHearable.sqf
+++ b/addons/sys_rack/fnc_isRackHearable.sqf
@@ -26,7 +26,7 @@ if (isNull _vehicle) then {
 if (!alive _vehicle) exitWith {false};
 
 // Infantry phone units are not allowed
-if (_unit isEqualTo (vehicle _unit)) exitWith {false};
+if (_unit == vehicle _unit) exitWith {false};
 
 private _wiredIntercoms = [_rackId] call FUNC(getWiredIntercoms);
 

--- a/addons/sys_rack/fnc_isRackHearable.sqf
+++ b/addons/sys_rack/fnc_isRackHearable.sqf
@@ -26,7 +26,7 @@ if (isNull _vehicle) then {
 if (!alive _vehicle) exitWith {false};
 
 // Infantry phone units are not allowed
-if (_unit isEqualTo ((_vehicle getVariable [QEGVAR(sys_intercom,unitInfantryPhone), [objNull, 0]]) select 0)) exitWith {false};
+if (_unit isEqualTo (vehicle _unit)) exitWith {false};
 
 private _wiredIntercoms = [_rackId] call FUNC(getWiredIntercoms);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes possibility to access racks  from other vehicles when using the infantry phone.