### PR TITLE
Fix pgm menu

### DIFF
--- a/addons/sys_prc152/menus/types/ActionSeries.sqf
+++ b/addons/sys_prc152/menus/types/ActionSeries.sqf
@@ -47,6 +47,8 @@ DFUNC(renderMenu_ActionSeries) = {
             [_subMenu] call FUNC(changeMenu);
         };
 
+        // Get the last menuAction in case it was modified during menu operations (RX only, power level selection, ...)
+        _currentAction = GET_STATE_DEF("menuAction", 0);
         _currentAction = _currentAction + 1;
         SET_STATE("menuAction", _currentAction);
 


### PR DESCRIPTION
**When merged this pull request will:**
Issue description:
- On a 152, if a default power level was chosen, the user was forced to go through all the menus and edit the power level.
- The same was happening when changing the frequency and selecting use RX Frequency.

Fixes
- Closes #474
- Configuration menus now behave as expected.