### PR TITLE
Add radio presets to the AN/PRC-77

### DIFF
--- a/addons/api/fnc_setupMission.sqf
+++ b/addons/api/fnc_setupMission.sqf
@@ -43,6 +43,7 @@ if (_setupPresets) then {
                     ["ACRE_PRC117F", "default2" ] call FUNC(setPreset);
                     ["ACRE_PRC152", "default2" ] call FUNC(setPreset);
                     ["ACRE_PRC148", "default2" ] call FUNC(setPreset);
+                    ["ACRE_PRC77", "default2" ] call FUNC(setPreset);
                 };
                 case west: {
                     ["ACRE_PRC343", "default3" ] call FUNC(setPreset);
@@ -50,6 +51,7 @@ if (_setupPresets) then {
                     ["ACRE_PRC117F", "default3" ] call FUNC(setPreset);
                     ["ACRE_PRC152", "default3" ] call FUNC(setPreset);
                     ["ACRE_PRC148", "default3" ] call FUNC(setPreset);
+                    ["ACRE_PRC77", "default3" ] call FUNC(setPreset);
                 };
                 case independent: {
                     ["ACRE_PRC343", "default4" ] call FUNC(setPreset);
@@ -57,6 +59,7 @@ if (_setupPresets) then {
                     ["ACRE_PRC117F", "default4" ] call FUNC(setPreset);
                     ["ACRE_PRC152", "default4" ] call FUNC(setPreset);
                     ["ACRE_PRC148", "default4" ] call FUNC(setPreset);
+                    ["ACRE_PRC77", "default4" ] call FUNC(setPreset);
                 };
                 default {
                     ["ACRE_PRC343", "default" ] call FUNC(setPreset);
@@ -64,6 +67,7 @@ if (_setupPresets) then {
                     ["ACRE_PRC117F", "default" ] call FUNC(setPreset);
                     ["ACRE_PRC152", "default" ] call FUNC(setPreset);
                     ["ACRE_PRC148", "default" ] call FUNC(setPreset);
+                    ["ACRE_PRC77", "default" ] call FUNC(setPreset);
                 };
             };
         };

--- a/addons/sys_prc77/XEH_preInit.sqf
+++ b/addons/sys_prc77/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+[] call FUNC(preset_information);
+
 ADDON = true;

--- a/addons/sys_prc77/functions/__PREP__.sqf
+++ b/addons/sys_prc77/functions/__PREP__.sqf
@@ -1,6 +1,8 @@
 #include "script_component.hpp"
 TRACE_1("enter", _this);
 
+PREP_MODULE(functions,preset_information);
+
 PREP_MODULE(functions,onBandSelectorKnobPress);
 PREP_MODULE(functions,onFunctionKnobPress);
 PREP_MODULE(functions,onkHzTuneKnobPress);

--- a/addons/sys_prc77/functions/fnc_preset_information.sqf
+++ b/addons/sys_prc77/functions/fnc_preset_information.sqf
@@ -1,0 +1,80 @@
+/*
+ * Author: ACRE2Team
+ * Initialises and registers the default presets with the initial values of transmitting and receiving frequencies for each of the channels.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call acre_sys_prc77_fnc_presetInformation
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+// AN/PRC-77 
+// Frequency Range 30.00 to 75.95 Mhz
+
+// channel information
+///Default
+private _presetData = HASH_CREATE;
+private _channels = HASHLIST_CREATELIST(["frequencyTX"]);
+
+private _channel = HASHLIST_CREATEHASH(_channels);
+HASH_SET(_channel,"frequencyTX",30);
+HASHLIST_PUSH(_channels,_channel);
+
+_channel = HASHLIST_CREATEHASH(_channels); // 2nd Preset button
+HASH_SET(_channel,"frequencyTX",30);
+HASHLIST_PUSH(_channels,_channel);
+
+HASH_SET(_presetData,"channels",_channels);
+["ACRE_PRC77","default",_presetData] call EFUNC(sys_data,registerRadioPreset);
+
+///Default2
+_presetData = HASH_CREATE;
+_channels = HASHLIST_CREATELIST(["frequencyTX"]);
+
+_channel = HASHLIST_CREATEHASH(_channels);
+HASH_SET(_channel,"frequencyTX",35.50);
+HASHLIST_PUSH(_channels,_channel);
+
+_channel = HASHLIST_CREATEHASH(_channels); // 2nd Preset button
+HASH_SET(_channel,"frequencyTX",35.75);
+HASHLIST_PUSH(_channels,_channel);
+
+HASH_SET(_presetData,"channels",_channels);
+["ACRE_PRC77","default2",_presetData] call EFUNC(sys_data,registerRadioPreset);
+
+///Default3
+_presetData = HASH_CREATE;
+_channels = HASHLIST_CREATELIST(["frequencyTX"]);
+
+_channel = HASHLIST_CREATEHASH(_channels);
+HASH_SET(_channel,"frequencyTX",41.25);
+HASHLIST_PUSH(_channels,_channel);
+
+_channel = HASHLIST_CREATEHASH(_channels); // 2nd Preset button
+HASH_SET(_channel,"frequencyTX",41.65);
+HASHLIST_PUSH(_channels,_channel);
+
+HASH_SET(_presetData,"channels",_channels);
+["ACRE_PRC77","default3",_presetData] call EFUNC(sys_data,registerRadioPreset);
+
+///Default4
+_presetData = HASH_CREATE;
+_channels = HASHLIST_CREATELIST(["frequencyTX"]);
+
+_channel = HASHLIST_CREATEHASH(_channels);
+HASH_SET(_channel,"frequencyTX",62.85);
+HASHLIST_PUSH(_channels,_channel);
+
+_channel = HASHLIST_CREATEHASH(_channels); // 2nd Preset button
+HASH_SET(_channel,"frequencyTX",64.65);
+HASHLIST_PUSH(_channels,_channel);
+
+HASH_SET(_presetData,"channels",_channels);
+["ACRE_PRC77","default4",_presetData] call EFUNC(sys_data,registerRadioPreset);

--- a/addons/sys_prc77/radio/fnc_initializeRadio.sqf
+++ b/addons/sys_prc77/radio/fnc_initializeRadio.sqf
@@ -20,24 +20,62 @@
  */
 #include "script_component.hpp"
 
-params ["_radioId", "", "", "_radioData", ""];
+params ["_radioId", "", "_eventData", "_radioData", ""];
 TRACE_1("INITIALIZING RADIO 77", _this);
 
-SCRATCH_SET(_radioId, "currentTransmissions", []);
+// Function to convert frequency to knob positions.
+private _frequencyToKnobPositions = {
+    params ["_frequency"];
+    private _basedFrequncy = _frequency - 30;
+    if (_frequency >= 53) then {
+        _basedFrequncy = _frequency - 53;
+    };
+    private _floor = floor _basedFrequncy;
+    private _dif = _basedFrequncy - _floor;
+    private _twentyiths = (round (_dif * 20));
 
+    +[_floor,_twentyiths];
+};
+
+_eventData params ["_baseName", "_preset"];
+private _presetData = [_baseName, _preset] call EFUNC(sys_data,getPresetData);
+private _channels = HASH_GET(_presetData,"channels");
+
+private _channelData = HASH_COPY(_channels select 0);
+private _frequencyTx = HASH_GET(_channelData,"frequencyTX");
+_frequencyTx = ((round (_frequencyTx * 20))/20);
+
+private _secondChannelData = HASH_COPY(_channels select 1);
+private _secondPresetFrequency = HASH_GET(_secondChannelData,"frequencyTX");
+_secondPresetFrequency = ((round (_secondPresetFrequency * 20))/20);
+
+//Finding the MHz
+//interpreting the band selector
+
+// Band is the 30-52,53-75 selector
+private _band = 0;
+if (_frequencyTx >= 53) then {
+    _band = 1;
+};
+
+private _knobPositions = ([_frequencyTx] call _frequencyToKnobPositions);
+private _secondPresetKnobPositions = ([_secondPresetFrequency] call _frequencyToKnobPositions);
+
+
+SCRATCH_SET(_radioId, "currentTransmissions", []);
 
 //Radio Settings
 HASH_SET(_radioData,"volume",1); //0-1
 HASH_SET(_radioData,"function",2); //0 - OFF, 1 - ON, 2 - SQUELCH, 3 - RETRANS, 4 - LITE (Temp)
 HASH_SET(_radioData,"radioOn",1); //0 - OFF, 1 - ON
-HASH_SET(_radioData,"band",0); //{0,1}
-HASH_SET(_radioData,"currentPreset",[ARR_2([ARR_2(0,0)],[ARR_2(0,0)])]); //Array of Presetarrays (KnobPositions)
-HASH_SET(_radioData,"currentChannel",[ARR_2(0,0)]);
+HASH_SET(_radioData,"band",_band); //{0,1}
+HASH_SET(_radioData,"currentPreset",[ARR_2(_knobPositions,_secondPresetKnobPositions)]); //Array of Presetarrays (KnobPositions)
+HASH_SET(_radioData,"currentChannel",_knobPositions);
 
 
 //Common Channel Settings
-HASH_SET(_radioData,"frequencyTX",30);
-HASH_SET(_radioData,"frequencyRX",30);
+HASH_SET(_radioData,"frequencyTX",_frequencyTx);
+HASH_SET(_radioData,"frequencyRX",_frequencyTx);
 HASH_SET(_radioData,"power",3500);
 HASH_SET(_radioData,"mode","singleChannel");
 HASH_SET(_radioData,"CTCSSTx", 150);


### PR DESCRIPTION
**When merged this pull request will:**
- Adds presets to the AN/PRC77 radio
- The preset consists of '2 channels' - These channels are both stored on the 2 preset buttons on the AN/PRC-77
- The radio will be set to the frequency of the first channel on initialisation
- Fixes #260
