### PR TITLE
Fix TX power selection in 152

### DIFF
--- a/addons/sys_prc152/farris_menus/PGM.sqf
+++ b/addons/sys_prc152/farris_menus/PGM.sqf
@@ -412,17 +412,18 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         {
                             // If we are not in user mode, just skip this menu item
                             private _check = SCRATCH_GET_DEF(GVAR(currentRadioId), "pgm_tx_select", "HIGH");
+                            systemChat format ["check %1", _check];
                             if (_check != "USER") then {
                                 private _currentAction = GET_STATE("menuAction");
                                 _currentAction = _currentAction + 1;
                                 switch _check do {
-                                    case 'HIGH': {
+                                    case "HIGH": {
                                         SET_STATE("pgm_tx_power", 5000);
                                     };
-                                    case 'MED': {
+                                    case "MED": {
                                         SET_STATE("pgm_tx_power", 2000);
                                     };
-                                    case 'LOW': {
+                                    case "LOW": {
                                         SET_STATE("pgm_tx_power", 250);
                                     };
                                 };
@@ -445,7 +446,10 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                     ],
                     [
                         {
-                            private _value = GET_RADIO_VALUE("power");
+                            private _value = GET_STATE("pgm_tx_power");
+                            if (isNil "_value") then {
+                                _value = GET_RADIO_VALUE("power");
+                            };
                             SCRATCH_SET(GVAR(currentRadioId), "menuNumber", _value);
                         },
                         nil

--- a/addons/sys_prc152/farris_menus/PGM.sqf
+++ b/addons/sys_prc152/farris_menus/PGM.sqf
@@ -412,7 +412,6 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         {
                             // If we are not in user mode, just skip this menu item
                             private _check = SCRATCH_GET_DEF(GVAR(currentRadioId), "pgm_tx_select", "HIGH");
-                            systemChat format ["check %1", _check];
                             if (_check != "USER") then {
                                 private _currentAction = GET_STATE("menuAction");
                                 _currentAction = _currentAction + 1;


### PR DESCRIPTION
**When merged this pull request will:**
- Partially closes #474 

- 152 TX selection now  behaves as follows (previously, it always showed the actual radio power upon selecting a power preset):
  - If selection of TX power HIGH, MIDDLE or LOW the next screen shows the actual value for high (5000mW), Middle (2000mW) and Low(250mW)
  - If user is selected, the value displayed is the current power value set on the radio