### PR TITLE
Improve Racks interaction usability

### DIFF
--- a/addons/ace_interact/fnc_radioChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioChildrenActions.sqf
@@ -4,7 +4,7 @@
  *
  * Arguments:
  * 0: Unit with ACRE2 radios <OBJECT>
- * 1: None <TYPE>
+ * 1: Active <BOOL>
  * 2: Array with additional parameters: unique radio ID <ARRAY>
  *
  * Return Value:
@@ -18,7 +18,7 @@
 #include "script_component.hpp"
 
 params ["_target","","_params"];
-_params params ["_radio", "", "_pttAssign"];
+_params params ["_radio", "_active", "_pttAssign"];
 
 private _actions = [];
 
@@ -40,7 +40,7 @@ if (!(_radio in ACRE_EXTERNALLY_USED_PERSONAL_RADIOS)) then {
         _actions pushBack [_action, [], _target];
     };
 
-    _action = [QGVAR(makeActive), localize LSTRING(setAsActive), "", {[(_this select 2) select 0] call EFUNC(api,setCurrentRadio)}, {!((_this select 2) select 1)}, {},_params] call ace_interact_menu_fnc_createAction;
+    _action = [QGVAR(makeActive), localize LSTRING(setAsActive), "", {[(_this select 2) select 0] call EFUNC(api,setCurrentRadio)}, {!((_this select 2) select 1)}, {}, [_radio, _active]] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
 
     // External radios. Show only options to share/stop sharing the radio if you are the actual owner and not an external user.

--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -44,7 +44,7 @@ private _radioList = [] call EFUNC(api,getCurrentRadioList);
     private _currentChannel = [_x] call EFUNC(api,getRadioChannel);
     _displayName = format [localize LSTRING(channelShort), _displayName, _currentChannel];
     private _picture = getText (_item >> "picture");
-    private _isActive = _x isEqualTo _currentRadio;
+    private _isActive = _x isEqualTo _currentRadio; // Unused
 
     private _action = [
         _x,

--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -44,7 +44,7 @@ private _radioList = [] call EFUNC(api,getCurrentRadioList);
     private _currentChannel = [_x] call EFUNC(api,getRadioChannel);
     _displayName = format [localize LSTRING(channelShort), _displayName, _currentChannel];
     private _picture = getText (_item >> "picture");
-    private _isActive = _x isEqualTo _currentRadio; // Unused
+    private _isActive = _x isEqualTo _currentRadio;
 
     private _action = [
         _x,

--- a/addons/sys_rack/CfgVehicles.hpp
+++ b/addons/sys_rack/CfgVehicles.hpp
@@ -2,7 +2,7 @@ class CfgVehicles {
     // Vehicle rack vehicle definitions
     class ACRE_BaseRack;
     class ACRE_VRC64 : ACRE_BaseRack {
-        displayName = "AN/VRC-64 Rack";
+        displayName = "AN/VRC-64";
     };
     RADIO_ID_LIST(ACRE_VRC64)
 

--- a/addons/sys_rack/fnc_rackChildrenActions.sqf
+++ b/addons/sys_rack/fnc_rackChildrenActions.sqf
@@ -28,45 +28,94 @@ private _mountedRadio = [_rackClassName] call FUNC(getMountedRadio);
 if ([_rackClassName, _unit] call FUNC(isRackAccessible)) then {
     if (_mountedRadio == "") then { // Empty
         if ([_rackClassName] call FUNC(isRadioRemovable)) then {
-            private _action = [QGVAR(mountRadio), localize LSTRING(mountRadio), QPATHTOEF(ace_interact,data\icons\connector4.paa), {1+1;}, {true}, {_this call FUNC(generateMountableRadioActions);}, _params] call ace_interact_menu_fnc_createAction;
+            private _action = [
+                QGVAR(mountRadio),
+                localize LSTRING(mountRadio),
+                QPATHTOEF(ace_interact,data\icons\connector4.paa),
+                {true},
+                {true},
+                {_this call FUNC(generateMountableRadioActions)},
+                _params
+            ] call ace_interact_menu_fnc_createAction;
             _actions pushBack [_action, [], _target];
         };
     } else {
         private _class = configFile >> "CfgWeapons" >> _mountedRadio;
+        private _currentChannel = [_mountedRadio] call EFUNC(api,getRadioChannel);
+        private _displayName = format [localize ELSTRING(ace_interact,channelShort), getText (_class >> "displayName"), _currentChannel];
         private _icon = getText (_class >> "picture");
-        if ([_rackClassName] call FUNC(isRadioRemovable)) then {
-            private _text = format [localize LSTRING(unmountRadio), getText (_class >> "displayName")];
-            private _params = [_rackClassName, _mountedRadio];
-            private _action = [QGVAR(mountedRadio), _text, _icon, {
-                params ["_target","_unit","_params"];
-                _params params ["_rackClassName"];
-                [_rackClassName, _unit] call FUNC(unmountRadio);
-            }, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
-        } else {
-            private _text = format [localize LSTRING(unmountable), getText (_class >> "displayName")];
-            private _action = [QGVAR(mountedRadio), _text, _icon, {1+1;}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
-            _actions pushBack [_action, [], _target];
-        };
+
+        // General radio
+        private _action = [
+            QGVAR(mountedRadio),
+            _displayName,
+            _icon,
+            {[_this#2#1] call EFUNC(sys_radio,openRadio)},
+            {true},
+            {
+                _this#2 params ["_rackClassName", "_mountedRadio"];
+
+                // Mounting options
+                if ([_rackClassName] call FUNC(isRadioRemovable)) then {
+                    // Unmount
+                    private _action = [
+                        QGVAR(unmount),
+                        localize LSTRING(unmountRadio),
+                        "",
+                        {[this#2, this#1] call FUNC(unmountRadio)},
+                        {true},
+                        {},
+                        _rackClassName
+                    ] call ace_interact_menu_fnc_createAction;
+                    [[_action, [], _target]]
+                } else {
+                    // Unmountable
+                    private _action = [
+                        QGVAR(unmountable),
+                        localize LSTRING(unmountable),
+                        "",
+                        {true},
+                        {true}
+                    ] call ace_interact_menu_fnc_createAction;
+                    [[_action, [], _target]]
+                };
+            },
+            [_rackClassName, _mountedRadio]
+        ] call ace_interact_menu_fnc_createAction;
+        _actions pushBack [_action, [], _target];
+
+        // Using options
         if (_mountedRadio in ACRE_ACCESSIBLE_RACK_RADIOS || {_mountedRadio in ACRE_HEARABLE_RACK_RADIOS}) then {
-            // stop
-            private _action = [QGVAR(stopUsingMountedRadio), localize LSTRING(stopUsingRadio), "", {
-                params ["_target","_unit","_params"];
-                _params params ["_mountedRadio"];
-                [_target, _unit, _mountedRadio] call FUNC(stopUsingMountedRadio);
-            }, {true}, {}, [_mountedRadio]] call ace_interact_menu_fnc_createAction;
+            // Stop
+            private _action = [
+                QGVAR(stopUsingMountedRadio),
+                localize LSTRING(stopUsingRadio),
+                "",
+                {_this call FUNC(stopUsingMountedRadio)},
+                {true},
+                {},
+                _mountedRadio
+            ] call ace_interact_menu_fnc_createAction;
             _actions pushBack [_action, [], _target];
 
             private _pttAssign = [] call EFUNC(api,getMultiPushToTalkAssignment);
-            private _radioActions = [_target, _unit, [_mountedRadio, (_mountedRadio isEqualTo ACRE_ACTIVE_RADIO), _pttAssign]] call EFUNC(ace_interact,radioChildrenActions);
+            private _radioActions = [
+                _target,
+                _unit,
+                [_mountedRadio, _mountedRadio isEqualTo ACRE_ACTIVE_RADIO, _pttAssign]
+            ] call EFUNC(ace_interact,radioChildrenActions);
             _actions append _radioActions;
         } else {
             // Use
-            private _action = [QGVAR(useMountedRadio), localize LSTRING(useRadio), "", {
-                params ["_target", "_unit", "_params"];
-                _params params ["_mountedRadio"];
-                [_target, _unit, _mountedRadio] call FUNC(startUsingMountedRadio);
-            }, {true}, {}, [_mountedRadio]] call ace_interact_menu_fnc_createAction;
+            private _action = [
+                QGVAR(useMountedRadio),
+                localize LSTRING(useRadio),
+                "",
+                {_this call FUNC(startUsingMountedRadio)},
+                {true},
+                {},
+                _mountedRadio
+            ] call ace_interact_menu_fnc_createAction;
             _actions pushBack [_action, [], _target];
         };
     };
@@ -75,25 +124,42 @@ if ([_rackClassName, _unit] call FUNC(isRackAccessible)) then {
         if ([_rackClassName, _unit] call FUNC(isRackHearable)) then {
             // Radio type
             private _class = configFile >> "CfgWeapons" >> _mountedRadio;
+            private _currentChannel = [_mountedRadio] call EFUNC(api,getRadioChannel);
+            private _displayName = format [localize ELSTRING(ace_interact,channelShort), getText (_class >> "displayName"), _currentChannel];
             private _icon = getText (_class >> "picture");
-            private _text = format [localize LSTRING(mountedRadio), getText (_class >> "displayName")];
-            private _action = [QGVAR(mountedRadio), _text, _icon, {1+1;}, {true}, {}, _params] call ace_interact_menu_fnc_createAction;
+
+            // General radio
+            private _action = [
+                QGVAR(mountedRadio),
+                _displayName,
+                _icon,
+                {true},
+                {true}
+            ] call ace_interact_menu_fnc_createAction;
             _actions pushBack [_action, [], _target];
 
-            // Check as well if a unit has the radio already in use (Turned out/in etc)
+            // Check as well if a unit has the radio already in use (turned out/in etc)
             if (_mountedRadio in ACRE_HEARABLE_RACK_RADIOS || {_mountedRadio in ACRE_ACCESSIBLE_RACK_RADIOS}) then {
-                private _action = [QGVAR(stopUsingMountedRadio), localize LSTRING(stopUsingRadio), "", {
-                    params ["_target", "_unit", "_params"];
-                    _params params ["_mountedRadio"];
-                    [_target, _unit, _mountedRadio] call FUNC(stopUsingMountedRadio);
-                }, {true}, {}, [_mountedRadio]] call ace_interact_menu_fnc_createAction;
+                private _action = [
+                    QGVAR(stopUsingMountedRadio),
+                    localize LSTRING(stopUsingRadio),
+                    "",
+                    {_this call FUNC(stopUsingMountedRadio)},
+                    {true},
+                    {},
+                    _mountedRadio
+                ] call ace_interact_menu_fnc_createAction;
                 _actions pushBack [_action, [], _target];
             } else {
-                private _action = [QGVAR(useMountedRadio), localize LSTRING(useRadio), "", {
-                    params ["_target", "_unit", "_params"];
-                    _params params ["_mountedRadio"];
-                    [_target, _unit, _mountedRadio] call FUNC(startUsingMountedRadio);
-                }, {true}, {}, [_mountedRadio]] call ace_interact_menu_fnc_createAction;
+                private _action = [
+                    QGVAR(useMountedRadio),
+                    localize LSTRING(useRadio),
+                    "",
+                    {_this call FUNC(startUsingMountedRadio)},
+                    {true},
+                    {},
+                    _mountedRadio
+                ] call ace_interact_menu_fnc_createAction;
                 _actions pushBack [_action, [], _target];
             };
         };
@@ -102,7 +168,14 @@ if ([_rackClassName, _unit] call FUNC(isRackAccessible)) then {
 
 /* Connectors */
 if (EGVAR(ace_interact,connectorsEnabled)) then {
-    private _action = ["acre_connectors", "Connectors", QPATHTOEF(ace_interact,data\icons\connector4.paa), {true /*Statement/Action*/}, {true}, { _this call EFUNC(ace_interact,generateConnectors);}, _params] call ace_interact_menu_fnc_createAction;
+    private _action = [
+        "acre_connectors",
+        "Connectors",
+        QPATHTOEF(ace_interact,data\icons\connector4.paa),
+        {true},
+        {true},
+        {_this call EFUNC(ace_interact,generateConnectors)}
+    ] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
 };
 

--- a/addons/sys_rack/fnc_rackListChildrenActions.sqf
+++ b/addons/sys_rack/fnc_rackListChildrenActions.sqf
@@ -1,16 +1,15 @@
 /*
  * Author: ACRE2Team
- * SHORT DESCRIPTION
+ * Generates a list of actions for a vehicle rack.
  *
  * Arguments:
- * 0: ARGUMENT ONE <TYPE>
- * 1: ARGUMENT TWO <TYPE>
+ * 0: Vehicle with racks <OBJECT>
  *
  * Return Value:
- * RETURN VALUE <TYPE>
+ * Array of actions <ARRAY>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [vehicle acre_player] call acre_sys_rack_fnc_rackListChildrenActions
  *
  * Public: No
  */
@@ -27,26 +26,21 @@ private _racks = [_target, acre_player] call FUNC(getAccessibleVehicleRacks);
 } forEach ([_target, acre_player] call FUNC(getHearableVehicleRacks));
 
 {
-    private _rackClassName = _x;
-    private _config = ConfigFile >> "CfgVehicles" >> _rackClassName;
-    private _displayName = getText (_config >> "displayName");
-    //private _currentChannel = [_x] call acre_api_fnc_getRadioChannel;
-    //_displayName = format ["%1 Chn: %2",_displayName, _currentChannel];
-    //private _isActive = _x isEqualTo _currentRadio;
-
-    private _name = [_rackClassName, "getState", "name"] call EFUNC(sys_data,dataEvent);
-    _displayName = format ["%1 (%2)", _name, _displayName];
+    // _x is rack classname
+    private _config = configFile >> "CfgVehicles" >> _x;
+    private _name = [_x, "getState", "name"] call EFUNC(sys_data,dataEvent);
+    private _displayName = format ["%1 (%2)", _name, getText (_config >> "displayName")];
 
     private _action = [
-        _rackClassName,
+        _x,
         _displayName,
         QPATHTOEF(ace_interact,data\icons\rack.paa),
         {true},
         {true},
         {_this call FUNC(rackChildrenActions);},
-        [_rackClassName]
+        [_x]
     ] call ace_interact_menu_fnc_createAction;
     _actions pushBack [_action, [], _target];
 } forEach _racks;
 
-_actions;
+_actions

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -13,19 +13,19 @@
             <Italian>Monta</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_rack_unmountable">
-            <English>Unmountable (%1)</English>
-            <Italian>Non montabile (%1)</Italian>
+            <English>Unmountable</English>
+            <Italian>Non montabile</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_rack_unmountRadio">
-            <English>Unmount (%1)</English>
-            <German>Entferne (%1)</German>
-            <Japanese>降ろす (%1)</Japanese>
-            <Chinese>卸載 (%1)</Chinese>
-            <Chinesesimp>卸载 (%1)</Chinesesimp>
-            <Korean>분리 (%1)</Korean>
-            <Portuguese>Desmontar (%1)</Portuguese>
-            <Polish>Wymontuj (%1)</Polish>
-            <Italian>Smonta (%1)</Italian>
+            <English>Unmount</English>
+            <German>Entferne</German>
+            <Japanese>降ろす</Japanese>
+            <Chinese>卸載</Chinese>
+            <Chinesesimp>卸载</Chinesesimp>
+            <Korean>분리</Korean>
+            <Portuguese>Desmontar</Portuguese>
+            <Polish>Wymontuj</Polish>
+            <Italian>Smonta</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_rack_mountedRadio">
             <English>Mounted (%1)</English>

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACRE">
     <Package name="sys_rack">
         <Key ID="STR_ACRE_sys_rack_mountRadio">
@@ -98,7 +98,7 @@
             <Italian>Cruscotto</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_rack_dashLower">
-            <English>Dashboard Lower</English>
+            <English>Dash Lower</English>
             <German>Unterer Steckplatz</German>
             <Chinese>儀錶板下降</Chinese>
             <Chinesesimp>仪表板下降</Chinesesimp>
@@ -113,7 +113,7 @@
             <Italian>C. Basso</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_rack_dashUpper">
-            <English>Dashboard Upper</English>
+            <English>Dash Upper</English>
             <German>Oberer Steckplatz</German>
             <Chinese>儀錶板上升</Chinese>
             <Chinesesimp>仪表板上升</Chinesesimp>

--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -83,8 +83,6 @@ def check_sqf_syntax(filepath):
                         if (c == '"' or c == "'"):
                             isInString = True
                             inStringType = c
-                        elif (c == '#'):
-                            ignoreTillEndOfLine = True
                         elif (c == '/'):
                             checkIfInComment = True
                         elif (c == '('):

--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -83,6 +83,8 @@ def check_sqf_syntax(filepath):
                         if (c == '"' or c == "'"):
                             isInString = True
                             inStringType = c
+                        elif (c == '#'):
+                            checkForSemiColumn = False
                         elif (c == '/'):
                             checkIfInComment = True
                         elif (c == '('):


### PR DESCRIPTION
**When merged this pull request will:**
- Shorten Dashboard Lower and Upper stringtables
  - Make them fit into 1 ACE3 Interaction Menu line
  - Conform with single Dash action
- Correct display name of AN/VRC-64
- Improve rack interaction usability - close #522 
  - Add channel label to radio name
  - Move Unmountable and Unmount texts as radio sub-actions ("Unmountable" is dummy action)
  - Change radio action to open radio instead of unmount (conform with self-interaction, avoid confusion and mistakes)
  - Cleanup rack children actions function

![20180510204355_1](https://user-images.githubusercontent.com/7935003/39887938-bd1a4412-5493-11e8-8e89-85d34787cbcf.jpg)
![20180510204342_1](https://user-images.githubusercontent.com/7935003/39887939-bd39f8fc-5493-11e8-9ddd-cdc1927e96cd.jpg)