### PR TITLE
Don't try to assign more presets than the radio supports

### DIFF
--- a/addons/api/fnc_nameChannels.sqf
+++ b/addons/api/fnc_nameChannels.sqf
@@ -27,11 +27,16 @@ FUNC(_channelNamesForPresets) = {
                 private _channelName = _x;
                 private _channelNumber = _forEachIndex;
                 {
-                    //["ACRE_PRC117F",["default3"],10,"label","SUPPORT"]
-                    #ifdef DEBUG_MODE_FULL
-                        diag_log text format ["%1, %2, %3, %4, %5", _x select 0, _x select 1, _channelNumber + 1, "label", _channelName];
-                    #endif
-                    [_x select 0, _x select 1, _channelNumber + 1, "label", _channelName] call FUNC(setPresetChannelField);
+                    _x params ["_radioClass", "_presetName"];
+
+                    private _presetData = [_radioClass, _presetName] call EFUNC(sys_data,getPresetData);
+                    if (!isNil "_presetData" && {count HASH_GET(_presetData,"channels") >= _channelNumber}) then {
+                        // Example: ["ACRE_PRC117F", "default3", 10, "label", "SUPPORT"]
+                        #ifdef DEBUG_MODE_FULL
+                            diag_log text format ["%1, %2, %3, %4, %5", _radioClass, _presetName, _channelNumber + 1, "label", _channelName];
+                        #endif
+                        [_radioClass, _presetName, _channelNumber + 1, "label", _channelName] call FUNC(setPresetChannelField);
+                    };
                 } forEach _presetNames;
             };
         } forEach _channelNames;

--- a/addons/api/fnc_nameChannels.sqf
+++ b/addons/api/fnc_nameChannels.sqf
@@ -29,6 +29,7 @@ FUNC(_channelNamesForPresets) = {
                 {
                     _x params ["_radioClass", "_presetName"];
 
+                    // Filter out preset channel if greater than supported channel (eg. ACRE_PRC77 only has 2 presets)
                     private _presetData = [_radioClass, _presetName] call EFUNC(sys_data,getPresetData);
                     if (!isNil "_presetData" && {count HASH_GET(_presetData,"channels") >= _channelNumber}) then {
                         // Example: ["ACRE_PRC117F", "default3", 10, "label", "SUPPORT"]

--- a/addons/api/fnc_setPresetChannelField.sqf
+++ b/addons/api/fnc_setPresetChannelField.sqf
@@ -2,6 +2,7 @@
  * Author: ACRE2Team
  * Sets the value of a given channel field for the given radio preset.
  * This function must be called on all clients and the server to work properly.
+ * Will only assign as many presets as the radio can take (eg. AN/PRC-77 only has 2).
  *
  * Arguments:
  * 0: Radio Base class <STRING>
@@ -51,23 +52,29 @@ if (_channelReference isEqualType []) then {
 
 // The API takes channel numbers as 1-
 _channelNumber = _channelNumber - 1;
-TRACE_1("", _channelNumber);
+TRACE_1("",_channelNumber);
 
 //_channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
 private _presetData = [_radioClass, _presetName] call EFUNC(sys_data,getPresetData);
 if (isNil "_presetData") exitWith {false};
 TRACE_1("", _presetData);
 
-private _channels = HASH_GET(_presetData, "channels");
-TRACE_1("", _channels);
+private _channels = HASH_GET(_presetData,"channels");
+TRACE_1("",_channels);
 
-private _channel = HASHLIST_SELECT(_channels, _channelNumber);
-TRACE_1("", _channel);
+// Exit if we ran out of available presets on the given radio
+if (count _channels < _channelNumber) exitWith {
+    TRACE_3("ran out of presets",_radioClass,count _channels,_channelNumber);
+    false
+};
+
+private _channel = HASHLIST_SELECT(_channels,_channelNumber);
+TRACE_1("",_channel);
 
 private _newFieldName = [_radioClass, _fieldName] call FUNC(mapChannelFieldName);
-TRACE_2("", _channel, _newFieldName);
+TRACE_2("",_channel,_newFieldName);
 
-if (!HASH_HASKEY(_channel, _newFieldName)) exitWith { false };
-HASH_SET(_channel, _newFieldName, _value);
+if (!HASH_HASKEY(_channel,_newFieldName)) exitWith { false };
+HASH_SET(_channel,_newFieldName,_value);
 
 true

--- a/addons/api/fnc_setPresetChannelField.sqf
+++ b/addons/api/fnc_setPresetChannelField.sqf
@@ -2,7 +2,6 @@
  * Author: ACRE2Team
  * Sets the value of a given channel field for the given radio preset.
  * This function must be called on all clients and the server to work properly.
- * Will only assign as many presets as the radio can take (eg. AN/PRC-77 only has 2).
  *
  * Arguments:
  * 0: Radio Base class <STRING>
@@ -64,7 +63,7 @@ TRACE_1("",_channels);
 
 // Exit if we ran out of available presets on the given radio
 if (count _channels < _channelNumber) exitWith {
-    TRACE_3("ran out of presets",_radioClass,count _channels,_channelNumber);
+    WARNING_3("Attempted to set channel preset field for a non-existent radio channel %1 for %2 (max %3)!",_channelNumber,_radioClass,count _channels);
     false
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #412 (regression in #392)
- Remove spaces in macros in `acre_api_fnc_setPresetChannelField` (not the cause, but to be safe)