### PR TITLE
Fix shared radios in vehicles

### DIFF
--- a/addons/sys_external/fnc_isExternalRadioAvailable.sqf
+++ b/addons/sys_external/fnc_isExternalRadioAvailable.sqf
@@ -23,7 +23,7 @@
 params ["_radioId", "_owner"];
 
 // Check if actual owner of the radio is less than 2.0m away.
-if ((_owner distance acre_player) > EXTERNAL_RADIO_MAXDISTANCE) exitWith {false};
+if (((_owner distance acre_player) > EXTERNAL_RADIO_MAXDISTANCE) && {vehicle _owner != vehicle acre_player}) exitWith {false};
 
 // Captive players are not allowed to use external radios
 if (captive acre_player) exitWith {false};


### PR DESCRIPTION
**When merged this pull request will:**
When a player was sharing a radio inside a vehicle and the speed was 0, everything was ok. This was not the case when the vehicle was moving.