### PR TITLE
Enhance  rack initialisation

### DIFF
--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -85,7 +85,7 @@ private _allowed = [_vehicle, _allowed] call EFUNC(sys_core,processVehicleSystem
 private _disabled = [_vehicle, _disabled] call EFUNC(sys_core,processVehicleSystemAccessArray);
 _intercoms = _intercoms apply {toLower _x};
 
-[{
+private _condition = {
     // A player must do the action of adding a rack
     private _player = objNull;
 
@@ -95,21 +95,23 @@ _intercoms = _intercoms apply {toLower _x};
     } else {
         _player = acre_player;
     };
+
+    _player
+};
+
+[{
+    params ["_condition"];
+
+    private _player =  call _condition;
 
     !isNil "_player"
 }, {
-    params ["_vehicle", "_rackClassname", "_rackName", "_rackShortName", "_isRadioRemovable", "_allowed", "_disabled", "_mountedRadio", "_defaultComponents","_intercoms"];
-    // A player must do the action of adding a rack
-    private _player = objNull;
+    params ["_condition", "_vehicle", "_rackClassname", "_rackName", "_rackShortName", "_isRadioRemovable", "_allowed", "_disabled", "_mountedRadio", "_defaultComponents","_intercoms"];
 
-    if (isDedicated) then {
-        // Pick the first player
-        _player = (allPlayers - entities "HeadlessClient_F") select 0;
-    } else {
-        _player = acre_player;
-    };
+    // A player must do the action of adding a rack
+    private _player = call _condition;
 
     [QEGVAR(sys_rack,addVehicleRacks), [_vehicle, _rackClassname, _rackName, _rackShortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _defaultComponents, _intercoms], _player] call CBA_fnc_targetEvent;
-}, [_vehicle, _rackClassname, _rackName, _rackShortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _defaultComponents, _intercoms]] call CBA_fnc_waitUntilAndExecute;
+}, [_condition, _vehicle, _rackClassname, _rackName, _rackShortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _defaultComponents, _intercoms]] call CBA_fnc_waitUntilAndExecute;
 
 true

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -95,7 +95,7 @@ _intercoms = _intercoms apply {toLower _x};
     } else {
         _player = acre_player;
     };
-    systemChat format ["player %1", _player];
+
     !isNil "_player"
 }, {
     params ["_vehicle", "_rackClassname", "_rackName", "_rackShortName", "_isRadioRemovable", "_allowed", "_disabled", "_mountedRadio", "_defaultComponents","_intercoms"];

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -85,16 +85,31 @@ private _allowed = [_vehicle, _allowed] call EFUNC(sys_core,processVehicleSystem
 private _disabled = [_vehicle, _disabled] call EFUNC(sys_core,processVehicleSystemAccessArray);
 _intercoms = _intercoms apply {toLower _x};
 
-// A player must do the action of adding a rack
-private _player = objNull;
+[{
+    // A player must do the action of adding a rack
+    private _player = objNull;
 
-if (isDedicated) then {
-    // Pick the first player
-    _player = (allPlayers - entities "HeadlessClient_F") select 0;
-} else {
-    _player = acre_player;
-};
+    if (isDedicated) then {
+        // Pick the first player
+        _player = (allPlayers - entities "HeadlessClient_F") select 0;
+    } else {
+        _player = acre_player;
+    };
+    systemChat format ["player %1", _player];
+    !isNil "_player"
+}, {
+    params ["_vehicle", "_rackClassname", "_rackName", "_rackShortName", "_isRadioRemovable", "_allowed", "_disabled", "_mountedRadio", "_defaultComponents","_intercoms"];
+    // A player must do the action of adding a rack
+    private _player = objNull;
 
-[QEGVAR(sys_rack,addVehicleRacks), [_vehicle, _rackClassname, _rackName, _rackShortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _defaultComponents, _intercoms], _player] call CBA_fnc_targetEvent;
+    if (isDedicated) then {
+        // Pick the first player
+        _player = (allPlayers - entities "HeadlessClient_F") select 0;
+    } else {
+        _player = acre_player;
+    };
+
+    [QEGVAR(sys_rack,addVehicleRacks), [_vehicle, _rackClassname, _rackName, _rackShortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _defaultComponents, _intercoms], _player] call CBA_fnc_targetEvent;
+}, [_vehicle, _rackClassname, _rackName, _rackShortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _defaultComponents, _intercoms]] call CBA_fnc_waitUntilAndExecute;
 
 true

--- a/addons/sys_core/XEH_PREP.hpp
+++ b/addons/sys_core/XEH_PREP.hpp
@@ -14,6 +14,7 @@ PREP(getHeadVector);
 PREP(getGear);
 PREP(getLanguageId);
 PREP(getLanguageName);
+PREP(getPlayersInVehicle);
 PREP(getSpeakingLanguageId);
 PREP(getSpokenLanguages);
 PREP(handleGetClientID);

--- a/addons/sys_core/fnc_getPlayersInVehicle.sqf
+++ b/addons/sys_core/fnc_getPlayersInVehicle.sqf
@@ -1,0 +1,30 @@
+/*
+ * Author: ACRE2Team
+ * Returns all player units inside a vehicle.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * Player units inside a vehicle <ARRAY>
+ *
+ * Example:
+ * [cursorTarget] call acre_sys_core_fnc_getPlayersInVehicle
+ *
+ * Public: No
+ */
+
+params ["_vehicle"];
+
+private _fullCrew = fullCrew [_vehicle, "", false];
+
+private _playersInVehicle = [];
+
+{
+    private _unit = _x select 0;
+    if (!isNull _unit && {isPlayer _unit}) then {
+        _playersInVehicle pushBack _unit;
+    };
+} forEach _fullCrew;
+
+_playersInVehicle

--- a/addons/sys_rack/fnc_enterVehicle.sqf
+++ b/addons/sys_rack/fnc_enterVehicle.sqf
@@ -23,11 +23,10 @@ if (_unit != _vehicle) then {
 
     if (!_initialized) then {
         // Only initialize if we are first in the crew array - This helps prevent multiple requests if multiple players enter a vehicle around the same time.
-        private _crew = crew _vehicle;
+        private _crew = [_vehicle] call EFUNC(sys_core,getPlayersInVehicle);
         private _firstPlayer = objNull;
         {
-            if (!isNull _firstPlayer) exitWith {};
-            if (isPlayer _x) exitWith {
+            if (!isNull _x) exitWith {
                 _firstPlayer = _x;
             };
         } forEach _crew;

--- a/addons/sys_rack/fnc_onReturnRackId.sqf
+++ b/addons/sys_rack/fnc_onReturnRackId.sqf
@@ -35,7 +35,7 @@ if (_replacementId != "") then {
 };
 
 // To further check. No isses found.
-private _crewPlayers = (crew _entity) select {isPlayer _x};
+private _crewPlayers = [_entity] call EFUNC(sys_core,getPlayersInVehicle);
 private _condition = false;
 if (count _crewPlayers > 0) then {
     if (local (_crewPlayers select 0)) then {

--- a/addons/sys_rack/fnc_onReturnRadioId.sqf
+++ b/addons/sys_rack/fnc_onReturnRadioId.sqf
@@ -28,9 +28,8 @@ HASH_SET(EGVAR(sys_server,objectIdRelationTable),_class,_idRelation);
 private _vehicle = _rackObject;
 _vehicle = _rackObject getVariable [QGVAR(rackVehicle), _rackObject];
 
-
 // To further check. No isses found.
-private _crewPlayers = (crew _vehicle) select {isPlayer _x};
+private _crewPlayers =  [_vehicle] call EFUNC(sys_core,getPlayersInVehicle);
 private _condition = false;
 if (count _crewPlayers > 0) then {
     if (local (_crewPlayers select 0)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Allow rack initialisation in all vehicle positions (previously only supported in positions returned by crew command).
- Ensure that player is initialised  in ` fnc_addRackToVehicle`. Previously extra  code was needed in init.sqf in order to work properly.