### PR TITLE
Add Start/Stop Speaking CBA Events

### DIFF
--- a/addons/sys_core/fnc_localStartSpeaking.sqf
+++ b/addons/sys_core/fnc_localStartSpeaking.sqf
@@ -18,11 +18,14 @@
  */
 #include "script_component.hpp"
 
-private _onRadio = parseNumber(_this select 2);
+private _onRadio = (parseNumber (_this select 2)) == 1;
 private _radioId = _this select 3;
 TRACE_1("LOCAL START SPEAKING ENTER", _this);
+
 ACRE_LOCAL_SPEAKING = true;
-if (_onRadio == 1) then {
+["acre_startedSpeaking", [acre_player, _onRadio == 1, _radioId]] call CBA_fnc_localEvent; // [unit, on radio, radio ID]
+
+if (_onRadio) then {
     ACRE_LOCAL_BROADCASTING = true;
 
     if (isNil "ACRE_CustomVolumeControl") then {

--- a/addons/sys_core/fnc_localStartSpeaking.sqf
+++ b/addons/sys_core/fnc_localStartSpeaking.sqf
@@ -3,8 +3,8 @@
  * Handles the local player start speaking event.
  *
  * Arguments:
- * 0: Speaking ID <STRING>
- * 1: Net id of local player object <STRING>
+ * 0: Speaking ID <STRING> (unused)
+ * 1: Net id of local player object <STRING> (unused)
  * 2: On radio ("0" for false, "1" for true) <STRING>
  * 3: Radio ID if talking on radio <STRING>
  *
@@ -18,9 +18,9 @@
  */
 #include "script_component.hpp"
 
-private _onRadio = (parseNumber (_this select 2)) == 1;
-private _radioId = _this select 3;
 TRACE_1("LOCAL START SPEAKING ENTER", _this);
+params ["", "", "_onRadio", ["_radioId", ""]];
+_onRadio = _onRadio == "1";
 
 ACRE_LOCAL_SPEAKING = true;
 ["acre_startedSpeaking", [acre_player, _onRadio, _radioId]] call CBA_fnc_localEvent; // [unit, on radio, radio ID]
@@ -50,14 +50,8 @@ if (_onRadio) then {
 } else {
     ACRE_LOCAL_BROADCASTING = false;
 };
-/*
-_speakingId = parseNumber((_this select 0));
-_netId = _this select 1;
-_onRadio = parseNumber((_this select 2));
-_radioId = _this select 3;
-*/
 
-//Make all the present speakers on the radio net, volume go to 0
+// Make all the present speakers on the radio net, volume go to 0
 if (!GVAR(fullDuplex)) then {
     if (ACRE_BROADCASTING_RADIOID != "") then {
         GVAR(previousSortedParams) params ["_radios","_sources"];

--- a/addons/sys_core/fnc_localStartSpeaking.sqf
+++ b/addons/sys_core/fnc_localStartSpeaking.sqf
@@ -23,7 +23,7 @@ private _radioId = _this select 3;
 TRACE_1("LOCAL START SPEAKING ENTER", _this);
 
 ACRE_LOCAL_SPEAKING = true;
-["acre_startedSpeaking", [acre_player, _onRadio == 1, _radioId]] call CBA_fnc_localEvent; // [unit, on radio, radio ID]
+["acre_startedSpeaking", [acre_player, _onRadio, _radioId]] call CBA_fnc_localEvent; // [unit, on radio, radio ID]
 
 if (_onRadio) then {
     ACRE_LOCAL_BROADCASTING = true;

--- a/addons/sys_core/fnc_localStopSpeaking.sqf
+++ b/addons/sys_core/fnc_localStopSpeaking.sqf
@@ -17,8 +17,11 @@
 #include "script_component.hpp"
 
 TRACE_1("LOCAL STOP SPEAKING ENTER", _this);
+
+["acre_stoppedSpeaking", [acre_player, ACRE_LOCAL_BROADCASTING]] call CBA_fnc_localEvent; // [unit, on radio]
 ACRE_LOCAL_SPEAKING = false;
 ACRE_LOCAL_BROADCASTING = false;
+
 //ACRE_BROADCASTING_RADIOID = "";
 if (isNil "ACRE_CustomVolumeControl") then {
     [] call EFUNC(sys_gui,closeVolumeControl); // reset voice curve.

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -133,6 +133,10 @@ entries:
       url: /wiki/frameworks/functions-list
       output: web, pdf
 
+    - title: Events List
+      url: /wiki/frameworks/events-list
+      output: web, pdf
+
     - title: Mission Making Intro
       url: /wiki/frameworks/mission-making-intro
       output: web, pdf

--- a/docs/wiki/frameworks/events-list.md
+++ b/docs/wiki/frameworks/events-list.md
@@ -2,6 +2,8 @@
 title: Events List
 ---
 
+{% include important.html content="Following table lists only public API events!" %}
+
 | Name  | Arguments | Type | Version |
 | ----- |---------- | ---- | ------- |
 | `acre_startedSpeaking` | Unit <OBJECT>, On Radio <BOOL>, Radio ID <NUMBER> | Local | 2.7.0 |

--- a/docs/wiki/frameworks/events-list.md
+++ b/docs/wiki/frameworks/events-list.md
@@ -7,4 +7,4 @@ title: Events List
 | Name  | Arguments | Type | Version |
 | ----- |---------- | ---- | ------- |
 | `acre_startedSpeaking` | Unit <OBJECT>, On Radio <BOOL>, Radio ID <NUMBER> | Local | 2.7.0 |
-| `acre_stoppedSpeaking` | Unit <OBJECT> | Local | 2.7.0 |
+| `acre_stoppedSpeaking` | Unit <OBJECT>, On Radio <BOOL> | Local | 2.7.0 |

--- a/docs/wiki/frameworks/events-list.md
+++ b/docs/wiki/frameworks/events-list.md
@@ -1,0 +1,8 @@
+---
+title: Events List
+---
+
+| Name  | Arguments | Type | Version |
+| ----- |---------- | ---- | ------- |
+| `acre_startedSpeaking` | Unit <OBJECT>, On Radio <BOOL>, Radio ID <NUMBER> | Local | 2.7.0 |
+| `acre_stoppedSpeaking` | Unit <OBJECT> | Local | 2.7.0 |


### PR DESCRIPTION
**When merged this pull request will:**
- Add CBA local events for start and stop of speaking
  - One can read if direct speaking or radio speaking via the variables provided
- Use `_onRadio` as boolean after first read (comes as string from extension)
- Close #570 