### PR TITLE
Readd ACRE Test Bag dummy and optimize arsenal close function

### DIFF
--- a/addons/sys_core/fnc_arsenalClose.sqf
+++ b/addons/sys_core/fnc_arsenalClose.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * [] call acre_sys_core_fnc_closeArsenal
+ * [] call acre_sys_core_fnc_arsenalClose
  *
  * Public: No
  */
@@ -17,7 +17,7 @@
 
 if (is3DEN) exitWith {}; // Exit if Eden Arsenal
 
-private _weapons = ([acre_player] call EFUNC(sys_core,getGear)) apply {toLower _x};
+private _weapons = [acre_player] call EFUNC(sys_core,getGear);
 
 {
     _x params ["_baseClass","_radio"];

--- a/addons/sys_radio/CfgVehicles.hpp
+++ b/addons/sys_radio/CfgVehicles.hpp
@@ -17,4 +17,12 @@ class CfgVehicles {
             MACRO_ADDITEM(ACRE_SEM70,5);
         };
     };
+
+    // Backwards compatibility
+    class B_Kitbag_mcamo;
+    class ACRE_testBag: B_Kitbag_mcamo {
+        scope = 1; // Hidden in 2.5.1
+        displayName = "ACRE TEST BAG";
+        allowedSlots[] = {701, 801, 901};
+    };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Re-add "ACRE TEST BAG" as a dummy hidden item for backwards compatibility
- Optimize `acre_sys_core_fcn_arsenalClose` - lower-cased gear is already returned since #433 