### PR TITLE
Fix API Function "getCurrentRadioChannel"

### DIFF
--- a/addons/api/fnc_getCurrentRadioChannelNumber.sqf
+++ b/addons/api/fnc_getCurrentRadioChannelNumber.sqf
@@ -21,5 +21,4 @@ if (_radioId == "") exitWith { -1 };
 private _channelNumber = [_radioId] call FUNC(getRadioChannel);
 
 if (isNil "_channelNumber") exitWith { -1 };
-_channelNumber = _channelNumber + 1;
 _channelNumber


### PR DESCRIPTION
`EFUNC(api,getCurrentRadioChannel)` had an additional increase of the channel number. This PR fixes it.

closes #448 
