### PR TITLE
Remove default keybinding

### DIFF
--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -24,8 +24,7 @@ if (!hasInterface) exitWith {};
         } else {
             [PTT_ACTION] call FUNC(handlePttKeyPressUp);
         };
-    },
-    [52, [true, false, false]]
+    }
 ] call cba_fnc_addKeybind;
 
 [
@@ -39,8 +38,7 @@ if (!hasInterface) exitWith {};
         } else {
             [BROADCAST_ACTION] call FUNC(handlePttKeyPressUp);
         };
-    },
-    [52, [true, false, false]]
+    }
 ] call cba_fnc_addKeybind;
 
 ["ACRE2", "PreviousIntercom", (localize LSTRING(previousIntercom)), "", { [-1, true] call FUNC(switchIntercomFast) }, [51, [true, false, false]]] call cba_fnc_addKeybind;


### PR DESCRIPTION
**When merged this pull request will:**
- Remove assigning the default keybinding for broadcasting and ptt activation of intercom