### PR TITLE
Ensure metadata buffer is not overflown

### DIFF
--- a/extensions/src/ACRE2DistortionTestPlugin/TsCallbacks_static.cpp
+++ b/extensions/src/ACRE2DistortionTestPlugin/TsCallbacks_static.cpp
@@ -43,7 +43,8 @@ void ts3plugin_infoData(uint64 serverConnectionHandlerID, uint64 id, enum Plugin
                 if (!metaData) { 
                     noAcre = TRUE;
                 }
-                if (strlen(metaData) < 3) {
+                int metaDataLength = strlen(metaData);
+                if (metaDataLength < 3 || metaDataLength > (INFODATA_BUFSIZE - 2)) {
                     noAcre = TRUE;
                 }
                 *data = (char*)malloc(INFODATA_BUFSIZE * sizeof(char)); 

--- a/extensions/src/ACRE2TS/TsCallbacks_static.cpp
+++ b/extensions/src/ACRE2TS/TsCallbacks_static.cpp
@@ -45,7 +45,8 @@ void ts3plugin_infoData(uint64 serverConnectionHandlerID, uint64 id, enum Plugin
                 if (!metaData) { 
                     noAcre = TRUE;
                 }
-                if (strlen(metaData) < 3) {
+                int metaDataLength = strlen(metaData);
+                if (metaDataLength < 3 || metaDataLength > (INFODATA_BUFSIZE - 2)) {
                     noAcre = TRUE;
                 }
                 *data = (char*)malloc(INFODATA_BUFSIZE * sizeof(char)); 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #419 
- Teamspeak would crash if any teamspeak plugin would use a large string for the CLIENT MetaData.