### PR TITLE
Added option to remember racks in use for re-entering a vehicle

### DIFF
--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -128,6 +128,16 @@
     {[_this, true] call EFUNC(api,setRevealToAI)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;
 
+// Remember used rack radios
+[
+    QGVAR(rememberUsedRackRadios),
+    "CHECKBOX",
+    localize LSTRING(rememberUsedRackRadios_displayName),
+    "ACRE2",
+    true,
+    true
+] call CBA_Settings_fnc_init;
+
 // @todo remove in 2.7.0
 // Module settings
 // Applies the difficulty module settings over CBA settings. If the module is not present, this function has no effect.

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -405,6 +405,9 @@
             <Portuguese>Detecção de Voz de IA</Portuguese>
             <Italian>Rilevamento Voce IA</Italian>
         </Key>
+        <Key ID="STR_ACRE_sys_core_rememberUsedRackRadios_displayName">
+            <English>Remember Vehicle Racks In Use</English>
+        </Key>
         <Key ID="STR_ACRE_sys_core_switchRadioEarLeft">
             <English>Set to Left Ear</English>
             <Spanish>Usar auricular izquierdo</Spanish>

--- a/addons/sys_rack/fnc_enterVehicle.sqf
+++ b/addons/sys_rack/fnc_enterVehicle.sqf
@@ -54,6 +54,22 @@ if (_unit != _vehicle) then {
         };
     };
 
+    if (EGVAR(sys_core,rememberUsedRackRadios)) then {
+        private _rackedRadiosInUse = _vehicle getVariable [QGVAR(rackedRadiosInUse), []];
+        if (count _rackedRadiosInUse > 0) then {
+            [{
+                params ["_vehicle", "_unit", "_rackedRadiosInUse"];
+
+                private _rackedRadios = ([_vehicle, _unit] call FUNC(getVehicleRacks)) apply {[_x] call FUNC(getMountedRadio)};
+                {
+                    if (_x in _rackedRadios) then {
+                        [_vehicle, _unit, _x] call FUNC(startUsingMountedRadio);
+                    };
+                } forEach _rackedRadiosInUse;
+            }, [_vehicle, _unit, _rackedRadiosInUse]] call CBA_fnc_execNextFrame;
+        };
+    };
+
     // Update the display
     [_vehicle, _unit] call EFUNC(sys_intercom,updateVehicleInfoText);
 

--- a/addons/sys_rack/fnc_startUsingMountedRadio.sqf
+++ b/addons/sys_rack/fnc_startUsingMountedRadio.sqf
@@ -17,6 +17,12 @@
 
 params ["_vehicle", "_unit", "_radioId"];
 
+if (EGVAR(sys_core,rememberUsedRackRadios)) then {
+    private _rackedRadiosInUse = _vehicle getVariable [QGVAR(rackedRadiosInUse), []];
+    _rackedRadiosInUse pushBackUnique _radioId;
+    _vehicle setVariable [QGVAR(rackedRadiosInUse), _rackedRadiosInUse];
+};
+
 private _isRadioAccessible = [_radioId, _unit] call FUNC(isRadioAccessible);
 private _isRadioHearable = [_radioId, _unit] call FUNC(isRadioHearable);
 

--- a/addons/sys_rack/fnc_stopUsingMountedRadio.sqf
+++ b/addons/sys_rack/fnc_stopUsingMountedRadio.sqf
@@ -17,6 +17,12 @@
 
 params ["_vehicle", "_unit", "_radioId"];
 
+if (EGVAR(sys_core,rememberUsedRackRadios)) then {
+    private _rackedRadiosInUse = _vehicle getVariable [QGVAR(rackedRadiosInUse), []];
+    _rackedRadiosInUse deleteAt (_rackedRadiosInUse find _radioId);
+    _vehicle setVariable [QGVAR(rackedRadiosInUse), _rackedRadiosInUse];
+};
+
 if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS) then {
     ACRE_ACCESSIBLE_RACK_RADIOS deleteAt (ACRE_ACCESSIBLE_RACK_RADIOS find _radioId);
 } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Added the ability to remember which racked radios are in use
- When entering a vehicle, if any radios were remembered, it will try to start using those radios
- Can be disabled via setting (enabled by default)
