### PR TITLE
Allow rack initialisation based on a condition

### DIFF
--- a/addons/api/CfgFunctions.hpp
+++ b/addons/api/CfgFunctions.hpp
@@ -58,10 +58,12 @@ class CfgFunctions {
             PATHTO_FNC(areVehicleRacksInitialized);
             PATHTO_FNC(getMountedRackRadio);
             PATHTO_FNC(getVehicleRacks);
+            PATHTO_FNC(getVehicleRacksPreset);
             PATHTO_FNC(initVehicleRacks);
             PATHTO_FNC(isRackRadioRemovable);
             PATHTO_FNC(mountRackRadio);
             PATHTO_FNC(removeRackFromVehicle);
+            PATHTO_FNC(setVehicleRacksPreset);
             PATHTO_FNC(unmountRackRadio);
         };
 

--- a/addons/api/CfgFunctions.hpp
+++ b/addons/api/CfgFunctions.hpp
@@ -58,12 +58,10 @@ class CfgFunctions {
             PATHTO_FNC(areVehicleRacksInitialized);
             PATHTO_FNC(getMountedRackRadio);
             PATHTO_FNC(getVehicleRacks);
-            PATHTO_FNC(getVehicleRacksPreset);
             PATHTO_FNC(initVehicleRacks);
             PATHTO_FNC(isRackRadioRemovable);
             PATHTO_FNC(mountRackRadio);
             PATHTO_FNC(removeRackFromVehicle);
-            PATHTO_FNC(setVehicleRacksPreset);
             PATHTO_FNC(unmountRackRadio);
         };
 
@@ -80,6 +78,9 @@ class CfgFunctions {
 
             PATHTO_FNC(setPresetChannelField);
             PATHTO_FNC(getPresetChannelField);
+
+            PATHTO_FNC(setVehicleRacksPreset);
+            PATHTO_FNC(getVehicleRacksPreset);
         };
         class Speaking {
             PATHTO_FNC(isBroadcasting);

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -17,7 +17,7 @@
  *   7: Components <ARRAY> (default: [])
  *   8: Connected intercoms <ARRAY> (default: [])
  * 2: Force initialisation <BOOL> (default: false)
- * 3: Condition called with argument "_unit". If a longer function is given, it should be precompiled <CODE>. (default: {})
+ * 3: Condition called with argument "_unit". If a longer function is given, it should be precompiled. <CODE> (default: {})
  *
  * Return Value:
  * Rack added successfully <BOOL>

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -1,7 +1,8 @@
 /*
  * Author: ACRE2Team
- * Initialises all racks in the vehicle. Must be executed in the server. If no side is specified,
- * the radio will be configured to match the side of the first player.
+ * Initialises all racks in the vehicle. Must be executed in the server. If no condition is specified,
+ * the radio will be configured to match the vehicle preset defined using acre_api_fnc_setVehicleRacksPreset
+ * or the preset of the first player that matches the given condition if the vehicle preset is not defined. 
  *
  * Arguments:
  * 0: Vehicle <OBJECT> (default: objNull)
@@ -16,13 +17,13 @@
  *   7: Components <ARRAY> (default: [])
  *   8: Connected intercoms <ARRAY> (default: [])
  * 2: Force initialisation <BOOL> (default: false)
- * 3: Condition called with argument "_unit" <STRING> (default: "")
+ * 3: Condition called with argument "_unit". If a longer function is given, it should be a precompiled <CODE> (default: "")
  *
  * Return Value:
  * Rack added successfully <BOOL>
  *
  * Example:
- * [cursorTarget, ["ACRE_VRC103", "Upper Dash", "Dash", false, ["external"], [], "ACRE_PRC117F", [], ["intercom_1"]], false, "side _unit == west"] call acre_api_fnc_addRackToVehicle
+ * [cursorTarget, ["ACRE_VRC103", "Upper Dash", "Dash", false, ["external"], [], "ACRE_PRC117F", [], ["intercom_1"]], false] call acre_api_fnc_addRackToVehicle
  *
  * Public: Yes
  */
@@ -91,7 +92,8 @@ private _selectPlayer = {
     // A player must do the action of adding a rack
     private _player = objNull;
 
-    if (_condition isEqualTo "") then {
+    private _vehiclePresetName = [_vehicle] call FUNC(getVehicleRacksPreset);
+    if (_condition isEqualTo "" && {_vehiclePresetName == ""}) then {
         _player = ([] call CBA_fnc_players) select 0;
     } else {
         // Pick the first player that matches side criteria
@@ -100,10 +102,10 @@ private _selectPlayer = {
             if ([_unit] call compile _condition) then {
                 _player = _unit;
             };
-        } forEach (allPlayers - entities "HeadlessClient_F");
+        } forEach ([] call CBA_fnc_players);
 
         if (isNull _player) then {
-            WARNING_1("No unit found for side %1, defaulting to first player",_side);
+            WARNING_1("No unit found for condition %1, defaulting to first player",_condition);
             _player = ([] call CBA_fnc_players) select 0;
         };
     };

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -93,7 +93,7 @@ private _selectPlayer = {
     private _player = objNull;
 
     private _vehiclePresetName = [_vehicle] call FUNC(getVehicleRacksPreset);
-    if (_condition isEqualTo "" && {_vehiclePresetName == ""}) then {
+    if (_condition isEqualTo "" && {!(_vehiclePresetName isEqualTo "")}) then {
         _player = ([] call CBA_fnc_players) select 0;
     } else {
         // Pick the first player that matches side criteria

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -2,7 +2,7 @@
  * Author: ACRE2Team
  * Initialises all racks in the vehicle. Must be executed in the server. If no condition is specified,
  * the radio will be configured to match the vehicle preset defined using acre_api_fnc_setVehicleRacksPreset
- * or the preset of the first player that matches the given condition if the vehicle preset is not defined. 
+ * or the preset of the first player that matches the given condition if the vehicle preset is not defined.
  *
  * Arguments:
  * 0: Vehicle <OBJECT> (default: objNull)
@@ -17,7 +17,7 @@
  *   7: Components <ARRAY> (default: [])
  *   8: Connected intercoms <ARRAY> (default: [])
  * 2: Force initialisation <BOOL> (default: false)
- * 3: Condition called with argument "_unit". If a longer function is given, it should be a precompiled <CODE> (default: {})
+ * 3: Condition called with argument "_unit". If a longer function is given, it should be precompiled <CODE>. (default: {})
  *
  * Return Value:
  * Rack added successfully <BOOL>

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -53,7 +53,7 @@ if (_forceInitialisation) then {
         WARNING_1("Vehicle %1 is already initialised but function forces it to initialise again",_vehicle);
     } else {
         TRACE_1("Forcing initialisation of vehicle %1 in order to add a rack",_vehicle);
-        _success = [_vehicle] call EFUNC(api,initVehicleRacks);
+        _success = [_vehicle, _side] call EFUNC(api,initVehicleRacks);
     };
 };
 

--- a/addons/api/fnc_addRackToVehicle.sqf
+++ b/addons/api/fnc_addRackToVehicle.sqf
@@ -16,7 +16,7 @@
  *   7: Components <ARRAY> (default: [])
  *   8: Connected intercoms <ARRAY> (default: [])
  * 2: Force initialisation <BOOL> (default: false)
- * 3: Condition called with argument "_unit" <STRING> (default: "")
+ * 3: Condition called with argument "_unit" <CODE> (default: {})
  *
  * Return Value:
  * Rack added successfully <BOOL>
@@ -91,19 +91,18 @@ private _selectPlayer = {
     // A player must do the action of adding a rack
     private _player = objNull;
 
-    if (_condition isEqualTo "") then {
+    if (_condition isEqualTo {}) then {
         _player = ([] call CBA_fnc_players) select 0;
     } else {
         // Pick the first player that matches side criteria
         {
-            private _unit = _x;
-            if ([_unit] call compile _condition) then {
-                _player = _unit;
+            if ([_x] call _condition) exitWith {
+            _player = _x;
             };
-        } forEach (allPlayers - entities "HeadlessClient_F");
+        } forEach ([] call CBA_fnc_players);
 
         if (isNull _player) then {
-            WARNING_1("No unit found for side %1, defaulting to first player",_side);
+            WARNING_1("No unit found for condition %1, defaulting to first player",_condition);
             _player = ([] call CBA_fnc_players) select 0;
         };
     };

--- a/addons/api/fnc_copyPreset.sqf
+++ b/addons/api/fnc_copyPreset.sqf
@@ -11,7 +11,7 @@
  * Copy preset successful <BOOLEAN>
  *
  * Example:
- * [["ACRE_PRC152", "default2", "balls"] call acre_api_fnc_copyPreset;E
+ * [["ACRE_PRC152", "default2", "balls"] call acre_api_fnc_copyPreset
  *
  * Public: Yes
  */

--- a/addons/api/fnc_copyPreset.sqf
+++ b/addons/api/fnc_copyPreset.sqf
@@ -11,7 +11,7 @@
  * Copy preset successful <BOOLEAN>
  *
  * Example:
- * [["ACRE_PRC152", "default2", "balls"] call acre_api_fnc_copyPreset
+ * ["ACRE_PRC152", "default2", "balls"] call acre_api_fnc_copyPreset
  *
  * Public: Yes
  */

--- a/addons/api/fnc_getVehicleRacksPreset.sqf
+++ b/addons/api/fnc_getVehicleRacksPreset.sqf
@@ -3,10 +3,10 @@
  * Gets the preset name used for initialising the vehicle racks.
  *
  * Arguments:
- * 0: Vehicle <OBJECT> (Default: objNull)
+ * 0: Vehicle <OBJECT> (default: objNull)
  *
  * Return Value:
- * Preset name. Empty string if not defined <STRING> 
+ * Preset name ("" if undefined) <STRING>
  *
  * Example:
  * [cursorTarget] call acre_api_fnc_getVehicleRacksPreset
@@ -18,7 +18,7 @@
 params [["_vehicle", objNull], ["_presetName", ""]];
 
 if (isNull _vehicle) exitWith {
-    ERROR("Vehicle is null");
+    WARNING("Vehicle is null");
     ""
 };
 

--- a/addons/api/fnc_getVehicleRacksPreset.sqf
+++ b/addons/api/fnc_getVehicleRacksPreset.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: ACRE2Team
+ * Gets the preset name used for initialising the vehicle racks.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT> (Default: objNull)
+ *
+ * Return Value:
+ * Preset name. Empty string if not defined <STRING> 
+ *
+ * Example:
+ * [cursorTarget] call acre_api_fnc_getVehicleRacksPreset
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params [["_vehicle", objNull], ["_presetName", ""]];
+
+if (isNull _vehicle) exitWith {
+    ERROR("Vehicle is null");
+    ""
+};
+
+_vehicle getVariable [QEGVAR(sys_rack,vehicleRacksPreset), ""]

--- a/addons/api/fnc_initVehicleRacks.sqf
+++ b/addons/api/fnc_initVehicleRacks.sqf
@@ -5,7 +5,7 @@
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
- * 1: Condition called with argument "_unit" <STRING> (default: "")
+ * 1: Condition called with argument "_unit" <CODE> (default: {})
  *
  * Return Value:
  * Setup successful <BOOL>
@@ -17,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params [["_vehicle", objNull], ["_condition", ""]];
+params [["_vehicle", objNull], ["_condition", {}]];
 
 if (!isServer) exitWith {
     WARNING("Function must be called on the server.");
@@ -37,14 +37,13 @@ if ([_vehicle] call FUNC(areVehicleRacksInitialized)) exitWith {
 // A player must do the action of initialising a rack
 private _player = objNull;
 
-if (_condition isEqualTo "") then {
+if (_condition isEqualTo {}) then {
     _player = ([] call CBA_fnc_players) select 0;
 } else {
     // Pick the first player that matches side criteria
     {
-        private _unit = _x;
-        if ([_unit] call compile _condition) then {
-            _player = _unit;
+        if ([_x] call _condition) exitWith {
+            _player = _x;
         };
     } forEach ([] call CBA_fnc_players);
 

--- a/addons/api/fnc_initVehicleRacks.sqf
+++ b/addons/api/fnc_initVehicleRacks.sqf
@@ -2,11 +2,11 @@
  * Author: ACRE2Team
  * Initialises all racks in the vehicle. Must be executed in the server. If no condition is specified,
  * the radio will be configured to match the vehicle preset defined using acre_api_fnc_setVehicleRacksPreset
- * or the preset of the first player that matches the given condition if the vehicle preset is not defined. 
+ * or the preset of the first player that matches the given condition if the vehicle preset is not defined.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
- * 1: Condition called with argument "_unit". If a longer function is given, it should be a precompiled <CODE> (default: {})
+ * 1: Condition called with argument "_unit". If a longer function is given, it should be precompiled. <CODE> (default: {})
  *
  * Return Value:
  * Setup successful <BOOL>

--- a/addons/api/fnc_initVehicleRacks.sqf
+++ b/addons/api/fnc_initVehicleRacks.sqf
@@ -1,9 +1,11 @@
 /*
  * Author: ACRE2Team
- * Initialises all racks in the vehicle. Must be executed in the server.
+ * Initialises all racks in the vehicle. Must be executed in the server. If no side is specified,
+ * the radio will be configured to match the side of the first player.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
+ * 1: Side <STRING> (default: "")
  *
  * Return Value:
  * Setup successful <BOOL>
@@ -15,7 +17,7 @@
  */
 #include "script_component.hpp"
 
-params [["_vehicle", objNull]];
+params [["_vehicle", objNull], ["_side", ""]];
 
 if (!isServer) exitWith {
     WARNING("Function must be called on the server.");
@@ -35,11 +37,20 @@ if ([_vehicle] call FUNC(areVehicleRacksInitialized)) exitWith {
 // A player must do the action of initialising a rack
 private _player = objNull;
 
-if (isDedicated) then {
-    // Pick the first player
+if (_side isEqualTo "") then {
     _player = (allPlayers - entities "HeadlessClient_F") select 0;
 } else {
-    _player = acre_player;
+    // Pick the first player that matches side criteria
+    {
+        if (side _x isEqualTo _side) then {
+            _player = _x;
+        };
+    } forEach (allPlayers - entities "HeadlessClient_F");
+
+    if (isNull _player) then {
+        WARNING_1("No unit found for side %1, defaulting to first player",_side);
+        _player = (allPlayers - entities "HeadlessClient_F") select 0;
+    };
 };
 
 [QEGVAR(sys_rack,initVehicleRacks), [_vehicle], _player] call CBA_fnc_targetEvent;

--- a/addons/api/fnc_initVehicleRacks.sqf
+++ b/addons/api/fnc_initVehicleRacks.sqf
@@ -5,19 +5,19 @@
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
- * 1: Side <STRING> (default: "")
+ * 1: Condition called with argument "_unit" <STRING> (default: "")
  *
  * Return Value:
  * Setup successful <BOOL>
  *
  * Example:
- * [cursorTarget] call acre_api_fnc_initVehicleRacks
+ * [cursorTarget, "side _unit == west"] call acre_api_fnc_initVehicleRacks
  *
  * Public: Yes
  */
 #include "script_component.hpp"
 
-params [["_vehicle", objNull], ["_side", ""]];
+params [["_vehicle", objNull], ["_condition", ""]];
 
 if (!isServer) exitWith {
     WARNING("Function must be called on the server.");
@@ -37,19 +37,20 @@ if ([_vehicle] call FUNC(areVehicleRacksInitialized)) exitWith {
 // A player must do the action of initialising a rack
 private _player = objNull;
 
-if (_side isEqualTo "") then {
-    _player = (allPlayers - entities "HeadlessClient_F") select 0;
+if (_condition isEqualTo "") then {
+    _player = ([] call CBA_fnc_players) select 0;
 } else {
     // Pick the first player that matches side criteria
     {
-        if (side _x isEqualTo _side) then {
-            _player = _x;
+        private _unit = _x;
+        if ([_unit] call compile _condition) then {
+            _player = _unit;
         };
-    } forEach (allPlayers - entities "HeadlessClient_F");
+    } forEach ([] call CBA_fnc_players);
 
     if (isNull _player) then {
-        WARNING_1("No unit found for side %1, defaulting to first player",_side);
-        _player = (allPlayers - entities "HeadlessClient_F") select 0;
+        WARNING_1("No unit found for condition %1, defaulting to first player",_condition);
+        _player = ([] call CBA_fnc_players) select 0;
     };
 };
 

--- a/addons/api/fnc_initVehicleRacks.sqf
+++ b/addons/api/fnc_initVehicleRacks.sqf
@@ -1,17 +1,18 @@
 /*
  * Author: ACRE2Team
- * Initialises all racks in the vehicle. Must be executed in the server. If no side is specified,
- * the radio will be configured to match the side of the first player.
+ * Initialises all racks in the vehicle. Must be executed in the server. If no condition is specified,
+ * the radio will be configured to match the vehicle preset defined using acre_api_fnc_setVehicleRacksPreset
+ * or the preset of the first player that matches the given condition if the vehicle preset is not defined. 
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
- * 1: Condition called with argument "_unit" <STRING> (default: "")
+ * 1: Condition called with argument "_unit". If a longer function is given, it should be a precompiled <CODE> (default: "")
  *
  * Return Value:
  * Setup successful <BOOL>
  *
  * Example:
- * [cursorTarget, "side _unit == west"] call acre_api_fnc_initVehicleRacks
+ * [cursorTarget, {}] call acre_api_fnc_initVehicleRacks
  *
  * Public: Yes
  */
@@ -37,7 +38,8 @@ if ([_vehicle] call FUNC(areVehicleRacksInitialized)) exitWith {
 // A player must do the action of initialising a rack
 private _player = objNull;
 
-if (_condition isEqualTo "") then {
+private _vehiclePresetName = [_vehicle] call FUNC(getVehicleRacksPreset);
+if (_condition isEqualTo "" && {_vehiclePresetName == ""}) then {
     _player = ([] call CBA_fnc_players) select 0;
 } else {
     // Pick the first player that matches side criteria
@@ -55,6 +57,5 @@ if (_condition isEqualTo "") then {
 };
 
 [QEGVAR(sys_rack,initVehicleRacks), [_vehicle], _player] call CBA_fnc_targetEvent;
-
 
 true

--- a/addons/api/fnc_initVehicleRacks.sqf
+++ b/addons/api/fnc_initVehicleRacks.sqf
@@ -39,7 +39,7 @@ if ([_vehicle] call FUNC(areVehicleRacksInitialized)) exitWith {
 private _player = objNull;
 
 private _vehiclePresetName = [_vehicle] call FUNC(getVehicleRacksPreset);
-if (_condition isEqualTo "" && {_vehiclePresetName == ""}) then {
+if (_condition isEqualTo "" && {!(_vehiclePresetName isEqualTo "")}) then {
     _player = ([] call CBA_fnc_players) select 0;
 } else {
     // Pick the first player that matches side criteria

--- a/addons/api/fnc_setVehicleRacksPreset.sqf
+++ b/addons/api/fnc_setVehicleRacksPreset.sqf
@@ -3,8 +3,8 @@
  * Sets the preset name used for initialising the vehicle racks.
  *
  * Arguments:
- * 0: Vehicle <OBJECT> (Default: objNull)
- * 1: Preset name <STRING> (Default: "")
+ * 0: Vehicle <OBJECT> (default: objNull)
+ * 1: Preset name <STRING> (default: "")
  *
  * Return Value:
  * Successfully set the vehicle preset <BOOL>
@@ -19,12 +19,12 @@
 params [["_vehicle", objNull], ["_presetName", ""]];
 
 if (isNull _vehicle) exitWith {
-    ERROR("Vehicle is null");
+    WARNING("Vehicle is null");
     false
 };
 
 if (_presetName isEqualTo "") exitWith {
-    ERROR("Empty preset name introduced");
+    WARNING("Empty preset name introduced");
     false
 };
 

--- a/addons/api/fnc_setVehicleRacksPreset.sqf
+++ b/addons/api/fnc_setVehicleRacksPreset.sqf
@@ -1,0 +1,33 @@
+/*
+ * Author: ACRE2Team
+ * Sets the preset name used for initialising the vehicle racks.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT> (Default: objNull)
+ * 1: Preset name <STRING> (Default: "")
+ *
+ * Return Value:
+ * Successfully set the vehicle preset <BOOL>
+ *
+ * Example:
+ * [cursorTarget, "default4"] call acre_api_fnc_setVehicleRacksPreset
+ *
+ * Public: Yes
+ */
+#include "script_component.hpp"
+
+params [["_vehicle", objNull], ["_presetName", ""]];
+
+if (isNull _vehicle) exitWith {
+    ERROR("Vehicle is null");
+    false
+};
+
+if (_presetName isEqualTo "") exitWith {
+    ERROR("Empty preset name introduced");
+    false
+};
+
+_vehicle setVariable [QEGVAR(sys_rack,vehicleRacksPreset), _presetName, true];
+
+true

--- a/addons/sys_rack/fnc_onReturnRadioId.sqf
+++ b/addons/sys_rack/fnc_onReturnRadioId.sqf
@@ -52,7 +52,10 @@ if (_condition) then {
         TRACE_2("Adding radio", _class, _baseRadio);
 
         // initialize the new radio
-        private _preset = [BASECLASS(_class)] call EFUNC(sys_data,getRadioPresetName);
+        private _preset = _vehicle getVariable [QGVAR(vehicleRacksPreset), ""];
+        if (_preset isEqualTo "") then {
+            preset = [BASECLASS(_class)] call EFUNC(sys_data,getRadioPresetName);
+        }
         [_class, _preset] call EFUNC(sys_radio,initDefaultRadio);
 
         //Mount the radio into the rack.

--- a/addons/sys_rack/fnc_onReturnRadioId.sqf
+++ b/addons/sys_rack/fnc_onReturnRadioId.sqf
@@ -55,7 +55,7 @@ if (_condition) then {
         private _preset = _vehicle getVariable [QGVAR(vehicleRacksPreset), ""];
         if (_preset isEqualTo "") then {
             preset = [BASECLASS(_class)] call EFUNC(sys_data,getRadioPresetName);
-        }
+        };
         [_class, _preset] call EFUNC(sys_radio,initDefaultRadio);
 
         //Mount the radio into the rack.


### PR DESCRIPTION
**Problem descriptioin**
Rack initialisation through API selected always the first player. This could break TvT games where radio presets are assigned depending on the side of the unit.

**When merged this pull request will:**
- Adds an additional argument to API functions `initVehicleRacks` and `addRackToVehicle` that specifies  the condition for a given unit. The first player that matches the side criteria will initialise the rack.

**Update** custom radio presets can be added to racked radios too. Two new API functions have been added for this purpose:

- setVehicleRacksPreset
- getVehicleRacksPreset

Vehicle racks preset have priority over player presets if defined.