### PR TITLE
Fix Default 1 preset of PRC-77 (second channel frequency)

### DIFF
--- a/addons/sys_prc77/functions/fnc_preset_information.sqf
+++ b/addons/sys_prc77/functions/fnc_preset_information.sqf
@@ -28,7 +28,7 @@ HASH_SET(_channel,"frequencyTX",30);
 HASHLIST_PUSH(_channels,_channel);
 
 _channel = HASHLIST_CREATEHASH(_channels); // 2nd Preset button
-HASH_SET(_channel,"frequencyTX",30);
+HASH_SET(_channel,"frequencyTX",30.50);
 HASHLIST_PUSH(_channels,_channel);
 
 HASH_SET(_presetData,"channels",_channels);


### PR DESCRIPTION
**When merged this pull request will:**
- Changes the frequency of the second channel for preset "default" of PRC77