### PR TITLE
Remove component warning in racks

### DIFF
--- a/addons/sys_rack/CfgAcreRacks.hpp
+++ b/addons/sys_rack/CfgAcreRacks.hpp
@@ -21,7 +21,7 @@ class CfgAcreComponents {
 
                 initializeComponent         = QFUNC(initializeRack);
 
-                attachComponent             = QEFUNC(sys_data,noApiSystemFunction);
+                attachComponent             = QFUNC(attachComponent);
                 detachComponent             = QEFUNC(sys_data,noApiSystemFunction);
                 mountRadio                  = QFUNC(vrc64MountRadio);
                 unmountRadio                = QFUNC(vrc64UnmountRadio);
@@ -57,7 +57,7 @@ class CfgAcreComponents {
 
                 initializeComponent         = QFUNC(initializeRack);
 
-                attachComponent             = QEFUNC(sys_data,noApiSystemFunction);
+                attachComponent             = QFUNC(attachComponent);
                 detachComponent             = QEFUNC(sys_data,noApiSystemFunction);
                 mountRadio                  = QFUNC(vrc110MountRadio);
                 unmountRadio                = QFUNC(vrc110UnmountRadio);
@@ -95,7 +95,7 @@ class CfgAcreComponents {
 
                 initializeComponent         = QFUNC(initializeRack);
 
-                attachComponent             = QEFUNC(sys_data,noApiSystemFunction);
+                attachComponent             = QFUNC(attachComponent);
                 detachComponent             = QEFUNC(sys_data,noApiSystemFunction);
                 mountRadio                  = QFUNC(vrc103MountRadio);
                 unmountRadio                = QFUNC(vrc103UnmountRadio);
@@ -131,7 +131,7 @@ class CfgAcreComponents {
 
                 initializeComponent         = QFUNC(initializeRack);
 
-                attachComponent             = QEFUNC(sys_data,noApiSystemFunction);
+                attachComponent             = QFUNC(attachComponent);
                 detachComponent             = QEFUNC(sys_data,noApiSystemFunction);
                 mountRadio                  = QFUNC(vrc111MountRadio);
                 unmountRadio                = QFUNC(vrc111UnmountRadio);
@@ -167,7 +167,7 @@ class CfgAcreComponents {
 
                 initializeComponent         = QFUNC(initializeRack);
 
-                attachComponent             = QEFUNC(sys_data,noApiSystemFunction);
+                attachComponent             = QFUNC(attachComponent);
                 detachComponent             = QEFUNC(sys_data,noApiSystemFunction);
                 mountRadio                  = QFUNC(sem90MountRadio);
                 unmountRadio                = QFUNC(sem90UnmountRadio);

--- a/addons/sys_rack/XEH_PREP.hpp
+++ b/addons/sys_rack/XEH_PREP.hpp
@@ -1,3 +1,6 @@
+// Components
+PREP(attachComponent);
+
 PREP(initActionVehicle);
 PREP(generateMountableRadioActions);
 PREP(rackChildrenActions);

--- a/addons/sys_rack/fnc_attachComponent.sqf
+++ b/addons/sys_rack/fnc_attachComponent.sqf
@@ -1,0 +1,16 @@
+/*
+ * Author: ACRE2Team
+ * Attaches a component
+ *
+ * Arguments:
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ *
+ *
+ * Public: No
+ */
+
+ // TODO: Implement component system for 2.7


### PR DESCRIPTION
**When merged this pull request will:**
- Remove component warning. I would prefer implementing component functions in 2.7
- #483 