### PR TITLE
Update Documentation Theme

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,3 +5,4 @@ _pdf
 .idea/
 .pdf
 Gemfile.lock
+!.vscode

--- a/docs/.vscode/settings.json
+++ b/docs/.vscode/settings.json
@@ -1,0 +1,6 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "files.associations": {
+    "*.html": "liquid"
+  }
+}

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-redirect-from'
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -57,6 +57,10 @@ entries:
       url: /wiki/user/direct-speech
       output: web, pdf
 
+    - title: Babel
+      url: /wiki/user/babel
+      output: web, pdf
+
     - title: External Radios
       url: /wiki/user/external-radios
       output: web, pdf
@@ -135,6 +139,10 @@ entries:
 
     - title: Mission Making Guide
       url: /wiki/frameworks/mission-making-guide
+      output: web, pdf
+
+    - title: Babel
+      url: /wiki/frameworks/babel
       output: web, pdf
 
     - title: Vehicle Attenuation

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -40,6 +40,7 @@
             {% endif %}
             {% endfor %}
         </ul>
+    </li>
         {% endif %}
         {% endfor %}
         {% endfor %}
@@ -48,9 +49,7 @@
                <a href="#" id="collapseAll">Collapse All</a> | <a href="#" id="expandAll">Expand All</a>
            </p>
            -->
-    </li>
 </ul>
-</div>
 
 <!-- this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above. Otherwise, if placed inside customscripts.js, the script runs before the sidebar code runs and the class never gets inserted.-->
 <script>$("li.active").parents('li').toggleClass("active");</script>

--- a/docs/_includes/topnav.html
+++ b/docs/_includes/topnav.html
@@ -12,6 +12,8 @@
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
+                <!-- toggle sidebar button -->
+                <li><a id="tg-sb-link" href="#"><i id="tg-sb-icon" class="fa fa-toggle-on"></i> Nav</a></li>
                 <!-- entries without drop-downs appear here -->
                 {% for entry in site.data.topnav.topnav %}
                 {% for item in entry.items %}
@@ -60,7 +62,7 @@
                                 searchInput: document.getElementById('search-input'),
                                 resultsContainer: document.getElementById('results-container'),
                                 dataSource: '{{ "/search.json" | prepend: site.baseurl }}',
-                                searchResultTemplate: '<li><a href="{url}" title="{{page.title | replace: "'", "\"}}">{title}</a></li>',
+                                searchResultTemplate: '<li><a href="{url}" title="{{page.title | replace: "\'", "\"}}">{title}</a></li>',
                     noResultsText: '{{site.data.strings.search_no_results_text}}',
                             limit: 10,
                             fuzzy: true,

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
     {% include head.html %}
     <script>
@@ -38,17 +39,35 @@
             $('[data-toggle="tooltip"]').tooltip()
         })
     </script>
-    {% if page.datatable == true %}
-    <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.5/css/jquery.dataTables.css">
-    <script type="text/javascript" charset="utf8" src="//cdn.datatables.net/1.10.5/js/jquery.dataTables.js"></script>
     <script>
-        $(document).ready(function(){
-
-            $('table.datatable').DataTable( {
-                        paging: false,
-                        stateSave: true
-                    }
-            );
+        $(document).ready(function() {
+            $("#tg-sb-link").click(function() {
+                $("#tg-sb-sidebar").toggle();
+                $("#tg-sb-content").toggleClass('col-md-9');
+                $("#tg-sb-content").toggleClass('col-md-12');
+                $("#tg-sb-icon").toggleClass('fa-toggle-on');
+                $("#tg-sb-icon").toggleClass('fa-toggle-off');
+            });
+        });
+    </script>
+    {% if page.datatable == true %}
+    <!-- Include the standard DataTables bits -->
+    <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.13/css/jquery.dataTables.css">
+    <script type="text/javascript" charset="utf8" src="//cdn.datatables.net/1.10.13/js/jquery.dataTables.js"></script>
+    <!-- First, this walks through the tables that occur between ...-begin
+         and ...-end and add the "datatable" class to them.
+         Then it invokes DataTable's standard initializer
+         Credit here: http://www.beardedhacker.com/blog/2015/08/28/add-class-attribute-to-markdown-table/
+      -->
+    <script>
+      $(document).ready(function(){
+          $('div.datatable-begin').nextUntil('div.datatable-end', 'table').addClass('display');
+          $('table.display').DataTable( {
+              paging: true,
+              stateSave: true,
+              searching: true
+          });
+       });
     </script>
     {% endif %}
 
@@ -60,14 +79,19 @@
     <div class="col-lg-12">&nbsp;</div>
     <!-- Content Row -->
     <div class="row">
-        <!-- Sidebar Column -->
-        <div class="col-md-3">
+        {% assign content_col_size = "col-md-12" %}
+        {% unless page.hide_sidebar %}
+            <!-- Sidebar Column -->
+            <div class="col-md-3" id="tg-sb-sidebar">
+                {% include sidebar.html %}
+            </div>
+            {% assign content_col_size = "col-md-9" %}
+        {% endunless %}
 
-          {% include sidebar.html %}
-    <!-- Content Column -->
-    <div class="col-md-9">
-        {{content}}
-    </div>
+        <!-- Content Column -->
+        <div class="{{content_col_size}}" id="tg-sb-content">
+            {{content}}
+        </div>
     <!-- /.row -->
 </div>
 <!-- /.container -->

--- a/docs/news/archive.html
+++ b/docs/news/archive.html
@@ -5,30 +5,24 @@ toc: false
 
 <div class="home">
     <div class="post-list">
-    <section id="archive">
-        <h3>This year's posts</h3>
-        {%for post in site.posts %}
-        {% unless post.next %}
-        <ul class="this">
-            {% else %}
-            {% capture year %}{{ post.date | date: '%Y' }}{% endcapture %}
-            {% capture nyear %}{{ post.next.date | date: '%Y' }}{% endcapture %}
-            {% if year != nyear %}
-        </ul>
-        <h3>{{ post.date | date: '%Y' }}</h3>
-        <ul class="past">
-            {% endif %}
-            {% endunless %}
-            <li><time>{{ post.date | date:"%d %b" }}</time><a href="{{post.url}}">{{ post.title }}</a></li>
-            {% endfor %}
-        </ul>
-    </section>
-
-
-    <hr/>
-
-
-
-
-
+        <section id="archive">
+            <h3>This year's posts</h3>
+            {%for post in site.posts %}
+            {% unless post.next %}
+            <ul class="this">
+                {% else %}
+                {% capture year %}{{ post.date | date: '%Y' }}{% endcapture %}
+                {% capture nyear %}{{ post.next.date | date: '%Y' }}{% endcapture %}
+                {% if year != nyear %}
+            </ul>
+            <h3>{{ post.date | date: '%Y' }}</h3>
+            <ul class="past">
+                {% endif %}
+                {% endunless %}
+                <li><time>{{ post.date | date:"%d %b" }}</time><a href="{{post.url}}">{{ post.title }}</a></li>
+                {% endfor %}
+            </ul>
+        </section>
+        <hr/>
     </div>
+</div>

--- a/docs/pdfconfigs/titlepage.html
+++ b/docs/pdfconfigs/titlepage.html
@@ -10,11 +10,11 @@ permalink: /titlepage/
     <hr />
 
     <div class="printTitleImage">
-        <img src="{{site.url}}/{{site.baseurl}}/images/company_logo_big.png"/>
+        <img src="{{site.url}}/{{site.baseurl}}/images/company_logo_big.png" alt="Company Logo"/>
     </div>
 
     <div class="copyrightBoilerplate">
-        <p>&copy; 2016 Your company. This is a boilerplate copyright statement... All rights reserved. No part of this publication may be reproduced, distributed, or transmitted in any form or by any means, including photocopying, recording, or other electronic or mechanical methods, without the prior written permission of the publisher, except in the case of brief quotations embodied in critical reviews and certain other noncommercial uses permitted by copyright law.
+        <p>&copy; {{ site.time | date: "%Y" }} {{site.company_name}}. This is a boilerplate copyright statement... All rights reserved. No part of this publication may be reproduced, distributed, or transmitted in any form or by any means, including photocopying, recording, or other electronic or mechanical methods, without the prior written permission of the publisher, except in the case of brief quotations embodied in critical reviews and certain other noncommercial uses permitted by copyright law.
         </p>
 
     </div>

--- a/docs/search.json
+++ b/docs/search.json
@@ -8,7 +8,7 @@ search: exclude
 {% for page in site.pages %}
 {% unless page.search == "exclude" %}
 {
-"title": "{{ page.title | escape }}",
+"title": "{{ page.title | escape }} ({{ page.dir | replace: '/', '' | replace: 'wiki', '' | capitalize}})",
 "url": "{{ page.url }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
@@ -18,7 +18,7 @@ search: exclude
 {% for post in site.posts %}
 
 {
-"title": "{{ post.title | escape }}",
+"title": "{{ post.title | escape }} (Post)",
 "url": "{{ post.url }}",
 "summary": "{{post.summary | strip }}"
 }

--- a/docs/wiki/development/docs_guidelines.md
+++ b/docs/wiki/development/docs_guidelines.md
@@ -4,7 +4,7 @@ title: Documentation Guidelines
 
 ## Overview
 
-This documentation is built using [Jekyll Documentation Theme](http://idratherbewriting.com/documentation-theme-jekyll/) ([commit](https://github.com/tomjohnson1492/documentation-theme-jekyll/commit/06dc9e0e257e014d1ccf9de158e76a61d74f84e6)), all the theme documentation and tutorials are appliccable to ACRE2's documentation, with few changes:
+This documentation is built using [Jekyll Documentation Theme](http://idratherbewriting.com/documentation-theme-jekyll/) ([commit](https://github.com/tomjohnson1492/documentation-theme-jekyll/commit/5505b46f0efbf75dd65b0634ad0c77db78692d41)), all the theme documentation and tutorials are appliccable to ACRE2's documentation, with few changes:
 - Added nicer keyboard tags styling
 - Merged news pages into main part
 - Removed tooltips functionality

--- a/docs/wiki/frameworks/babel.md
+++ b/docs/wiki/frameworks/babel.md
@@ -1,16 +1,5 @@
-
 ---
 title: Babel
 ---
-
-## Overview
-
-ACRE2 introduces an exciting new voice feature for adversarial and cooperative play in the Babel System. This system allows mission makers to define a set of "languages" for players and assign players individually, however you choose, which languages from that set they speak, from one language to multiple languages. If a player speaks a language that another player doesn’t understand the voice of that speaker will be transformed into an unintelligible sound, but one that still retains the elements of language, such as inflection, tone of voice, and cadence of speech. If you speak multiple languages you are able to switch between which language you are speaking in, and will hear people speaking any of the languages you understand unaffected by the Babel System.
-
-For adversarial play this allows you to hide all enemy communications from understanding unless there is someone defined as speaking that language. For cooperative play the use of interpreters between multiple language groups becomes essential, adding a new dynamic to the play experience.
-
-The Babel System and API is present as of the ACRE2 Alpha build number 509. All functions are part of the standard mission maker API and are listed below.
-
-## Concepts
 
 The Babel System uses a local API system that must be executed on all clients equally except for where the definition of a individual persons language is concerned, which can differ between clients. Language IDs are sent during the start of speaking events, with non-timely updates applied if a person changes languages in the middle of a conversation. It is imperative that languages be added in the same order on all machines, including JIP, otherwise the numerical values sent during speaking events will not match their literal values on the client. It is best to avoid manipulating the list of languages available after mission init or JIP init.

--- a/docs/wiki/user/babel.md
+++ b/docs/wiki/user/babel.md
@@ -1,0 +1,7 @@
+---
+title: Babel
+---
+
+ACRE2 introduces an exciting new voice feature for adversarial and cooperative play in the Babel System. This system allows mission makers to define a set of "languages" for players and assign players individually, however you choose, which languages from that set they speak, from one language to multiple languages. If a player speaks a language that another player doesn’t understand the voice of that speaker will be transformed into an unintelligible sound, but one that still retains the elements of language, such as inflection, tone of voice, and cadence of speech. If you speak multiple languages you are able to switch between which language you are speaking in, and will hear people speaking any of the languages you understand unaffected by the Babel System.
+
+For adversarial play this allows you to hide all enemy communications from understanding unless there is someone defined as speaking that language. For cooperative play the use of interpreters between multiple language groups becomes essential, adding a new dynamic to the play experience.


### PR DESCRIPTION
**When merged this pull request will:**
- Fix Babel documentation title
- Split Babel into User and Framework pages
- Add section in `()` to search results to distinguish between 2 pages from different sections with same name
- Update Jekyll Documentation Theme to [5505b46f0efbf75dd65b0634ad0c77db78692d41](https://github.com/tomjohnson1492/documentation-theme-jekyll/commit/5505b46f0efbf75dd65b0634ad0c77db78692d41)
    - Add sidebar show toggle to top navigation bar
    - Update and Fix DataTables
    - Fix missing tags and typos and stuff
    - Add VSCode configuration file for Liquid