### PR TITLE
Fix API function - acre_api_fnc_isInitialized when unit is null

### DIFF
--- a/addons/api/fnc_isInitialized.sqf
+++ b/addons/api/fnc_isInitialized.sqf
@@ -19,6 +19,8 @@ if (!hasInterface) exitWith {false}; //Exit on server.
 
 params [["_unit",acre_player]];
 
+if (isNull _unit) exitWith {false}; // Player hasn't initialised yet.
+
 private _returnValue = !([_unit] call FUNC(hasBaseRadio)); // Is initialized if the unit has no base radio. HasBaseRadio also can not return nil.
 
 if (_returnValue) then { // Just check that we don't return true if the unit has an itemRadio as itemRadio is also a base radio.


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes #354 - function wouldn't check for the unit being null.
