### PR TITLE
Add API to passthrough ACRE2 keys to custom displays

### DIFF
--- a/addons/api/CfgFunctions.hpp
+++ b/addons/api/CfgFunctions.hpp
@@ -5,6 +5,8 @@ class CfgFunctions {
 
             PATHTO_FNC(setupMission);
 
+            PATHTO_FNC(addDisplayPassthroughKeys);
+
             PATHTO_FNC(getMultiPushToTalkAssignment);
             PATHTO_FNC(setMultiPushToTalkAssignment);
 

--- a/addons/api/fnc_addDisplayPassthroughKeys.sqf
+++ b/addons/api/fnc_addDisplayPassthroughKeys.sqf
@@ -10,7 +10,7 @@
  * Successfully added passthrough key handling <BOOL>
  *
  * Example:
- * [display] call acre_api_fnc_addDisplayPassthroughKeys;
+ * [display] call acre_api_fnc_addDisplayPassthroughKeys
  *
  * Public: Yes
  */

--- a/addons/api/fnc_addDisplayPassthroughKeys.sqf
+++ b/addons/api/fnc_addDisplayPassthroughKeys.sqf
@@ -1,0 +1,21 @@
+/*
+ * Author: ACRE2Team
+ * Adds key handling compatibility to a custom display, which otherwise does not pass through CBA keybinds.
+ * Must be called after display has been loaded.
+ *
+ * Arguments:
+ * 0: Display <DISPLAY>
+ *
+ * Return Value:
+ * Successfully added passthrough key handling <BOOL>
+ *
+ * Example:
+ * [display] call acre_api_fnc_addDisplayPassthroughKeys;
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+if (!hasInterface) exitWith {};
+
+_this call EFUNC(sys_core,addDisplayPassthroughKeys);

--- a/addons/sys_core/CfgEventHandlers.hpp
+++ b/addons/sys_core/CfgEventHandlers.hpp
@@ -27,3 +27,9 @@ class Extended_DisplayLoad_EventHandlers {
         ADDON = QUOTE(_this call COMPILE_FILE(XEH_spectatorEGDisplayLoad));
     };
 };
+
+class Extended_DisplayUnload_EventHandlers {
+    class RscDisplayEGSpectator {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_spectatorEGDisplayUnload));
+    };
+};

--- a/addons/sys_core/CfgEventHandlers.hpp
+++ b/addons/sys_core/CfgEventHandlers.hpp
@@ -21,3 +21,9 @@ class Extended_Killed_EventHandlers {
         ADDON = QUOTE(_this call FUNC(onPlayerKilled));
     };
 };
+
+class Extended_DisplayLoad_EventHandlers {
+    class RscDisplayEGSpectator {
+        ADDON = QUOTE(_this call COMPILE_FILE(XEH_spectatorEGDisplayLoad));
+    };
+};

--- a/addons/sys_core/XEH_PREP.hpp
+++ b/addons/sys_core/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(addDisplayPassthroughKeys);
 PREP(addGear);
 PREP(addLanguageType);
 PREP(aliveMonitor);

--- a/addons/sys_core/XEH_spectatorEGDisplayLoad.sqf
+++ b/addons/sys_core/XEH_spectatorEGDisplayLoad.sqf
@@ -4,3 +4,5 @@ params ["_display"];
 
 // Key handling compatibility for Vanilla Spectator (EG Spectator)
 [_display] call FUNC(addDisplayPassthroughKeys);
+
+[] call FUNC(spectatorOn);

--- a/addons/sys_core/XEH_spectatorEGDisplayLoad.sqf
+++ b/addons/sys_core/XEH_spectatorEGDisplayLoad.sqf
@@ -1,0 +1,6 @@
+#include "script_component.hpp"
+
+params ["_display"];
+
+// Key handling compatibility for Vanilla Spectator (EG Spectator)
+[_display] call FUNC(addDisplayPassthroughKeys);

--- a/addons/sys_core/XEH_spectatorEGDisplayUnload.sqf
+++ b/addons/sys_core/XEH_spectatorEGDisplayUnload.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+[] call FUNC(spectatorOff);

--- a/addons/sys_core/fnc_addDisplayPassthroughKeys.sqf
+++ b/addons/sys_core/fnc_addDisplayPassthroughKeys.sqf
@@ -9,7 +9,7 @@
  * Successfully added passthrough key handling <BOOL>
  *
  * Example:
- * [display] call acre_core_fnc_addDisplayPassthroughKeys
+ * [display] call acre_sys_core_fnc_addDisplayPassthroughKeys
  *
  * Public: Yes
  */

--- a/addons/sys_core/fnc_addDisplayPassthroughKeys.sqf
+++ b/addons/sys_core/fnc_addDisplayPassthroughKeys.sqf
@@ -9,7 +9,7 @@
  * Successfully added passthrough key handling <BOOL>
  *
  * Example:
- * [display] call acre_core_fnc_addDisplayPassthroughKeys;
+ * [display] call acre_core_fnc_addDisplayPassthroughKeys
  *
  * Public: Yes
  */

--- a/addons/sys_core/fnc_addDisplayPassthroughKeys.sqf
+++ b/addons/sys_core/fnc_addDisplayPassthroughKeys.sqf
@@ -1,0 +1,31 @@
+/*
+ * Author: ACRE2Team
+ * Adds key handling compatibility to a custom display, which otherwise does not pass through CBA keybinds.
+ *
+ * Arguments:
+ * 0: Display <DISPLAY>
+ *
+ * Return Value:
+ * Successfully added passthrough key handling <BOOL>
+ *
+ * Example:
+ * [display] call acre_core_fnc_addDisplayPassthroughKeys;
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params ["_display"];
+
+if (isNull _display) exitWith {false};
+
+// Toggle Headset
+_display displayAddEventHandler ["KeyDown", {
+    params ["", "_key", "_shift", "_ctrl", "_alt"];
+    if ([_key, [_shift, _ctrl, _alt]] in ((["ACRE2", "HeadSet"] call CBA_fnc_getKeybind) select 8)) then {
+        [] call FUNC(toggleHeadset);
+    };
+    false
+}];
+
+true


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #372 - Assign keys to Vanilla Spectator (EG Spectator) display
- Toggle Spectator Mode when opening/closing Vanilla Spectator (EG Spectator)

Completely untested as of opening this!