### PR TITLE
Intercoms - Don't run configIntercom if no intercoms exist

### DIFF
--- a/addons/sys_intercom/fnc_configIntercom.sqf
+++ b/addons/sys_intercom/fnc_configIntercom.sqf
@@ -4,6 +4,7 @@
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
+ * 1: Intercom Configs <ARRAY>
  *
  * Return Value:
  * None
@@ -15,10 +16,9 @@
  */
 #include "script_component.hpp"
 
-params ["_vehicle"];
+params ["_vehicle", "_intercoms"];
 
 private _classname = typeOf _vehicle;
-private _intercoms = configFile >> "CfgVehicles" >> _classname >> "AcreIntercoms";
 private _intercomNames = [];
 private _intercomDisplayNames = [];
 private _intercomShortNames = [];
@@ -113,7 +113,7 @@ private _broadcasting = [];
     _intercomConnectByDefault pushBack _connectedByDefault;
     _intercomMasterStation pushBack _masterStationPositions;
     _broadcasting pushBack [false, objNull];
-} forEach (configProperties [_intercoms, "isClass _x", true]);
+} forEach _intercoms;
 
 [_vehicle, _intercomPositions, _intercomExceptions, _intercomLimitedPositions, _intercomConnectByDefault, _intercomMasterStation] call FUNC(configIntercomStations);
 

--- a/addons/sys_intercom/fnc_initVehicleIntercom.sqf
+++ b/addons/sys_intercom/fnc_initVehicleIntercom.sqf
@@ -19,10 +19,10 @@ params ["_vehicle"];
 
 private _classname = typeOf _vehicle;
 
-private _intercoms = configFile >> "CfgVehicles" >> _classname >> "AcreIntercoms";
+private _intercoms = configProperties [configFile >> "CfgVehicles" >> _classname >> "AcreIntercoms", "isClass _x", true];
 
 if !(_intercoms isEqualTo []) then {
-    [_vehicle] call FUNC(configIntercom);
+    [_vehicle, _intercoms] call FUNC(configIntercom);
 
     if (hasInterface && {isClass (configFile >> "CfgPatches" >> "ace_interact_menu")}) then {
         [_vehicle] call FUNC(intercomAction);


### PR DESCRIPTION
initVehicleIntercom.sqf was checking
```
private _intercoms = configFile >> "CfgVehicles" >> _classname >> "AcreIntercoms";
if !(_intercoms isEqualTo []) then {
```

`_intercoms` would always be type config (so `isEqualTo []` could never be true)