### PR TITLE
Infantry phone fixes

### DIFF
--- a/addons/sys_intercom/fnc_configInfantryPhone.sqf
+++ b/addons/sys_intercom/fnc_configInfantryPhone.sqf
@@ -20,10 +20,10 @@ params ["_vehicle"];
 private _type = typeOf _vehicle;
 
 // Configure what intercom networks the infantry phone has access to
-private _infantryPhoneIntercom = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneIntercom");
-private _infantryPhoneControlActions = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneControlActions");
+private _infantryPhoneIntercom = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneIntercom") apply {toLower _x};
+private _infantryPhoneControlActions = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneControlActions") apply {toLower _x};
 private _infantryPhoneDisableRinging = (getNumber (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneDisableRinging")) == 1;
-private _infantryPhoneCustomRinging = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneCustomRinging");
+private _infantryPhoneCustomRinging = getArray (configFile >> "CfgVehicles" >> _type >> "acre_infantryPhoneCustomRinging") apply {toLower _x};
 
 // Set by default to have access to all intercom networks if none was specified
 

--- a/addons/sys_intercom/fnc_infantryPhoneAction.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneAction.sqf
@@ -76,10 +76,10 @@ private _infantryPhoneSpeakerAction = [
         private _intercomAvailable = false;
         // Find if at least one intercom is available
         {
-            if ([_target, acre_player, _forEachIndex] call FUNC(isInfantryPhoneSpeakerAvailable)) exitWith {true};
+            if ([_target, acre_player, _forEachIndex] call FUNC(isInfantryPhoneSpeakerAvailable)) exitWith {_intercomAvailable = true};
         } forEach _intercomNames;
         _intercomAvailable
-    },//{_this call FUNC(isInfantryPhoneSpeakerAvailable)},
+    },
     {_this call FUNC(infantryPhoneChildrenActions)},
     [],
     [0, 0, 0],

--- a/addons/sys_intercom/fnc_infantryPhoneChildrenActions.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneChildrenActions.sqf
@@ -70,13 +70,13 @@ if (_target isKindOf "CAManBase") then {
                     _forEachIndex
                 ] call ace_interact_menu_fnc_createAction;
                 _actions pushBack [_action, [], _target];
-            } forEach _intercomNames;
+            } forEach (_intercomNames select {_x in (_target getVariable [QGVAR(infantryPhoneIntercom), []])});
         } else {
             (_target getVariable [QGVAR(unitInfantryPhone), [acre_player, INTERCOM_DISCONNECTED]]) params ["_unitInfantryPhone", ""];
             if (_vehicleInfantryPhone == _target) then {
                 // Generate the action to return the infantry telephone
                 private _action = [
-                    format ["acre_return_infantryTelephone"],
+                    "acre_return_infantryTelephone",
                     format [localize LSTRING(returnInfantryPhone)],
                     "",
                     {
@@ -114,7 +114,7 @@ if (_target isKindOf "CAManBase") then {
                         [_forEachIndex, _infantryPhoneNetwork]
                     ] call ace_interact_menu_fnc_createAction;
                     _actions pushBack [_action, [], _target];
-                } forEach _intercomNames;
+                } forEach (_intercomNames select {_x in (_target getVariable [QGVAR(infantryPhoneIntercom), []])});
             };
         };
     } else {
@@ -138,20 +138,22 @@ if (_target isKindOf "CAManBase") then {
             _actions pushBack [_action, [], _target];
         } else {
             if (isNull _vehicleInfantryPhone && {!(_target getVariable [QGVAR(infPhoneDisableRinging), false])}) then {
-                private _action = [
-                    "acre_infantryTelephone_startCalling",
-                    localize LSTRING(infantryPhone_startCalling),
-                    "",
-                    {
-                         params ["_target", "_player", "_params"];
-                        _params params ["_intercomNetwork"];
+                {
+                    private _action = [
+                        format ["acre_infantryTelephone_startCalling_%1", _x],
+                        format [localize LSTRING(infantryPhone_startCalling), "(" + (_intercomDisplayNames select _forEachIndex) + ")"],
+                        "",
+                        {
+                             params ["_target", "_player", "_params"];
+                            _params params ["_intercomNetwork"];
 
-                        [_target, _intercomNetwork] call FUNC(infantryPhoneSoundCall)},
-                    {true},
-                    {},
-                    _isCalling select 1
-                ] call ace_interact_menu_fnc_createAction;
+                            [_target, _intercomNetwork] call FUNC(infantryPhoneSoundCall)},
+                        {true},
+                        {},
+                        _isCalling select 1
+                    ] call ace_interact_menu_fnc_createAction;
                 _actions pushBack [_action, [], _target];
+                } forEach (_intercomNames select {_x in (_target getVariable [QGVAR(infantryPhoneIntercom), []])});
             };
         };
     };

--- a/addons/sys_intercom/fnc_isInfantryPhoneSpeakerAvailable.sqf
+++ b/addons/sys_intercom/fnc_isInfantryPhoneSpeakerAvailable.sqf
@@ -24,5 +24,5 @@ if (!alive _unit) exitWith {false};
 private _intercomName = (_vehicle getVariable [QGVAR(intercomNames), []]) select _intercomNetwork;
 private _intercomControl = _vehicle getVariable [QGVAR(infantryPhoneControlActions), []];
 
-// For the moment only those in crew intercom are entitled to infantry phone actions
+// Only those intercoms with control capabilities have access to it
 [_vehicle, _unit, _intercomNetwork] call FUNC(isIntercomAvailable) && (_intercomName in _intercomControl)

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -56,15 +56,15 @@
             <Korean>보병 전화를 돌려놓기</Korean>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_infantryPhone_startCalling">
-            <English>Start calling</English>
-            <Spanish>Llamar al exterior</Spanish>
-            <German>Läuten</German>
-            <Japanese>呼び出す</Japanese>
-            <Russian>Начать звонок</Russian>
-            <Polish>Zadzwoń</Polish>
-            <Chinese>開始呼叫</Chinese>
-            <Chinesesimp>开始呼叫</Chinesesimp>
-            <Korean>전화 시작</Korean>
+            <English>Start calling %1</English>
+            <Spanish>Llamar al exterior %1</Spanish>
+            <German>Läuten %1</German>
+            <Japanese>呼び出す %1</Japanese>
+            <Russian>Начать звонок %1</Russian>
+            <Polish>Zadzwoń %1</Polish>
+            <Chinese>開始呼叫 %1</Chinese>
+            <Chinesesimp>开始呼叫 %1</Chinesesimp>
+            <Korean>전화 시작 %1</Korean>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_infantryPhone_stopCalling">
             <English>Stop calling</English>


### PR DESCRIPTION
**When merged this pull request will:**
- [x] Fixes: Infantry phone had access to all intercom networks regardless of the configuration.
- [x] Fixes: Lower case treatment of intercom names.
- [x] Fixes: Calling action was not available.
- [x] Fixes: Calling action is now available for each of the intercom networks.
