### PR TITLE
Display radio number in front of radio in ACE self-interact

### DIFF
--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -43,6 +43,13 @@ private _radioList = [] call EFUNC(api,getCurrentRadioList);
 
     private _currentChannel = [_x] call EFUNC(api,getRadioChannel);
     _displayName = format [localize LSTRING(channelShort), _displayName, _currentChannel];
+
+    // Display radio keys in front of those which are bound
+    private _radiokey = (_pttAssign find _x) + 1;
+    if (_radiokey <= 3) then {
+        _displayName = format ["%1: %2", _radiokey, _displayName, _currentChannel];
+    };
+
     private _picture = getText (_item >> "picture");
     private _isActive = _x isEqualTo _currentRadio;
 


### PR DESCRIPTION
This PR will add a number corresponding to the radio key / "multi PTT" to each radio on the "Radios" subsection of ACE self interaction.

![No rack bound](https://i.imgur.com/xigxCjG.png)

![With a rack bound](https://i.imgur.com/ahGfKJo.png)