### PR TITLE
Fix wrong coordination system for antenna calculation

### DIFF
--- a/addons/sys_components/fnc_getAntennaDirMan.sqf
+++ b/addons/sys_components/fnc_getAntennaDirMan.sqf
@@ -19,15 +19,15 @@
 
  //@TODO: This is a hack fix for vehicles having funky up vectors when people are inside...
  if (vehicle _obj == _obj) then {
-     private _spinePos = (_obj selectionPosition "Spine3");
-     _upV = _spinePos vectorFromTo (_obj selectionPosition "Neck");
+     private _spinePos = _obj modelToWorldVisual (_obj selectionPosition "Spine3");
+     _upV = _spinePos vectorFromTo (_obj modelToWorldVisual (_obj selectionPosition "Neck"));
 
      private _upP = _upV call cba_fnc_vect2polar;
      _upP set [2, (_upP select 2) - 90];
      _forwardV = _upP call cba_fnc_polar2vect;
 
-     _forwardV = (ATLtoASL (_obj modelToWorldVisual _spinePos)) vectorFromTo (ATLtoASL ((_obj modelToWorldVisual _spinePos) vectorAdd _forwardV));
-     _upV = (ATLtoASL (_obj modelToWorldVisual _spinePos)) vectorFromTo (ATLtoASL ((_obj modelToWorldVisual _spinePos) vectorAdd _upV));
+     _forwardV = (ATLtoASL _spinePos) vectorFromTo (ATLtoASL (_spinePos vectorAdd _forwardV));
+     _upV = (ATLtoASL _spinePos) vectorFromTo (ATLtoASL (_spinePos vectorAdd _upV));
  } else {
      _forwardV = vectorDir (vehicle _obj);
      _upV = vectorUp (vehicle _obj);


### PR DESCRIPTION
Fix the antenna direction calculation. Currently all antennas are always looking northwards. 