### PR TITLE
Set all radios as lowercase in getGear

### DIFF
--- a/addons/sys_core/fnc_getGear.sqf
+++ b/addons/sys_core/fnc_getGear.sqf
@@ -15,18 +15,18 @@
  */
 #include "script_component.hpp"
 
- params ["_unit"];
+params ["_unit"];
 
- if (isNull _unit) exitWith {[]};
+if (isNull _unit) exitWith {[]};
 
- // diag_log text format["Assigned Items: %1", (assignedItems _unit)];
+// diag_log text format["Assigned Items: %1", (assignedItems _unit)];
 
- private _gear = (weapons _unit) + (items _unit) + (assignedItems _unit);
+private _gear = (weapons _unit) + (items _unit) + (assignedItems _unit);
 
- _gear = _gear select {(_x select [0, 4]) == "ACRE" || _x == "ItemRadio" || _x == "ItemRadioAcreFlagged"}; // We are only interested in ACRE gear.
- // The below is really slow and tends to worsen performance.
- //_gear = _gear select {(_x call EFUNC(api,getBaseRadio)) in (call EFUNC(api,getAllRadios) select 0) || {_x == "ItemRadio"} || {_x == "ItemRadioAcreFlagged"}};
+_gear = _gear select {(_x select [0, 4]) == "ACRE" || _x == "ItemRadio" || _x == "ItemRadioAcreFlagged"}; // We are only interested in ACRE gear.
+// The below is really slow and tends to worsen performance.
+//_gear = _gear select {(_x call EFUNC(api,getBaseRadio)) in (call EFUNC(api,getAllRadios) select 0) || {_x == "ItemRadio"} || {_x == "ItemRadioAcreFlagged"}};
 
 _gear = _gear apply {toLower _x};
 
- _gear;
+_gear;

--- a/addons/sys_core/fnc_getGear.sqf
+++ b/addons/sys_core/fnc_getGear.sqf
@@ -27,4 +27,6 @@
  // The below is really slow and tends to worsen performance.
  //_gear = _gear select {(_x call EFUNC(api,getBaseRadio)) in (call EFUNC(api,getAllRadios) select 0) || {_x == "ItemRadio"} || {_x == "ItemRadioAcreFlagged"}};
 
+_gear = _gear apply {toLower _x};
+
  _gear;


### PR DESCRIPTION
**When merged this pull request will:**
If radios are mixed upper/lowercase, it will destroy e.g. internal speakers. This will fix it.

Fixes #358 

We may need to cancel #348 