### PR TITLE
No verb at the beginning for radio states

### DIFF
--- a/addons/sys_external/fnc_allowExternalUse.sqf
+++ b/addons/sys_external/fnc_allowExternalUse.sqf
@@ -18,4 +18,4 @@
 
 params ["_radioId", "_allowExternalUse"];
 
-[_radioId, "setState", ["isShared", _allowExternalUse]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioShared", _allowExternalUse]] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_external/fnc_getExternalRadioUser.sqf
+++ b/addons/sys_external/fnc_getExternalRadioUser.sqf
@@ -17,4 +17,4 @@
 
 params ["_radioId"];
 
-[_radioId, "getState", "isUsedExternally"] call EFUNC(sys_data,dataEvent) select 1
+[_radioId, "getState", "radioUsedExternally"] call EFUNC(sys_data,dataEvent) select 1

--- a/addons/sys_external/fnc_getSharedExternalRadios.sqf
+++ b/addons/sys_external/fnc_getSharedExternalRadios.sqf
@@ -22,4 +22,4 @@ private _radioList = _radios select {_x call EFUNC(sys_radio,isUniqueRadio)};
 
 if (!(alive _unit) || (captive _unit)) exitWith {_radioList};
 
-_radioList select {[_x, "getState", "isShared"] call EFUNC(sys_data,dataEvent)}
+_radioList select {[_x, "getState", "radioShared"] call EFUNC(sys_data,dataEvent)}

--- a/addons/sys_external/fnc_initRadio.sqf
+++ b/addons/sys_external/fnc_initRadio.sqf
@@ -18,7 +18,7 @@
 params ["_radioId"];
 
 [_radioId, false] call FUNC(allowExternalUse);
-[_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
 
 // To prevent the GUI from being simultaneously opened
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_external/fnc_isExternalRadioUsed.sqf
+++ b/addons/sys_external/fnc_isExternalRadioUsed.sqf
@@ -17,4 +17,4 @@
 
 params ["_radioId"];
 
-[_radioId, "getState", "isUsedExternally"] call EFUNC(sys_data,dataEvent) select 0
+[_radioId, "getState", "radioUsedExternally"] call EFUNC(sys_data,dataEvent) select 0

--- a/addons/sys_external/fnc_isRadioShared.sqf
+++ b/addons/sys_external/fnc_isRadioShared.sqf
@@ -17,4 +17,4 @@
 
 params ["_radioId"];
 
-[_radioId, "getState", "isShared"] call EFUNC(sys_data,dataEvent)
+[_radioId, "getState", "radioShared"] call EFUNC(sys_data,dataEvent)

--- a/addons/sys_external/fnc_startUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_startUsingExternalRadio.sqf
@@ -24,7 +24,7 @@ private _displayName = getText (ConfigFile >> "CfgWeapons" >> _baseRadio >> "dis
 
 // Do not flag as being externally used if it is already so (action give)
 if (!([_radioId] call FUNC(isExternalRadioUsed))) then {
-    [_radioId, "setState", ["isUsedExternally", [true, _endUser]]] call EFUNC(sys_data,dataEvent);
+    [_radioId, "setState", ["radioUsedExternally", [true, _endUser]]] call EFUNC(sys_data,dataEvent);
 
     // Handle remote owner
     private _message = format [localize LSTRING(hintTakeOwner), _endUser, _displayName];

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -34,7 +34,7 @@ if (_target == _owner) then {
     [QGVAR(stopUsingRadioLocal), [_message, _radioId], _owner] call CBA_fnc_targetEvent;
 
     // Give radio back to the owner
-    [_radioId, "setState", ["isUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
+    [_radioId, "setState", ["radioUsedExternally", [false, objNull]]] call EFUNC(sys_data,dataEvent);
 } else {
     // Show a hint to the actual owner that the radio was given to another player
     private _message = format [localize LSTRING(hintGiveOwner), name ([_radioId] call FUNC(getExternalRadioUser)), _displayName, name _target];

--- a/addons/sys_prc117f/fnc_closeGui.sqf
+++ b/addons/sys_prc117f/fnc_closeGui.sqf
@@ -19,7 +19,7 @@
 TRACE_1("", _this);
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc117f/fnc_openGui.sqf
+++ b/addons/sys_prc117f/fnc_openGui.sqf
@@ -27,7 +27,7 @@ GVAR(currentRadioId) = _radioId;
 createDialog "Prc117f_RadioDialog";
 [] call FUNC(clearDisplay);
 
-[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 
 _onState = [GVAR(currentRadioId), "getOnOffState"] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_prc148/fnc_closeGui.sqf
+++ b/addons/sys_prc148/fnc_closeGui.sqf
@@ -17,7 +17,7 @@
 #include "script_component.hpp"
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 [GVAR(PFHId)] call CBA_fnc_removePerFrameHandler;
 GVAR(currentRadioId) = nil;

--- a/addons/sys_prc148/fnc_openGui.sqf
+++ b/addons/sys_prc148/fnc_openGui.sqf
@@ -24,7 +24,7 @@ if (!([_radioId] call EFUNC(sys_radio,canOpenRadio))) exitWith { false };
 disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC148_RadioDialog";
-[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 GVAR(PFHId) = ADDPFH(DFUNC(PFH), 0.33, []);
 

--- a/addons/sys_prc152/fnc_closeGui.sqf
+++ b/addons/sys_prc152/fnc_closeGui.sqf
@@ -19,7 +19,7 @@
 TRACE_1("", _this);
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc152/fnc_openGui.sqf
+++ b/addons/sys_prc152/fnc_openGui.sqf
@@ -26,7 +26,7 @@ disableSerialization;
 
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC152_RadioDialog";
-[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 _onState = [GVAR(currentRadioId), "getOnOffState"] call EFUNC(sys_data,dataEvent);
 

--- a/addons/sys_prc343/radio/fnc_closeGui.sqf
+++ b/addons/sys_prc343/radio/fnc_closeGui.sqf
@@ -20,7 +20,7 @@
 #include "script_component.hpp"
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc343/radio/fnc_openGui.sqf
+++ b/addons/sys_prc343/radio/fnc_openGui.sqf
@@ -30,6 +30,6 @@ if (!([_radioId] call EFUNC(sys_radio,canOpenRadio))) exitWith { false };
 disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC343_RadioDialog";
-[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 true

--- a/addons/sys_prc77/radio/fnc_closeGui.sqf
+++ b/addons/sys_prc77/radio/fnc_closeGui.sqf
@@ -22,7 +22,7 @@
 TRACE_1("", _this);
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = nil;
 

--- a/addons/sys_prc77/radio/fnc_openGui.sqf
+++ b/addons/sys_prc77/radio/fnc_openGui.sqf
@@ -26,6 +26,6 @@ disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC77_RadioDialog";
 
-[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 true

--- a/addons/sys_radio/fnc_canOpenRadio.sqf
+++ b/addons/sys_radio/fnc_canOpenRadio.sqf
@@ -33,7 +33,7 @@ if ((_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS && !([_radioId] call FUNC(isManpack
     };
 };
 
-if ([_radioId, "getState", "isGuiOpened"] call EFUNC(sys_data,dataEvent)) then {
+if ([_radioId, "getState", "radioGuiOpened"] call EFUNC(sys_data,dataEvent)) then {
     _canOpenRadio = false;
     [localize LSTRING(alreadyOpenRadio), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
 };

--- a/addons/sys_sem52sl/radio/fnc_closeGui.sqf
+++ b/addons/sys_sem52sl/radio/fnc_closeGui.sqf
@@ -38,7 +38,7 @@
 */
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_sem52sl/radio/fnc_openGui.sqf
+++ b/addons/sys_sem52sl/radio/fnc_openGui.sqf
@@ -53,7 +53,7 @@ if (([GVAR(currentRadioId), "getState", "channelKnobPosition"] call EFUNC(sys_da
 };
 GVAR(lastAction) = time;
 createDialog "SEM52SL_RadioDialog";
-[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 // Use this to turn off the backlight display//also to save last channel
 

--- a/addons/sys_sem70/radio/fnc_closeGui.sqf
+++ b/addons/sys_sem70/radio/fnc_closeGui.sqf
@@ -38,7 +38,7 @@
 */
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["isGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
 
 GVAR(currentRadioId) = -1;
 


### PR DESCRIPTION
**When merged this pull request will:**
- As discussed in another PR. Changes radio states from having a verb at the beginning: "isShared" to "radioShared", ... 