### PR TITLE
Prevent simultaneous transmission on manpack radios

### DIFF
--- a/addons/sys_core/fnc_remoteStartSpeaking.sqf
+++ b/addons/sys_core/fnc_remoteStartSpeaking.sqf
@@ -94,8 +94,8 @@ private _result = false;
         _unit setVariable [QGVAR(lastSpeakingEventTime), diag_tickTime, false];
         if (_onRadio == 1) then {
             if ([_radioId] call EFUNC(sys_radio,radioExists)) then {
-                // Handle rack radios that are simultaneously in use.
-                if ((toLower _radioId) in ACRE_ACCESSIBLE_RACK_RADIOS || (toLower _radioId) in ACRE_HEARABLE_RACK_RADIOS) then {
+                // Handle rack radios or shared manpack radios that are simultaneously in use.
+                if ((toLower _radioId) in ACRE_ACCESSIBLE_RACK_RADIOS || {(toLower _radioId) in ACRE_HEARABLE_RACK_RADIOS} || {_radioId in ACRE_EXTERNALLY_USED_MANPACK_RADIOS} || {_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS}) then {
                     ACRE_BLOCKED_TRANSMITTING_RADIOS pushBackUnique (toLower _radioId);
                 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent simultaneous transmittion on manpack radios. A hint will be shown to the player: radio in use.