### PR TITLE
Fix  function getGear

### DIFF
--- a/addons/sys_core/fnc_getGear.sqf
+++ b/addons/sys_core/fnc_getGear.sqf
@@ -24,7 +24,7 @@ if (isNull _unit) exitWith {[]};
 private _gear = (getItemCargo (uniformContainer _unit)) select 0;
 _gear append ((getItemCargo (vestContainer _unit)) select 0);
 _gear append ((getItemCargo (backpackContainer _unit)) select 0);
-_gear pushBack ((assignedItems _unit) select 3);
+_gear append (assignedItems _unit);
 
 _gear = _gear select {(_x select [0, 4]) == "ACRE" || {_x == "ItemRadio"} || {_x == "ItemRadioAcreFlagged"}}; // We are only interested in ACRE gear.
 // The below is really slow and tends to worsen performance.


### PR DESCRIPTION
**When merged this pull request will:**
- Fix function getGear.
- As it is now, it assumes that radios are in position 3, which may not be always the case (if no radios). It may cause the following: 
```
_gear = _gear select {(_x se>
22:44:56   Error Zero divisor
22:44:56 File idi\acre\addons\sys_core\fnc_getGear.sqf, line 27
22:44:56 Error in expression <;
_gear pushBack ((assignedItems _unit) select 3);
```
