### PR TITLE
External radio fixes

### DIFF
--- a/addons/sys_external/CfgEventHandlers.hpp
+++ b/addons/sys_external/CfgEventHandlers.hpp
@@ -15,3 +15,9 @@ class Extended_PostInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_postInit););
     };
 };
+
+class Extended_Killed_EventHandlers {
+    class Man {
+        ADDON = QUOTE(_this call FUNC(onPlayerKilled));
+    };
+}

--- a/addons/sys_external/XEH_PREP.hpp
+++ b/addons/sys_external/XEH_PREP.hpp
@@ -8,6 +8,7 @@ PREP(initRadio);
 PREP(isExternalRadioAvailable);
 PREP(isExternalRadioUsed);
 PREP(isRadioShared);
+PREP(onPlayerKilled);
 PREP(startUsingExternalRadio);
 PREP(stopUsingExternalRadio);
 

--- a/addons/sys_external/fnc_externalRadioPFH.sqf
+++ b/addons/sys_external/fnc_externalRadioPFH.sqf
@@ -4,9 +4,9 @@
  *
  * - Disabled uses of external radios are:
  *   - Radio is in players inventory.
- *   - Player is dead. External radios are returned to the original owner.
  *   - Distance between owner and end user is greater than 2m.
  *   - Owner and end user are not in the same vehicle.
+ *   - Death of player is handled in fnc_onPlayerKilled.sqf.
  * - Radios in dead or captive units can always be accessed by other players.
  *
  * Arguments:
@@ -36,11 +36,5 @@ if (alive acre_player) then {
         if ((_x in _radios) || !_isExternalRadioAvailable) then {
             [_x, _owner] call FUNC(stopUsingExternalRadio);
         };
-    } forEach ACRE_ACTIVE_EXTERNAL_RADIOS;
-} else {
-    // All external radios in use are now returned to the owner.
-    {
-        private _owner = [_x] call FUNC(getExternalRadioOwner);
-        [_x, _owner] call FUNC(stopUsingExternalRadio);
     } forEach ACRE_ACTIVE_EXTERNAL_RADIOS;
 };

--- a/addons/sys_external/fnc_onPlayerKilled.sqf
+++ b/addons/sys_external/fnc_onPlayerKilled.sqf
@@ -18,7 +18,7 @@
 params ["_unit"];
 
 if (_unit == acre_player) then {
-    // All external radios in use are now returned to the owner.
+    // All external radios in use are now returned to the owner
     {
         private _owner = [_x] call FUNC(getExternalRadioOwner);
         [_x, _owner] call FUNC(stopUsingExternalRadio);

--- a/addons/sys_external/fnc_onPlayerKilled.sqf
+++ b/addons/sys_external/fnc_onPlayerKilled.sqf
@@ -1,0 +1,28 @@
+/*
+ * Author: ACRE2Team
+ * Handles death of unit, primarily for handling local player death. External radios are returned to the original owner.
+ *
+ * Arguments:
+ * 0: Unit <OBJECT>
+ *
+ * Return Value:
+ * Handled <BOOL>
+ *
+ * Example:
+ * [player] call acre_sys_external_fnc_onPlayerKilled
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit"];
+
+if (_unit == acre_player) then {
+    // All external radios in use are now returned to the owner.
+    {
+        private _owner = [_x] call FUNC(getExternalRadioOwner);
+        [_x, _owner] call FUNC(stopUsingExternalRadio);
+    } forEach ACRE_ACTIVE_EXTERNAL_RADIOS;
+};
+
+true

--- a/addons/sys_prc117f/fnc_closeGui.sqf
+++ b/addons/sys_prc117f/fnc_closeGui.sqf
@@ -19,7 +19,8 @@
 TRACE_1("", _this);
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, false] call EFUNC(sys_radio,setRadioOpenState);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc117f/fnc_openGui.sqf
+++ b/addons/sys_prc117f/fnc_openGui.sqf
@@ -27,7 +27,7 @@ GVAR(currentRadioId) = _radioId;
 createDialog "Prc117f_RadioDialog";
 [] call FUNC(clearDisplay);
 
-[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, true] call EFUNC(sys_radio,setRadioOpenState);
 
 
 private _onState = [GVAR(currentRadioId), "getOnOffState"] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_prc148/fnc_closeGui.sqf
+++ b/addons/sys_prc148/fnc_closeGui.sqf
@@ -17,7 +17,8 @@
 #include "script_component.hpp"
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, false] call EFUNC(sys_radio,setRadioOpenState);
 
 [GVAR(PFHId)] call CBA_fnc_removePerFrameHandler;
 GVAR(currentRadioId) = nil;

--- a/addons/sys_prc148/fnc_openGui.sqf
+++ b/addons/sys_prc148/fnc_openGui.sqf
@@ -24,7 +24,8 @@ if (!([_radioId] call EFUNC(sys_radio,canOpenRadio))) exitWith { false };
 disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC148_RadioDialog";
-[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, true] call EFUNC(sys_radio,setRadioOpenState);
 
 GVAR(PFHId) = ADDPFH(DFUNC(PFH), 0.33, []);
 

--- a/addons/sys_prc152/fnc_closeGui.sqf
+++ b/addons/sys_prc152/fnc_closeGui.sqf
@@ -19,7 +19,8 @@
 TRACE_1("", _this);
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, false] call EFUNC(sys_radio,setRadioOpenState);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc152/fnc_openGui.sqf
+++ b/addons/sys_prc152/fnc_openGui.sqf
@@ -26,7 +26,8 @@ disableSerialization;
 
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC152_RadioDialog";
-[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, true] call EFUNC(sys_radio,setRadioOpenState);
 
 private _onState = [GVAR(currentRadioId), "getOnOffState"] call EFUNC(sys_data,dataEvent);
 

--- a/addons/sys_prc343/radio/fnc_closeGui.sqf
+++ b/addons/sys_prc343/radio/fnc_closeGui.sqf
@@ -20,7 +20,8 @@
 #include "script_component.hpp"
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, false] call EFUNC(sys_radio,setRadioOpenState);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_prc343/radio/fnc_openGui.sqf
+++ b/addons/sys_prc343/radio/fnc_openGui.sqf
@@ -30,6 +30,7 @@ if (!([_radioId] call EFUNC(sys_radio,canOpenRadio))) exitWith { false };
 disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC343_RadioDialog";
-[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, true] call EFUNC(sys_radio,setRadioOpenState);
 
 true

--- a/addons/sys_prc77/radio/fnc_closeGui.sqf
+++ b/addons/sys_prc77/radio/fnc_closeGui.sqf
@@ -22,7 +22,8 @@
 TRACE_1("", _this);
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, false] call EFUNC(sys_radio,setRadioOpenState);
 
 GVAR(currentRadioId) = nil;
 

--- a/addons/sys_prc77/radio/fnc_openGui.sqf
+++ b/addons/sys_prc77/radio/fnc_openGui.sqf
@@ -26,6 +26,6 @@ disableSerialization;
 GVAR(currentRadioId) = _radioId;
 createDialog "PRC77_RadioDialog";
 
-[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, true] call EFUNC(sys_radio,setRadioOpenState);
 
 true

--- a/addons/sys_radio/XEH_PREP.hpp
+++ b/addons/sys_radio/XEH_PREP.hpp
@@ -14,6 +14,7 @@ PREP(setRadioVolume);
 PREP(isUniqueRadio);
 PREP(isBaseClassRadio);
 
+PREP(setRadioOpenState);
 PREP(setRadioSpatial);
 PREP(getRadioSpatial);
 

--- a/addons/sys_radio/XEH_postInit.sqf
+++ b/addons/sys_radio/XEH_postInit.sqf
@@ -1,14 +1,14 @@
 #include "script_component.hpp"
 
 if (isServer) then {
-    // Close the radio if it was opened in case of disconnection in order to prevend dead lock state
+    // Close the radio if it was opened in case of disconnection in order to prevent dead lock state
     GVAR(playerDisconnected) = addMissionEventHandler ["HandleDisconnected", {
         /*
          * Arguments:
          * 0: Disconnected unit <OBJECT>
          * 1: Unique DirectPlay ID <NUMBER>
          * 2: Steam ID of the leaving player <NUMBER>
-         * 3: profile name of the leaving player <STRING>
+         * 3: Profile name of the leaving player <STRING>
          */
         params ["_unit", "", "", ""];
         {

--- a/addons/sys_radio/XEH_postInit.sqf
+++ b/addons/sys_radio/XEH_postInit.sqf
@@ -5,7 +5,11 @@ if (isServer) then {
     GVAR(playerDisconnected) = addMissionEventHandler ["HandleDisconnected", {
         params ["_unit", "", "", ""];
         {
-            [_x, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+            if ([_x, "getState", "radioGuiOpened"] call EFUNC(sys_data,dataEvent)) then {
+                [_x, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+                [QEGVAR(sys_server,openRadioUpdate), [_x, false, _unit]] call CBA_fnc_localEvent;
+            };
         } forEach (_unit getVariable [QEGVAR(sys_data,radioIdList), []]);
     }];
 };

--- a/addons/sys_radio/XEH_postInit.sqf
+++ b/addons/sys_radio/XEH_postInit.sqf
@@ -3,6 +3,13 @@
 if (isServer) then {
     // Close the radio if it was opened in case of disconnection in order to prevend dead lock state
     GVAR(playerDisconnected) = addMissionEventHandler ["HandleDisconnected", {
+        /*
+         * Arguments:
+         * 0: Disconnected unit <OBJECT>
+         * 1: Unique DirectPlay ID <NUMBER>
+         * 2: Steam ID of the leaving player <NUMBER>
+         * 3: profile name of the leaving player <STRING>
+         */
         params ["_unit", "", "", ""];
         {
             if ([_x, "getState", "radioGuiOpened"] call EFUNC(sys_data,dataEvent)) then {

--- a/addons/sys_radio/XEH_postInit.sqf
+++ b/addons/sys_radio/XEH_postInit.sqf
@@ -1,5 +1,15 @@
 #include "script_component.hpp"
 
+if (isServer) then {
+    // Close the radio if it was opened in case of disconnection in order to prevend dead lock state
+    GVAR(playerDisconnected) = addMissionEventHandler ["HandleDisconnected", {
+        params ["_unit", "", "", ""];
+        {
+            [_x, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+        } forEach (_unit getVariable [QEGVAR(sys_data,radioIdList), []]);
+    }];
+};
+
 if (!hasInterface) exitWith {};
 
 // radio claiming handler

--- a/addons/sys_radio/fnc_canOpenRadio.sqf
+++ b/addons/sys_radio/fnc_canOpenRadio.sqf
@@ -51,7 +51,7 @@ if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS || {_radioId in ACRE_ACTIVE_EXTERNAL
         /* Check if in the server, there is a radio registered as opened. This is done in order to prevent race conditions when two players try to
          * simultaneously open a radio. We do not want fights because of ACRE2.
          */
-         [QEGVAR(sys_server,openRadioCheck), [_radioId, owner acre_player]] call CBA_fnc_serverEvent;
+         [QEGVAR(sys_server,openRadioCheck), [_radioId, acre_player]] call CBA_fnc_serverEvent;
     };
 };
 

--- a/addons/sys_radio/fnc_canOpenRadio.sqf
+++ b/addons/sys_radio/fnc_canOpenRadio.sqf
@@ -27,7 +27,10 @@ if (_vehicle != acre_player) then {
     };
 };
 
-if ((_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS && !([_radioId] call FUNC(isManpackRadio))) || _radioId in ACRE_HEARABLE_RACK_RADIOS) then {
+/*
+ * Logic: racked radios in intercom or personal radios from another user (handset or headset) cannot be opened.
+ */
+if (_radioId in ACRE_HEARABLE_RACK_RADIOS || {_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS && !([_radioId] call FUNC(isManpackRadio))}) then {
     _canOpenRadio = false;
     if (_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS) then {
         [localize LSTRING(noGuiExternal), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
@@ -36,9 +39,20 @@ if ((_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS && !([_radioId] call FUNC(isManpack
     };
 };
 
-if ([_radioId, "getState", "radioGuiOpened"] call EFUNC(sys_data,dataEvent)) then {
-    _canOpenRadio = false;
-    [localize LSTRING(alreadyOpenRadio), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+/* Logic:
+ * Radios that can be opened simultaneously by different players are accessible rack radios (ACRE_ACCESSIBLE_RACK_RADIOS), externally used manpack radios
+ * (ACRE_ACTIVE_EXTERNAL_RADIOS) and owned manpack radios that are being shared (ACRE_EXTERNALLY_USED_MANPACK_RADIOS)
+ */
+if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS || {_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS} || {_radioId in ACRE_EXTERNALLY_USED_MANPACK_RADIOS}) then {
+    if ([_radioId, "getState", "radioGuiOpened"] call EFUNC(sys_data,dataEvent)) then {
+        _canOpenRadio = false;
+        [localize LSTRING(alreadyOpenRadio), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+    } else {
+        /* Check if in the server, there is a radio registered as opened. This is done in order to prevent race conditions when two players try to
+         * simultaneously open a radio. We do not want fights because of ACRE2.
+         */
+         [QEGVAR(sys_server,openRadioCheck), [_radioId, owner acre_player]] call CBA_fnc_serverEvent;
+    };
 };
 
 if (!_canOpenRadio) then {

--- a/addons/sys_radio/fnc_monitorRadios.sqf
+++ b/addons/sys_radio/fnc_monitorRadios.sqf
@@ -102,8 +102,12 @@ DFUNC(monitorRadios_PFH) = {
                 acre_player assignItem "ItemRadioAcreFlagged";
             };
         } forEach _dif;
+
+        // Update the radio list
+        acre_player setVariable [QEGVAR(sys_data,radioIdList), _currentUniqueItems, true];
     };
     GVAR(oldUniqueItemList) = _currentUniqueItems;
+
     // if (!("ItemRadioAcreFlagged" in (assignedItems acre_player))) then { acre_player assignItem "ItemRadioAcreFlagged" };
 
 };

--- a/addons/sys_radio/fnc_onPlayerKilled.sqf
+++ b/addons/sys_radio/fnc_onPlayerKilled.sqf
@@ -23,6 +23,9 @@ if ((_this select 0) == acre_player) then {
     {
         private _radioName = _x;
         acre_player setVariable [_radioName, nil, false];
+
+        // Make sure the GUI state is closed so that other players can open the radio
+        [_radioName, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
     } foreach GVAR(currentRadioList);
     GVAR(currentRadioList) = [];
 

--- a/addons/sys_radio/fnc_onPlayerKilled.sqf
+++ b/addons/sys_radio/fnc_onPlayerKilled.sqf
@@ -24,7 +24,7 @@ if ((_this select 0) == acre_player) then {
         acre_player setVariable [_radioName, nil, false];
 
         // Make sure the GUI state is closed so that other players can open the radio
-        [_radioName, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+        [_radioName, false] call FUNC(setRadioOpenState);
     } foreach GVAR(currentRadioList);
     GVAR(currentRadioList) = [];
 

--- a/addons/sys_radio/fnc_onPlayerKilled.sqf
+++ b/addons/sys_radio/fnc_onPlayerKilled.sqf
@@ -1,16 +1,15 @@
 /*
  * Author: ACRE2Team
- * SHORT DESCRIPTION
+ * Handles death of unit, primarily for handling local player death.
  *
  * Arguments:
- * 0: ARGUMENT ONE <TYPE>
- * 1: ARGUMENT TWO <TYPE>
+ * 0: Unit <OBJECT>
  *
  * Return Value:
- * RETURN VALUE <TYPE>
+ * Handled <BOOL>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [player] call acre_sys_radio_fnc_onPlayerKilled
  *
  * Public: No
  */

--- a/addons/sys_radio/fnc_setRadioOpenState.sqf
+++ b/addons/sys_radio/fnc_setRadioOpenState.sqf
@@ -20,7 +20,7 @@ params ["_radioId", "_isRadioOpen"];
 
 [_radioId, "setState", ["radioGuiOpened", _isRadioOpen]] call EFUNC(sys_data,dataEvent);
 
-// In case of external radios or accessible racked radios, update the status on the server as well.
+// In case of external radios or accessible racked radios, update the status on the server as well
 if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS || {_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS} || {_radioId in ACRE_EXTERNALLY_USED_MANPACK_RADIOS}) then {
     [QEGVAR(sys_server,openRadioUpdate), [_radioId, _isRadioOpen, acre_player]] call CBA_fnc_serverEvent;
 };

--- a/addons/sys_radio/fnc_setRadioOpenState.sqf
+++ b/addons/sys_radio/fnc_setRadioOpenState.sqf
@@ -1,0 +1,26 @@
+/*
+ * Author: ACRE2Team
+ * Handle radio GUI opened/closed state.
+ *
+ * Arguments:
+ * 0: Unique radio ID <STRING>
+ * 1: Radio open state <BOOL>
+ *
+ * Return Value:
+ * Can open radio <BOOL>
+ *
+ * Example:
+ * ["acre_prc152_id_1", false] call acre_sys_radio_fnc_setRadioOpenState
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_radioId", "_isRadioOpen"];
+
+[_radioId, "setState", ["radioGuiOpened", _isRadioOpen]] call EFUNC(sys_data,dataEvent);
+
+// In case of external radios or accessible racked radios, update the status on the server as well.
+if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS || {_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS} || {_radioId in ACRE_EXTERNALLY_USED_MANPACK_RADIOS}) then {
+    [QEGVAR(sys_server,openRadioUpdate), [_radioId, _isRadioOpen, owner acre_player]] call CBA_fnc_serverEvent;
+};

--- a/addons/sys_radio/fnc_setRadioOpenState.sqf
+++ b/addons/sys_radio/fnc_setRadioOpenState.sqf
@@ -22,5 +22,5 @@ params ["_radioId", "_isRadioOpen"];
 
 // In case of external radios or accessible racked radios, update the status on the server as well.
 if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS || {_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS} || {_radioId in ACRE_EXTERNALLY_USED_MANPACK_RADIOS}) then {
-    [QEGVAR(sys_server,openRadioUpdate), [_radioId, _isRadioOpen, owner acre_player]] call CBA_fnc_serverEvent;
+    [QEGVAR(sys_server,openRadioUpdate), [_radioId, _isRadioOpen, acre_player]] call CBA_fnc_serverEvent;
 };

--- a/addons/sys_radio/stringtable.xml
+++ b/addons/sys_radio/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACRE">
     <Package name="sys_radio">
         <Key ID="STR_ACRE_sys_radio_radioSupplyCrate">
@@ -64,6 +64,9 @@
             <Chinese>無線電正在被另一名玩家進行設置。</Chinese>
             <Chinesesimp>无线电正在被另一名玩家进行设置。</Chinesesimp>
             <Korean>다른 플레이어가 무전기를 설정중입니다.</Korean>
+        </Key>
+        <Key ID="STR_ACRE_sys_radio_radioJustOpened">
+            <English>Somebody beat you when trying to configure the radio and you respectfully step away.</English>
         </Key>
     </Package>
 </Project>

--- a/addons/sys_radio/stringtable.xml
+++ b/addons/sys_radio/stringtable.xml
@@ -65,8 +65,5 @@
             <Chinesesimp>无线电正在被另一名玩家进行设置。</Chinesesimp>
             <Korean>다른 플레이어가 무전기를 설정중입니다.</Korean>
         </Key>
-        <Key ID="STR_ACRE_sys_radio_radioJustOpened">
-            <English>Somebody beat you when trying to configure the radio and you respectfully step away.</English>
-        </Key>
     </Package>
 </Project>

--- a/addons/sys_sem52sl/radio/fnc_closeGui.sqf
+++ b/addons/sys_sem52sl/radio/fnc_closeGui.sqf
@@ -38,7 +38,8 @@
 */
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, false] call EFUNC(sys_radio,setRadioOpenState);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_sem52sl/radio/fnc_openGui.sqf
+++ b/addons/sys_sem52sl/radio/fnc_openGui.sqf
@@ -53,7 +53,8 @@ if (([GVAR(currentRadioId), "getState", "channelKnobPosition"] call EFUNC(sys_da
 };
 GVAR(lastAction) = time;
 createDialog "SEM52SL_RadioDialog";
-[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, true] call EFUNC(sys_radio,setRadioOpenState);
 
 // Use this to turn off the backlight display//also to save last channel
 

--- a/addons/sys_sem70/radio/fnc_closeGui.sqf
+++ b/addons/sys_sem70/radio/fnc_closeGui.sqf
@@ -38,7 +38,8 @@
 */
 
 params ["_radioId", "", "", "", ""];
-[_radioId, "setState", ["radioGuiOpened", false]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, false] call EFUNC(sys_radio,setRadioOpenState);
 
 GVAR(currentRadioId) = -1;
 

--- a/addons/sys_sem70/radio/fnc_openGui.sqf
+++ b/addons/sys_sem70/radio/fnc_openGui.sqf
@@ -48,7 +48,8 @@ disableSerialization;
 GVAR(currentRadioId) = _radioId;
 GVAR(lastAction) = time;
 createDialog "SEM70_RadioDialog";
-[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+
+[_radioId, true] call EFUNC(sys_radio,setRadioOpenState);
 
 TRACE_2("OpenGui",GVAR(currentRadioId),GVAR(lastAction));
 

--- a/addons/sys_sem70/radio/fnc_openGui.sqf
+++ b/addons/sys_sem70/radio/fnc_openGui.sqf
@@ -48,7 +48,7 @@ disableSerialization;
 GVAR(currentRadioId) = _radioId;
 GVAR(lastAction) = time;
 createDialog "SEM70_RadioDialog";
-[_radioId, "setState", ["isGuiOpened", true]] call EFUNC(sys_data,dataEvent);
+[_radioId, "setState", ["radioGuiOpened", true]] call EFUNC(sys_data,dataEvent);
 
 TRACE_2("OpenGui",GVAR(currentRadioId),GVAR(lastAction));
 

--- a/addons/sys_server/XEH_PREPClient.hpp
+++ b/addons/sys_server/XEH_PREPClient.hpp
@@ -1,3 +1,4 @@
+PREP(openRadioCheckResult);
 PREP(addComponentCargo);
 PREP(clientGCRadio);
 PREP(updateIdObjects);

--- a/addons/sys_server/XEH_PREPServer.hpp
+++ b/addons/sys_server/XEH_PREPServer.hpp
@@ -1,3 +1,5 @@
+PREP(openRadioCheckRequest);
+PREP(openRadioUpdateState);
 PREP(doAddComponentCargo);
 PREP(getRadioId);
 PREP(setSpectator);

--- a/addons/sys_server/XEH_postInitClient.sqf
+++ b/addons/sys_server/XEH_postInitClient.sqf
@@ -6,3 +6,5 @@ if (!hasInterface) exitWith {};
 ["acre_updateIdObjects", { _this call FUNC(updateIdObjects) }] call CALLSTACK(CBA_fnc_addEventHandler);
 
 [QGVAR(intentToGarbageCollect), { _this call FUNC(clientIntentToGarbageCollect) }] call CALLSTACK(CBA_fnc_addEventHandler);
+
+[QGVAR(openRadioCheckResult), { _this call FUNC(openRadioCheckResult) }] call CALLSTACK(CBA_fnc_addEventHandler);

--- a/addons/sys_server/XEH_postInitServer.sqf
+++ b/addons/sys_server/XEH_postInitServer.sqf
@@ -14,6 +14,9 @@ ACRE_SERVER_INIT = true;
 [QGVAR(onSetSpector), { _this call FUNC(setSpectator) }] call CALLSTACK(CBA_fnc_addEventHandler);
 [QGVAR(doAddComponentCargo), { _this call FUNC(doAddComponentCargo) }] call CALLSTACK(CBA_fnc_addEventHandler);
 
+[QGVAR(openRadioCheck), {_this call FUNC(openRadioCheckRequest)}] call CALLSTACK(CBA_fnc_addEventHandler);
+[QGVAR(openRadioUpdate), {_this call FUNC(openRadioUpdateState)}] call CALLSTACK(CBA_fnc_addEventHandler);
+
 publicVariable "ACRE_SERVER_INIT";
 
 ACRE_FULL_SERVER_VERSION = QUOTE(VERSION);

--- a/addons/sys_server/XEH_preInitServer.sqf
+++ b/addons/sys_server/XEH_preInitServer.sqf
@@ -22,5 +22,7 @@ GVAR(nextSearchTime) = diag_tickTime + 5;
 GVAR(unacknowledgedIds) = [];
 GVAR(unacknowledgedTable) = HASH_CREATE;
 
+GVAR(radioOpenedBy) = HASH_CREATE;
+
 ADDON = true;
 

--- a/addons/sys_server/fnc_openRadioCheckRequest.sqf
+++ b/addons/sys_server/fnc_openRadioCheckRequest.sqf
@@ -19,7 +19,7 @@
 params ["_radioId", "_unit"];
 
 // Check first if the radio is opened by somebody else
-private _radioOpenedBy = missionNamespace getVariable [_radioId, objNull];
+private _radioOpenedBy = HASH_GET(GVAR(radioOpenedBy),_radioId);
 
 if (isNull _radioOpenedBy) then {
     _radioOpenedBy = _unit;

--- a/addons/sys_server/fnc_openRadioCheckRequest.sqf
+++ b/addons/sys_server/fnc_openRadioCheckRequest.sqf
@@ -3,27 +3,26 @@
  * Handles the request of a client checking if a radio is opened.
  *
  * Arguments:
- * 0: radio to check <STRING>
- * 1: Client ID <NUMBER>
+ * 0: Radio to check <STRING>
+ * 1: Unit <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * ["acre_prc152_id_1", 1] call acre_sys_server_fnc_openRadioCheckRequest
+ * ["acre_prc152_id_1", acre_player] call acre_sys_server_fnc_openRadioCheckRequest
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_radioId", "_clientId"];
+params ["_radioId", "_unit"];
 
-private "_radioOpenedBy";
-call compile format ["_radioOpenedBy = %1", _radioId];
+// Check first if the radio is opened by somebody else
+private _radioOpenedBy = missionNamespace getVariable [_radioId, objNull];
 
-// A -1 is also returned if the radio is not opened by anybody
-if (isNil "_radioOpenedBy" || {_radioOpenedBy == RADIO_IS_NOT_OPENED}) then {
-    _radioOpenedBy = clientId;
+if (isNull _radioOpenedBy) then {
+    _radioOpenedBy = _unit;
 };
 
-[QGVAR(openRadioCheckResult), [_radioId, _radioOpenedBy], _clientId] call CBA_fnc_ownerEvent;
+[QGVAR(openRadioCheckResult), [_radioId, _radioOpenedBy], _unit] call CBA_fnc_targetEvent;

--- a/addons/sys_server/fnc_openRadioCheckRequest.sqf
+++ b/addons/sys_server/fnc_openRadioCheckRequest.sqf
@@ -1,0 +1,29 @@
+/*
+ * Author: ACRE2Team
+ * Handles the request of a client checking if a radio is opened.
+ *
+ * Arguments:
+ * 0: radio to check <STRING>
+ * 1: Client ID <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["acre_prc152_id_1", 1] call acre_sys_server_fnc_openRadioCheckRequest
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_radioId", "_clientId"];
+
+private "_radioOpenedBy";
+call compile format ["_radioOpenedBy = %1", _radioId];
+
+// A -1 is also returned if the radio is not opened by anybody
+if (isNil "_radioOpenedBy" || {_radioOpenedBy == RADIO_IS_NOT_OPENED}) then {
+    _radioOpenedBy = clientId;
+};
+
+[QGVAR(openRadioCheckResult), [_radioId, _radioOpenedBy], _clientId] call CBA_fnc_ownerEvent;

--- a/addons/sys_server/fnc_openRadioCheckResult.sqf
+++ b/addons/sys_server/fnc_openRadioCheckResult.sqf
@@ -3,14 +3,14 @@
  * Handles the result of checking if a radio is opened.
  *
  * Arguments:
- * 0: radio to check <STRING>
- * 1: client Id with opened radio <NUMBER>
+ * 0: Radio to check <STRING>
+ * 1: Unit <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * ["acre_prc152_id_1", 2] call acre_sys_server_fnc_openRadioCheckResult
+ * ["acre_prc152_id_1", acre_player] call acre_sys_server_fnc_openRadioCheckResult
  *
  * Public: No
  */
@@ -18,7 +18,7 @@
 
 params ["_radioId", "_radioOpenedBy"];
 
-if (_radioOpenedBy != owner acre_player) then {
+if (_radioOpenedBy != acre_player) then {
     [_radioId, "closeGui"] call EFUNC(sys_data,interactEvent);
     [localize ELSTRING(sys_radio,radioJustOpened), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
 };

--- a/addons/sys_server/fnc_openRadioCheckResult.sqf
+++ b/addons/sys_server/fnc_openRadioCheckResult.sqf
@@ -20,5 +20,5 @@ params ["_radioId", "_radioOpenedBy"];
 
 if (_radioOpenedBy != acre_player) then {
     [_radioId, "closeGui"] call EFUNC(sys_data,interactEvent);
-    [localize ELSTRING(sys_radio,radioJustOpened), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+    [localize ELSTRING(sys_radio,alreadyOpenRadio), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
 };

--- a/addons/sys_server/fnc_openRadioCheckResult.sqf
+++ b/addons/sys_server/fnc_openRadioCheckResult.sqf
@@ -1,0 +1,24 @@
+/*
+ * Author: ACRE2Team
+ * Handles the result of checking if a radio is opened.
+ *
+ * Arguments:
+ * 0: radio to check <STRING>
+ * 1: client Id with opened radio <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["acre_prc152_id_1", 2] call acre_sys_server_fnc_openRadioCheckResult
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_radioId", "_radioOpenedBy"];
+
+if (_radioOpenedBy != owner acre_player) then {
+    [_radioId, "closeGui"] call EFUNC(sys_data,interactEvent);
+    [localize ELSTRING(sys_radio,radioJustOpened), ICON_RADIO_CALL] call EFUNC(sys_core,displayNotification);
+};

--- a/addons/sys_server/fnc_openRadioUpdateState.sqf
+++ b/addons/sys_server/fnc_openRadioUpdateState.sqf
@@ -28,5 +28,5 @@ if (isNull _radioOpenedBy || {_radioOpenedBy == _unit}) then {
     if (_radioIsOpened) then {
         _newState = _unit;
     };
-    missionNamespace setVariable [_radioId, _newState];
+    HASH_SET(GVAR(radioOpenedBy), _radioId, _newState);
 };

--- a/addons/sys_server/fnc_openRadioUpdateState.sqf
+++ b/addons/sys_server/fnc_openRadioUpdateState.sqf
@@ -1,0 +1,34 @@
+/*
+ * Author: ACRE2Team
+ * Updates the open radio state.
+ *
+ * Arguments:
+ * 0: radio to update <STRING>
+ * 1: radio opened state <BOOL>
+ * 2: client Id with opened radio <NUMBER>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * ["acre_prc152_id_1", false, 2] call acre_sys_server_fnc_openRadioUpdateState
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_radioId", "_radioIsOpened", "_clientId"];
+
+private _radioOpenedBy = RADIO_IS_NOT_OPENED;
+
+// Check first if the radio is opened by somebody else
+call compile format ["_radioOpenedBy = %1", _radioId];
+
+// If it does not exist or it has a value of -1, the value can be updated
+if (isNil "_radioOpenedBy" || {_radioOpenedBy == RADIO_IS_NOT_OPENED} || {_radioOpenedBy == _clientId}) then {
+    private _newState = RADIO_IS_NOT_OPENED;
+    if (_radioIsOpened) then {
+        _newState = _clientId;
+    };
+    call compile format ["%1 = %2", _radioId, _newState];
+};

--- a/addons/sys_server/fnc_openRadioUpdateState.sqf
+++ b/addons/sys_server/fnc_openRadioUpdateState.sqf
@@ -3,8 +3,8 @@
  * Updates the open radio state.
  *
  * Arguments:
- * 0: radio to update <STRING>
- * 1: radio opened state <BOOL>
+ * 0: Radio to update <STRING>
+ * 1: Radio opened state <BOOL>
  * 2: Unit <OBJECT>
  *
  * Return Value:

--- a/addons/sys_server/fnc_openRadioUpdateState.sqf
+++ b/addons/sys_server/fnc_openRadioUpdateState.sqf
@@ -28,5 +28,5 @@ if (isNull _radioOpenedBy || {_radioOpenedBy == _unit}) then {
     if (_radioIsOpened) then {
         _newState = _unit;
     };
-    HASH_SET(GVAR(radioOpenedBy), _radioId, _newState);
+    HASH_SET(GVAR(radioOpenedBy),_radioId,_newState);
 };

--- a/addons/sys_server/fnc_openRadioUpdateState.sqf
+++ b/addons/sys_server/fnc_openRadioUpdateState.sqf
@@ -5,30 +5,28 @@
  * Arguments:
  * 0: radio to update <STRING>
  * 1: radio opened state <BOOL>
- * 2: client Id with opened radio <NUMBER>
+ * 2: Unit <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * ["acre_prc152_id_1", false, 2] call acre_sys_server_fnc_openRadioUpdateState
+ * ["acre_prc152_id_1", false, acre_player] call acre_sys_server_fnc_openRadioUpdateState
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_radioId", "_radioIsOpened", "_clientId"];
-
-private _radioOpenedBy = RADIO_IS_NOT_OPENED;
+params ["_radioId", "_radioIsOpened", "_unit"];
 
 // Check first if the radio is opened by somebody else
-call compile format ["_radioOpenedBy = %1", _radioId];
+private _radioOpenedBy = missionNamespace getVariable [_radioId, objNull];
 
 // If it does not exist or it has a value of -1, the value can be updated
-if (isNil "_radioOpenedBy" || {_radioOpenedBy == RADIO_IS_NOT_OPENED} || {_radioOpenedBy == _clientId}) then {
-    private _newState = RADIO_IS_NOT_OPENED;
+if (isNull _radioOpenedBy || {_radioOpenedBy == _unit}) then {
+    private _newState = objNull;
     if (_radioIsOpened) then {
-        _newState = _clientId;
+        _newState = _unit;
     };
-    call compile format ["%1 = %2", _radioId, _newState];
+    missionNamespace setVariable [_radioId, _newState];
 };

--- a/addons/sys_server/script_component.hpp
+++ b/addons/sys_server/script_component.hpp
@@ -17,3 +17,4 @@
 #include "\idi\acre\addons\main\script_macros.hpp"
 
 #define MAX_RADIO 512
+#define RADIO_IS_NOT_OPENED -1

--- a/addons/sys_server/script_component.hpp
+++ b/addons/sys_server/script_component.hpp
@@ -17,4 +17,3 @@
 #include "\idi\acre\addons\main\script_macros.hpp"
 
 #define MAX_RADIO 512
-#define RADIO_IS_NOT_OPENED -1


### PR DESCRIPTION
**When merged this pull request will:**

- [x] Fixes deadlock if the player has the radio GUI opened and gets killed.
- [x] Fixes deadlock if player gets disconnected while having a radio GUI opened.
- [x] Fixes race condition when 2 players try to open a rack or shared  radio at the same time.
- [x] SEM70 radio GUI could not be locked.
- [x] handle the race condition when disconnecting.