### PR TITLE
Enable channel fast switch for racked radios

### DIFF
--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -23,8 +23,9 @@ private _radioId = ACRE_ACTIVE_RADIO;
 private _radioType = [_radioId] call EFUNC(sys_radio,getRadioBaseClassname);
 private _typeName = getText (configFile >> "CfgAcreComponents" >> _radioType >> "name");
 private _isManpack = getNumber (configFile >> "CfgAcreComponents" >> _radioType >> "isPackRadio");
+private _isRackRadio = vehicle acre_player != acre_player && {_radioId in (([vehicle acre_player] call EFUNC(api,getVehicleRacks)) apply {[_x] call EFUNC(api,getMountedRackRadio)})};
 
-if (_isManpack == 0) then {
+if (_isManpack == 0 || _isRackRadio) then {
     private _channel = [_radioId] call EFUNC(api,getRadioChannel);
 
     switch (_radioType) do {

--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -23,7 +23,7 @@ private _radioId = ACRE_ACTIVE_RADIO;
 private _radioType = [_radioId] call EFUNC(sys_radio,getRadioBaseClassname);
 private _typeName = getText (configFile >> "CfgAcreComponents" >> _radioType >> "name");
 private _isManpack = getNumber (configFile >> "CfgAcreComponents" >> _radioType >> "isPackRadio");
-private _isRackRadio = vehicle acre_player != acre_player && {_radioId in (([vehicle acre_player] call EFUNC(api,getVehicleRacks)) apply {[_x] call EFUNC(api,getMountedRackRadio)})};
+private _isRackRadio = vehicle acre_player != acre_player && {_radioId in (([vehicle acre_player] call EFUNC(api,getVehicleRacks)) apply {[_x] call EFUNC(api,getMountedRackRadio)})} && {[_radioId, acre_player] call EFUNC(sys_rack,isRadioAccessible)};
 
 if (_isManpack == 0 || _isRackRadio) then {
     private _channel = [_radioId] call EFUNC(api,getRadioChannel);

--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -23,9 +23,9 @@ private _radioId = ACRE_ACTIVE_RADIO;
 private _radioType = [_radioId] call EFUNC(sys_radio,getRadioBaseClassname);
 private _typeName = getText (configFile >> "CfgAcreComponents" >> _radioType >> "name");
 private _isManpack = getNumber (configFile >> "CfgAcreComponents" >> _radioType >> "isPackRadio");
-private _isRackRadio = vehicle acre_player != acre_player && {_radioId in (([vehicle acre_player] call EFUNC(api,getVehicleRacks)) apply {[_x] call EFUNC(api,getMountedRackRadio)})} && {[_radioId, acre_player] call EFUNC(sys_rack,isRadioAccessible)};
+private _isRackRadio = (vehicle acre_player != acre_player) && {_radioId in (([vehicle acre_player] call EFUNC(api,getVehicleRacks)) apply {[_x] call EFUNC(api,getMountedRackRadio)})} && {[_radioId, acre_player] call EFUNC(sys_rack,isRadioAccessible)};
 
-if (_isManpack == 0 || _isRackRadio) then {
+if (_isManpack == 0 || {_isRackRadio}) then {
     private _channel = [_radioId] call EFUNC(api,getRadioChannel);
 
     switch (_radioType) do {


### PR DESCRIPTION
**When merged this pull request will:**
- Add check to fast channel switch to allow fast switching of racked radios
- Rationale is a radio in a rack is usually as easily accessible as a normal radio