### PR TITLE
Only lower-case ACRE prefixed items, Fix casing for some functions

### DIFF
--- a/addons/api/fnc_hasKindOfRadio.sqf
+++ b/addons/api/fnc_hasKindOfRadio.sqf
@@ -18,6 +18,8 @@
 
 params ["_weaponArray", "_type"];
 
+_type = toLower _type;
+
 if (IS_OBJECT(_weaponArray)) then {
     _weaponArray = [_weaponArray] call EFUNC(sys_core,getGear);
 };

--- a/addons/sys_core/fnc_getGear.sqf
+++ b/addons/sys_core/fnc_getGear.sqf
@@ -1,12 +1,12 @@
 /*
  * Author: ACRE2Team
- * Returns an array of ACRE gear in the passed unit
+ * Returns an array of ACRE gear in the passed unit.
  *
  * Arguments:
  * 0: Unit <OBJECT>
  *
  * Return Value:
- * Array of ACRE related gear <ARRAY>
+ * Array of ACRE related gear (all lower-case except "ItemRadio" and "ItemRadioAcreFlagged") <ARRAY>
  *
  * Example:
  * [player] call acre_sys_core_fnc_getGear
@@ -27,6 +27,6 @@ _gear = _gear select {(_x select [0, 4]) == "ACRE" || _x == "ItemRadio" || _x ==
 // The below is really slow and tends to worsen performance.
 //_gear = _gear select {(_x call EFUNC(api,getBaseRadio)) in (call EFUNC(api,getAllRadios) select 0) || {_x == "ItemRadio"} || {_x == "ItemRadioAcreFlagged"}};
 
-_gear = _gear apply {toLower _x};
+_gear = _gear apply { [_x, toLower _x] select (_x select [0, 4] == "ACRE") };
 
-_gear;
+_gear

--- a/addons/sys_core/fnc_removeGear.sqf
+++ b/addons/sys_core/fnc_removeGear.sqf
@@ -18,11 +18,13 @@
 
 params ["_unit", "_item"];
 
+_item = toLower _item;
+
 /*_weapons = weapons _unit;
 _uniformItems = uniformItems _unit;
 _vestItems = vestItems _unit;
 _backpackItems = backpackitems _unit;*/
-private _assignedItems = assignedItems _unit;
+private _assignedItems = (assignedItems _unit) apply {toLower _x};
 
 if (_item in _assignedItems) then {
     _unit unassignitem _item;

--- a/addons/sys_core/fnc_replaceGear.sqf
+++ b/addons/sys_core/fnc_replaceGear.sqf
@@ -19,30 +19,36 @@
 
 params ["_unit", "_itemToReplace", "_itemReplaceWith"];
 
+_itemToReplace = toLower _itemToReplace;
+_itemReplaceWith = toLower _itemReplaceWith;
+
 private _uniform = (uniformContainer _unit);
-if (!isNull _uniform && {_itemToReplace in (itemCargo _uniform)}) exitWith {
+private _uniforCmargo = (itemCargo _uniform) apply {toLower _x};
+if (!isNull _uniform && {_itemToReplace in _uniforCmargo}) exitWith {
     _unit removeItem _itemToReplace;
     _uniform addItemCargoGlobal [_itemReplaceWith, 1]; // circumvent limit
 };
 
 private _vest = (vestContainer _unit);
-if (!isNull _vest && {_itemToReplace in (itemCargo _vest)}) exitWith {
+private _vestCargo = (itemCargo _vest) apply {toLower _x};
+if (!isNull _vest && {_itemToReplace in _vestCargo}) exitWith {
     _unit removeItem _itemToReplace;
     _vest addItemCargoGlobal [_itemReplaceWith, 1]; // circumvent limit
 };
 
 private _backpack = (backpackContainer _unit);
-if (!isNull _backpack && {_itemToReplace in (itemCargo _backpack)}) exitWith {
+private _backpackCargo = (itemCargo _backpack) apply {toLower _x};
+if (!isNull _backpack && {_itemToReplace in _backpackCargo}) exitWith {
     _unit removeItem _itemToReplace;
     _backpack addItemCargoGlobal [_itemReplaceWith, 1]; // circumvent limit
 };
 
-private _assignedItems = assignedItems _unit;
+private _assignedItems = (assignedItems _unit) apply {toLower _x};
 if (_itemToReplace in _assignedItems) then {
     _unit unassignItem _itemToReplace;
 };
 
-private _weapons = weapons _unit;
+private _weapons = (weapons _unit) apply {toLower _x};
 if (_itemToReplace in _weapons) exitWith {
     _unit removeWeapon _itemToReplace;
     _unit addWeapon _itemReplaceWith;

--- a/addons/sys_radio/fnc_monitorRadios.sqf
+++ b/addons/sys_radio/fnc_monitorRadios.sqf
@@ -41,7 +41,7 @@ DFUNC(monitorRadios_PFH) = {
 
         if (_flaggedCount > 1) then {
             for "_i" from 1 to (_flaggedCount - 1) do {
-                    [acre_player, "ItemRadioAcreFlagged"] call EFUNC(sys_core,removeGear);
+                [acre_player, "ItemRadioAcreFlagged"] call EFUNC(sys_core,removeGear);
             };
             acre_player assignItem "ItemRadioAcreFlagged";
         };

--- a/addons/sys_radio/fnc_onReturnRadioId.sqf
+++ b/addons/sys_radio/fnc_onReturnRadioId.sqf
@@ -40,7 +40,7 @@ if (_player == acre_player) then {
 
     //if (_baseRadio in _weapons || ("ItemRadio" in _weapons && _baseRadio == GVAR(defaultItemRadioType) ) ) then {
     TRACE_2("Check inventory", _baseRadio, _weapons);
-    if ((toLower _baseRadio) in (_weapons apply {toLower _x})) then {
+    if ((toLower _baseRadio) in _weapons) then {
         // Add a new radio based on the id we just got
         TRACE_3("Adding radio", _class, _baseRadio, _replacementId);
 

--- a/addons/sys_radio/fnc_stopUsingRadio.sqf
+++ b/addons/sys_radio/fnc_stopUsingRadio.sqf
@@ -20,7 +20,6 @@ params ["_radioId"];
 // Only do something if the radio is actually the active one
 if (ACRE_ACTIVE_RADIO isEqualTo _radioId) then {
     private _items = [acre_player] call EFUNC(sys_core,getGear);
-    _items = _items apply {toLower _x};
 
     // Change only the active radio if it is not in the player's inventory
     if (!(ACRE_ACTIVE_RADIO in _items)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Make `getGear` not lower-case `ItemRadio` and `ItemRadioAcreFlagged` (so we don't have to change it everywhere
- Fix casing for some functions (was not lower-casing input)
- Fix #450 - inability to deploy bipod or have an accessory item (laser, flashlight) enabled for longer than a fraction of a second