### PR TITLE
Update installation.md

### DIFF
--- a/docs/wiki/user/installation.md
+++ b/docs/wiki/user/installation.md
@@ -28,5 +28,5 @@ Make sure to launch both Arma 3 (Steam) and TeamSpeak 3 as admin, or neither.
 - **Radio beeps not audible on dedicated server**  
 Make sure your `server.cfg` has `"b64"` whitelisted in `allowedLoadFileExtensions[]` and `allowedPreprocessFileExtensions[]` if you are using that. Let your server administrator know if you have no idea what this means.
 
-- **insufficient client permissions (failed on i_channel_needed_subscribe_power)**  
-This does not affect ACRE. The ACRE teamspeak plugin will subscribe to all channels in the teamspeak server, and if the teamspeak server contains any channels which have a higher `i_channel_needed_subscribe_power` value than what the client is granted then teamspeak will flag an error.
+- **Insufficient client permissions `(failed on i_channel_needed_subscribe_power)`**
+This does not affect ACRE2's functionalities. The ACRE2 TeamSpeak plugin will subscribe to all channels in the TeamSpeak server, and if the TeamSpeak server contains any channels which have a higher `i_channel_needed_subscribe_power` value than what the client is granted then TeamSpeak will throw an error.

--- a/docs/wiki/user/installation.md
+++ b/docs/wiki/user/installation.md
@@ -28,5 +28,5 @@ Make sure to launch both Arma 3 (Steam) and TeamSpeak 3 as admin, or neither.
 - **Radio beeps not audible on dedicated server**  
 Make sure your `server.cfg` has `"b64"` whitelisted in `allowedLoadFileExtensions[]` and `allowedPreprocessFileExtensions[]` if you are using that. Let your server administrator know if you have no idea what this means.
 
-- **insufficient client permissions (failed on i_channel_needed_subscribe_power)**
+- **insufficient client permissions (failed on i_channel_needed_subscribe_power)**  
 This does not affect ACRE. The ACRE teamspeak plugin will subscribe to all channels in the teamspeak server, and if the teamspeak server contains any channels which have a higher `i_channel_needed_subscribe_power` value than what the client is granted then teamspeak will flag an error.

--- a/docs/wiki/user/installation.md
+++ b/docs/wiki/user/installation.md
@@ -27,3 +27,6 @@ Make sure to launch both Arma 3 (Steam) and TeamSpeak 3 as admin, or neither.
 
 - **Radio beeps not audible on dedicated server**  
 Make sure your `server.cfg` has `"b64"` whitelisted in `allowedLoadFileExtensions[]` and `allowedPreprocessFileExtensions[]` if you are using that. Let your server administrator know if you have no idea what this means.
+
+- **insufficient client permissions (failed on i_channel_needed_subscribe_power)**
+This does not affect ACRE. The ACRE teamspeak plugin will subscribe to all channels in the teamspeak server, and if the teamspeak server contains any channels which have a higher `i_channel_needed_subscribe_power` value than what the client is granted then teamspeak will flag an error.


### PR DESCRIPTION
Add a description for the `i_channel_needed_subscribe_power` error on teamspeak when the teamspeak server has a channel with a higher subscribe power than what the user is granted.

This error on teamspeak can cause confusion as the error doesn't indicate what channel the permission restriction is for, and so users may think it is a client permission issue for the channel they're currently in.

To understand this error, I looked through the source code for the teamspeak plugin and found the following lines of code
```cpp
// subscribe to all channels to receive event
ts3Functions.requestChannelSubscribeAll(ts3Functions.getCurrentServerConnectionHandlerID(), NULL);
if (CEngine::getInstance()->getClient()->getState() != ACRE_STATE_RUNNING) {
    CEngine::getInstance()->getClient()->start((ACRE_ID)id);
}
```

I do think people need to be aware of this for easier troubleshooting.

**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Respect the [SQF](https://github.com/IDI-Systems/acre2/wiki/Coding-Guidelines-(SQF)) and [C++](https://github.com/IDI-Systems/acre2/wiki/Coding-Guidelines-(CPP)) Coding Guidelines
