### PR TITLE
Use CBA Misc Items

### DIFF
--- a/addons/main/CfgWeapons.hpp
+++ b/addons/main/CfgWeapons.hpp
@@ -1,8 +1,15 @@
 class CfgWeapons {
+    // Hide vanilla radio
     class ItemCore;
     class ItemRadio: ItemCore {
         scopeCurator = 1;
         scope = 1;
     };
-    class ACRE_GameComponentBase: ItemRadio {};
+
+    // Base class for any ACRE component (using CBA_MiscItem for Virtual Arsenal compatibility)
+    class CBA_MiscItem;
+    class ACRE_GameComponentBase: CBA_MiscItem {
+        scopeCurator = 1;
+        scope = 1;
+    };
 };

--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -11,7 +11,7 @@
 
 // MINIMAL required version for the Mod. Components can specify others..
 #define REQUIRED_VERSION 1.64
-#define REQUIRED_CBA_VERSION {3,3,1}
+#define REQUIRED_CBA_VERSION {3,4,1}
 
 #ifdef COMPONENT_BEAUTIFIED
     #define COMPONENT_NAME QUOTE(ACRE2 - COMPONENT_BEAUTIFIED)

--- a/addons/sys_prc117f/CfgWeapons.hpp
+++ b/addons/sys_prc117f/CfgWeapons.hpp
@@ -1,7 +1,6 @@
 class CfgWeapons {
-    class Default;
     class ACRE_BaseRadio;
-    class ItemCore;
+    class CBA_MiscItem_ItemInfo;
 
     class ACRE_PRC117F: ACRE_BaseRadio {
         displayName = "AN/PRC-117F";
@@ -11,15 +10,12 @@ class CfgWeapons {
         descriptionShort = "AN/PRC-117F Manpack Radio";
         scopeCurator = 2;
         scope = 2;
-        class ItemInfo {
-             mass = 120;
-             allowedSlots[] = {901};
-            type = 0;
+
+        class ItemInfo: CBA_MiscItem_ItemInfo {
+            mass = 120;
+            allowedSlots[] = {901};
             scope = 0;
          };
-
-        type = 4096;
-        simulation = "ItemMineDetector";
 
         class Library {
             libTextDesc = "AN/PRC-117F Manpack Radio";

--- a/addons/sys_prc148/CfgWeapons.hpp
+++ b/addons/sys_prc148/CfgWeapons.hpp
@@ -1,6 +1,6 @@
 class CfgWeapons {
-    class Default;
     class ACRE_BaseRadio;
+    class CBA_MiscItem_ItemInfo;
 
     class ACRE_PRC148: ACRE_BaseRadio {
         displayName = "AN/PRC-148";
@@ -11,11 +11,8 @@ class CfgWeapons {
         scopeCurator = 2;
         scope = 2;
 
-        type = 4096;
-        simulation = "ItemMineDetector";
-        class ItemInfo {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 8;
-            type = 0;
             scope = 0;
         };
 

--- a/addons/sys_prc152/CfgWeapons.hpp
+++ b/addons/sys_prc152/CfgWeapons.hpp
@@ -1,7 +1,6 @@
 class CfgWeapons {
-    class Default;
     class ACRE_BaseRadio;
-    class ItemCore;
+    class CBA_MiscItem_ItemInfo;
 
     class ACRE_PRC152: ACRE_BaseRadio {
         displayName = "AN/PRC-152";
@@ -12,11 +11,8 @@ class CfgWeapons {
         scopeCurator = 2;
         scope = 2;
 
-        type = 4096;
-        simulation = "ItemMineDetector";
-        class ItemInfo {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 8;
-            type = 0;
             scope = 0;
         };
 

--- a/addons/sys_prc343/CfgWeapons.hpp
+++ b/addons/sys_prc343/CfgWeapons.hpp
@@ -1,17 +1,6 @@
-#define WeaponNoSlot        0    // dummy weapon
-#define WeaponSlotPrimary    1    // primary weapon
-#define WeaponSlotHandGun    2    // handGun/sidearm
-#define WeaponSlotSecondary    4    // secondary weapon    // 4 in ArmA, not 16.
-#define WeaponSlotHandGunItem    16    // sidearm/GL magazines    // 16 in ArmA, not 32.
-#define WeaponSlotItem        256    // main magazines, items, explosives
-#define WeaponSlotBinocular    4096    // binocular, NVG, LD, equipment
-#define WeaponHardMounted    65536
-#define WeaponSlotSmallItems    131072
-
 class CfgWeapons {
-    class Default;
     class ACRE_BaseRadio;
-    class ItemCore;
+    class CBA_MiscItem_ItemInfo;
 
     // replace ItemRadios icon with the 343 icon for stupid people
 
@@ -25,11 +14,8 @@ class CfgWeapons {
         scopeCurator = 2;
         scope = 2;
 
-        type = 4096;
-        simulation = "ItemMineDetector";
-        class ItemInfo {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 8;
-            type = 0;
             scope = 0;
         };
 

--- a/addons/sys_prc77/CfgWeapons.hpp
+++ b/addons/sys_prc77/CfgWeapons.hpp
@@ -1,19 +1,6 @@
-#define WeaponNoSlot        0    // dummy weapon
-#define WeaponSlotPrimary    1    // primary weapon
-#define WeaponSlotHandGun    2    // handGun/sidearm
-#define WeaponSlotSecondary    4    // secondary weapon    // 4 in ArmA, not 16.
-#define WeaponSlotHandGunItem    16    // sidearm/GL magazines    // 16 in ArmA, not 32.
-#define WeaponSlotItem        256    // main magazines, items, explosives
-#define WeaponSlotBinocular    4096    // binocular, NVG, LD, equipment
-#define WeaponHardMounted    65536
-#define WeaponSlotSmallItems    131072
-
 class CfgWeapons {
-    class Default;
     class ACRE_BaseRadio;
-    class ItemCore;
-
-
+    class CBA_MiscItem_ItemInfo;
 
     class ACRE_PRC77: ACRE_BaseRadio {
         displayName = "AN/PRC-77";
@@ -24,13 +11,9 @@ class CfgWeapons {
         scopeCurator = 2;
         scope = 2;
 
-        type = 4096;
-        simulation = "ItemMineDetector";
-
-        class ItemInfo {
-             mass = 120;
-             allowedSlots[] = {901};
-            type = 0;
+        class ItemInfo: CBA_MiscItem_ItemInfo {
+            mass = 120;
+            allowedSlots[] = {901};
             scope = 0;
          };
 

--- a/addons/sys_sem52sl/CfgWeapons.hpp
+++ b/addons/sys_sem52sl/CfgWeapons.hpp
@@ -1,17 +1,6 @@
-#define WeaponNoSlot        0    // dummy weapon
-#define WeaponSlotPrimary    1    // primary weapon
-#define WeaponSlotHandGun    2    // handGun/sidearm
-#define WeaponSlotSecondary    4    // secondary weapon    // 4 in ArmA, not 16.
-#define WeaponSlotHandGunItem    16    // sidearm/GL magazines    // 16 in ArmA, not 32.
-#define WeaponSlotItem        256    // main magazines, items, explosives
-#define WeaponSlotBinocular    4096    // binocular, NVG, LD, equipment
-#define WeaponHardMounted    65536
-#define WeaponSlotSmallItems    131072
-
 class CfgWeapons {
-    class Default;
     class ACRE_BaseRadio;
-    class ItemCore;
+    class CBA_MiscItem_ItemInfo;
 
     class ACRE_SEM52SL: ACRE_BaseRadio {
         displayName = "SEM 52 SL";
@@ -23,11 +12,8 @@ class CfgWeapons {
         scopeCurator = 2;
         scope = 2;
 
-        type = 4096;
-        simulation = "ItemMineDetector";
-        class ItemInfo {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 8;
-            type = 0;
             scope = 0;
         };
 

--- a/addons/sys_sem70/CfgWeapons.hpp
+++ b/addons/sys_sem70/CfgWeapons.hpp
@@ -1,17 +1,5 @@
-#define WeaponNoSlot 0    // dummy weapon
-#define WeaponSlotPrimary 1    // primary weapon
-#define WeaponSlotHandGun 2    // handGun/sidearm
-#define WeaponSlotSecondary 4    // secondary weapon    // 4 in ArmA, not 16.
-#define WeaponSlotHandGunItem 16    // sidearm/GL magazines    // 16 in ArmA, not 32.
-#define WeaponSlotItem 256    // main magazines, items, explosives
-#define WeaponSlotBinocular 4096    // binocular, NVG, LD, equipment
-#define WeaponHardMounted 65536
-#define WeaponSlotSmallItems 131072
-
 class CfgWeapons {
-    class Default;
     class ACRE_BaseRadio;
-    class ItemCore;
 
     class ACRE_SEM70: ACRE_BaseRadio {
         displayName = "SEM 70";
@@ -23,12 +11,9 @@ class CfgWeapons {
         scopeCurator = 2;
         scope = 2;
 
-        type = 4096;
-        simulation = "ItemMineDetector";
-        class ItemInfo {
+        class ItemInfo: CBA_MiscItem_ItemInfo {
             mass = 120;
             allowedSlots[] = {901};
-            type = 0;
             scope = 0;
         };
 

--- a/addons/sys_sem70/CfgWeapons.hpp
+++ b/addons/sys_sem70/CfgWeapons.hpp
@@ -1,5 +1,6 @@
 class CfgWeapons {
     class ACRE_BaseRadio;
+    class CBA_MiscItem_ItemInfo;
 
     class ACRE_SEM70: ACRE_BaseRadio {
         displayName = "SEM 70";


### PR DESCRIPTION
**When merged this pull request will:**
- Show ACRE2 items in Virtual Arsenal without them being Mine Detectors - fix #396 
- Cleanup some radio `CfgWeapons` configs

Requires https://github.com/CBATeam/CBA_A3/pull/744

Inheritance for base ACRE2 components has changed a bit, from:
`["ItemCore", "ItemRadio", "ACRE_GameComponentBase", "ACRE_BaseComponent", "ACRE_BaseRadio", "ACRE_<radioName>"]`
to
`["ItemCore", "CBA_MiscItem", "ACRE_GameComponentBase", "ACRE_BaseComponent", "ACRE_BaseRadio", "ACRE_<radioName>"]`