### PR TITLE
Hide volume slider on other dialog open, kill and unit change

### DIFF
--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -8,4 +8,9 @@ if (!hasInterface) exitWith {};
 acre_player addEventHandler ["Take", {call FUNC(handleTake)}];
 
 // Register volume control key handlers
-["ACRE2", "VolumeControl", (localize LSTRING(VolumeControl)), FUNC(onVolumeControlKeyPress), FUNC(onVolumeControlKeyPressUp), [15, [false, false, false]]] call cba_fnc_addKeybind;
+["ACRE2", "VolumeControl", localize LSTRING(VolumeControl),
+    FUNC(onVolumeControlKeyPress),
+    FUNC(onVolumeControlKeyPressUp),
+[15, [false, false, false]], true] call CBA_fnc_addKeybind;
+
+["unit", FUNC(onVolumeControlKeyPressUp)] call CBA_fnc_addPlayerEventHandler;

--- a/addons/sys_gui/fnc_onVolumeControlKeyPress.sqf
+++ b/addons/sys_gui/fnc_onVolumeControlKeyPress.sqf
@@ -16,7 +16,12 @@
  */
 #include "script_component.hpp"
 
-if (!(alive acre_player) || GVAR(keyBlock) || time < 1) exitWith { false };
+if (!alive acre_player || time < 1 || GVAR(keyBlock) || dialog) exitWith {
+    if (!alive acre_player || dialog) then {
+        call FUNC(onVolumeControlKeyPressUp);
+    };
+    false
+};
 
 inGameUISetEventHandler ["PrevAction", "true"];
 inGameUISetEventHandler ["NextAction", "true"];

--- a/addons/sys_gui/fnc_onVolumeControlKeyPress.sqf
+++ b/addons/sys_gui/fnc_onVolumeControlKeyPress.sqf
@@ -16,8 +16,8 @@
  */
 #include "script_component.hpp"
 
-if (!alive acre_player || time < 1 || GVAR(keyBlock) || dialog) exitWith {
-    if (!alive acre_player || dialog) then {
+if (!alive acre_player || time < 1 || GVAR(keyBlock) || dialog || ACRE_IS_SPECTATOR) exitWith {
+    if (!GVAR(keyBlock)) then {
         call FUNC(onVolumeControlKeyPressUp);
     };
     false

--- a/addons/sys_gui/fnc_onVolumeControlKeyPressUp.sqf
+++ b/addons/sys_gui/fnc_onVolumeControlKeyPressUp.sqf
@@ -16,15 +16,15 @@
  */
 #include "script_component.hpp"
 
-if (!(alive acre_player)) exitWith { false };
+if (!GVAR(keyBlock)) exitWith {false};
 
 inGameUISetEventHandler ["PrevAction", "false"];
 inGameUISetEventHandler ["NextAction", "false"];
 
+GVAR(keyBlock) = false;
 disableSerialization;
-GVAR(KeyBlock) = false;
+
 57701 cutRsc [QGVAR(VolumeControlDialog_Close), "PLAIN"];
 call FUNC(closeVolumeControl);
-
 
 false


### PR DESCRIPTION
**When merged this pull request will:**
- Hide volume slider when some other dialog is open
- Hide volume slider when killed
- Hide volume slider when changing unit (eg. respawn, remote control)
- Fix #290 

Slider will still be visible during respawn timer or pressing Escape (pause menu) while holding down Volume Slider keybind, not really that important. It solves bigger problem of staying open unexpectedly.