### PR TITLE
Hide TeamSpeak Channel Password text in in-game CBA Settings

### DIFF
--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -67,7 +67,7 @@
     "EDITBOX",
     localize LSTRING(ts3ChannelPassword_displayName),
     "ACRE2",
-    "",
+    ["", true],
     false,
     {if (!isNull (findDisplay 46)) then {call EFUNC(sys_io,ts3ChannelMove)};}
 ] call CBA_Settings_fnc_init;


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Should work with current CBA (as in not error, but no effect), ~~need to test~~ tested.