### PR TITLE
Introduce factor for AI revealing

### DIFF
--- a/addons/api/fnc_getRevealToAI.sqf
+++ b/addons/api/fnc_getRevealToAI.sqf
@@ -7,7 +7,7 @@
  * None
  *
  * Return Value:
- * AI enabled <BOOLEAN>
+ * AI enabled <NUMBER>
  *
  * Example:
  * [] call acre_api_fnc_getRevealToAI;

--- a/addons/api/fnc_setRevealToAI.sqf
+++ b/addons/api/fnc_setRevealToAI.sqf
@@ -4,14 +4,14 @@
  * Effects are local.
  *
  * Arguments:
- * 0: Reveal players to AI that speak <BOOL>
+ * 0: Reveal factor players to AI that speak <NUMBER>
  * 1: CBA Settings Call <BOOL> (default: false)
  *
  * Return Value:
- * Are players that speak revealed to AI <BOOL>
+ * Reveal factor for revealing players to AI <NUMBER>
  *
  * Example:
- * _status = [false] call acre_api_fnc_setRevealToAI
+ * _status = [0.5] call acre_api_fnc_setRevealToAI
  *
  * Public: Yes
  */
@@ -31,13 +31,10 @@ if (!_CBASettingCall) then {
     WARNING_1("%1 has been called directly and CBA Setting for it has been blocked!",QFUNC(setRevealToAI));
 };
 
-// Set
-if !(_var isEqualType false) exitWith { false };
-
-if (!EGVAR(sys_core,revealToAI) && _var) then {
+if (EGVAR(sys_core,revealToAI) isEqualTo 0 && _var > 0) then {
     [] call EFUNC(sys_core,enableRevealAI);
 } else {
-    if (EGVAR(sys_core,revealToAI) && !_var) then {
+    if ((EGVAR(sys_core,revealToAI) > 0) && _var isEqualTo 0) then {
         [] call EFUNC(sys_core,disableRevealAI);
     };
 };

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -87,7 +87,7 @@ if (!([findDisplay 0] isEqualTo allDisplays)) then {
 ADDPFH(DFUNC(coreInitPFH), 0, []);
 
 // Call our setter to enable AI reveal if its been set here
-if (GVAR(revealToAI) && hasInterface) then {
+if ((GVAR(revealToAI) > 0) && hasInterface) then {
     INFO("AI Detection Activated.");
     [] call FUNC(enableRevealAI);
 } else {

--- a/addons/sys_core/fnc_enableRevealAI.sqf
+++ b/addons/sys_core/fnc_enableRevealAI.sqf
@@ -1,4 +1,3 @@
-#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team

--- a/addons/sys_core/fnc_enableRevealAI.sqf
+++ b/addons/sys_core/fnc_enableRevealAI.sqf
@@ -1,3 +1,4 @@
+#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team
@@ -27,7 +28,7 @@ DFUNC(monitorAI_PFH) = {
 
     //soundFactor is how loud the local player is speaking.
     private _soundFactor = EGVAR(api,selectableCurveScale); // typically 0.1 -> 1.3
-    private _multiplier = 250*(_soundFactor^2);
+    private _multiplier = GVAR(revealToAI)*250*(_soundFactor^2);
 
     private _nearUnits = (getPosATL acre_player) nearEntities ["CAManBase", (130 * _soundFactor)];
     private _startTime = diag_tickTime;
@@ -67,7 +68,7 @@ DFUNC(monitorAI_PFH) = {
         };
     } forEach _nearUnits;
 
-    if (!GVAR(revealToAI)) then {
+    if (GVAR(revealToAI) isEqualTo 0) then {
         [(_this select 1)] call CBA_fnc_removePerFrameHandler;
     };
 };

--- a/addons/sys_core/fnc_enableRevealAI.sqf
+++ b/addons/sys_core/fnc_enableRevealAI.sqf
@@ -27,7 +27,7 @@ DFUNC(monitorAI_PFH) = {
 
     //soundFactor is how loud the local player is speaking.
     private _soundFactor = EGVAR(api,selectableCurveScale); // typically 0.1 -> 1.3
-    private _multiplier = GVAR(revealToAI)*250*(_soundFactor^2);
+    private _multiplier = GVAR(revealToAI) * 100 * (_soundFactor ^ 2);
 
     private _nearUnits = (getPosATL acre_player) nearEntities ["CAManBase", (130 * _soundFactor)];
     private _startTime = diag_tickTime;
@@ -46,7 +46,7 @@ DFUNC(monitorAI_PFH) = {
 
             // Cheaper approximation for AI
             private _intersectObjects = lineIntersectsObjs [eyePos _curUnit, ACRE_LISTENER_POS, _curUnit, acre_player, false, 6];
-            private _occlusion = ((0.1+_soundFactor)/2)^(count _intersectObjects); // - Occlusion make harsher the quieter the player is.
+            private _occlusion = ((0.1 + _soundFactor) / 2) ^ (count _intersectObjects); // - Occlusion make harsher the quieter the player is.
 
             // Calculate the probability of revealing.
             // y=\frac{250\cdot \left(\left(1.3\right)^2\right)}{\left(x\right)^2}

--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -123,7 +123,7 @@
     "SLIDER",
     localize LSTRING(revealToAI_displayName),
     "ACRE2",
-    [0, 1, 1, 2],
+    [0, 2.50, 1, 2],
     true,
     {[_this, true] call EFUNC(api,setRevealToAI)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;

--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -123,7 +123,7 @@
     "SLIDER",
     localize LSTRING(revealToAI_displayName),
     "ACRE2",
-    [0, 1, 0.50, 2],
+    [0, 1, 1, 2],
     true,
     {[_this, true] call EFUNC(api,setRevealToAI)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;

--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -120,10 +120,10 @@
 // Reveal to AI
 [
     QGVAR(revealToAI),
-    "CHECKBOX",
+    "SLIDER",
     localize LSTRING(revealToAI_displayName),
     "ACRE2",
-    true,
+    [0, 1, 0.50, 2],
     true,
     {[_this, true] call EFUNC(api,setRevealToAI)} // @todo remove second parameter in 2.7.0
 ] call CBA_Settings_fnc_init;


### PR DESCRIPTION
**When merged this pull request will:**
Convert the AI revealing setting from a boolean to a number. This enables communities and mission makers to set how good (how far) the AI hears players.

Closes #606 