### PR TITLE
Prevent backwards compatibility ACRE Game class from showing up in CBA Credits

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -875,7 +875,7 @@ class CfgPatches {
     };
 
     // Backwards compatibility
-    class acre_game: ADDON {}; // Component removed in 2.3.0
+    class acre_game: ADDON {author = "";}; // Component removed in 2.3.0
 };
 
 class CfgMods {


### PR DESCRIPTION
**When merged this pull request will:**
- Title