### PR TITLE
Change default radio keys and streamline key strings

### DIFF
--- a/addons/ace_interact/stringtable.xml
+++ b/addons/ace_interact/stringtable.xml
@@ -137,49 +137,49 @@
             <Portuguese>Difinir Como Ativo</Portuguese>
         </Key>
         <Key ID="STR_ACRE_ace_interact_bindMultiPushToTalk">
-            <English>Bind Multi PTT</English>
-            <Spanish>Definir como Multi PTT</Spanish>
+            <English>Bind PTT</English>
+            <Spanish>Definir como PTT</Spanish>
             <German>Sprechtasten festlegen</German>
             <Japanese>マルチ プッシュ トークに割当</Japanese>
-            <Czech>Přiřadit klávesu pro Multi PTT</Czech>
-            <Italian>Imposta Multi PTT</Italian>
-            <French>Définir Multi PTT</French>
+            <Czech>Přiřadit klávesu pro PTT</Czech>
+            <Italian>Imposta PTT</Italian>
+            <French>Définir PTT</French>
             <Korean>멀티 PTT 설정</Korean>
             <Polish>Ustaw klawisz PTT</Polish>
             <Russian>Назначить общую ПТТ</Russian>
             <Chinese>綁定多個按鍵發話</Chinese>
             <Chinesesimp>绑定多个按键发话</Chinesesimp>
-            <Portuguese>Ligar Multi PTT</Portuguese>
+            <Portuguese>Ligar PTT</Portuguese>
         </Key>
         <Key ID="STR_ACRE_ace_interact_multiPushToTalk">
-            <English>Multi PTT %1</English>
-            <Spanish>Multi PTT %1</Spanish>
+            <English>PTT %1</English>
+            <Spanish>PTT %1</Spanish>
             <German>Sprechtaste %1</German>
             <Japanese>マルチ プッシュ トーク %1</Japanese>
-            <Czech>Multi PTT %1</Czech>
-            <Italian>Multi PTT %1</Italian>
-            <French>Multi PTT %1</French>
+            <Czech>PTT %1</Czech>
+            <Italian>PTT %1</Italian>
+            <French>PTT %1</French>
             <Korean>멀티 PTT %1</Korean>
-            <Polish>Klawisz PTT %1</Polish>
+            <Polish>PTT %1</Polish>
             <Russian>Общая ПТТ %1</Russian>
             <Chinese>多個發話 %1</Chinese>
             <Chinesesimp>多个发话 %1</Chinesesimp>
-            <Portuguese>Multi PTT %1</Portuguese>
+            <Portuguese>PTT %1</Portuguese>
         </Key>
         <Key ID="STR_ACRE_ace_interact_setAsMultiPTT">
-            <English>Set as Multi PTT %1</English>
-            <Spanish>Definir como Multi PTT %1</Spanish>
+            <English>Set as PTT %1</English>
+            <Spanish>Definir como PTT %1</Spanish>
             <German>Als Sprechtaste %1 festlegen</German>
             <Japanese>%1をマルチ プッシュ トークに</Japanese>
-            <Czech>Nastavit jako Multi PTT</Czech>
-            <Italian>Imposta Multi PTT %1</Italian>
-            <French>Définir comme Multi PTT</French>
+            <Czech>Nastavit jako PTT</Czech>
+            <Italian>Imposta PTT %1</Italian>
+            <French>Définir comme PTT</French>
             <Korean>%1번 PTT로 설정</Korean>
-            <Polish>Ustaw Multi PTT %1</Polish>
+            <Polish>Ustaw PTT %1</Polish>
             <Russian>Назначить как общую ПТТ %1</Russian>
             <Chinese>設定多個發話 %1</Chinese>
             <Chinesesimp>设定多个发话 %1</Chinesesimp>
-            <Portuguese>Definir Como Multi PTT %1</Portuguese>
+            <Portuguese>Definir Como PTT %1</Portuguese>
         </Key>
         <Key ID="STR_ACRE_ace_interact_straightenAntenna">
             <English>Straighten antenna</English>

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
 [QGVAR(onRevealUnit), { _this call FUNC(onRevealUnit) }] call CALLSTACK(CBA_fnc_addEventHandler);
 
@@ -23,60 +24,67 @@ DFUNC(gen) = {
 };
 
 
-// CBA Keybinds
+// Keybinds - PTT
 ["ACRE2", "DefaultPTTKey", [localize LSTRING(DefaultPTTKey), localize LSTRING(DefaultPTTKey_description)], {
     [-1] call FUNC(handleMultiPttKeyPress)
 }, {
     [-1] call FUNC(handleMultiPttKeyPressUp)
-}, [58, [false, false, false]]] call CBA_fnc_addKeybind;
+}, [DIK_CAPSLOCK, [false, false, false]]] call CBA_fnc_addKeybind;
 
 ["ACRE2", "AltPTTKey1", [localize LSTRING(AltPTTKey1), localize LSTRING(AltPTTKey1_description)], {
     [0] call FUNC(handleMultiPttKeyPress)
 }, {
     [0] call FUNC(handleMultiPttKeyPressUp)
-}, [58, [true, false, false]]] call CBA_fnc_addKeybind;
+}, [DIK_CAPSLOCK, [true, false, false]]] call CBA_fnc_addKeybind;
 
 ["ACRE2", "AltPTTKey2", [localize LSTRING(AltPTTKey2), localize LSTRING(AltPTTKey2_description)], {
     [1] call FUNC(handleMultiPttKeyPress)
 }, {
     [1] call FUNC(handleMultiPttKeyPressUp)
-}, [58, [false, true, false]]] call CBA_fnc_addKeybind;
+}, [DIK_CAPSLOCK, [false, true, false]]] call CBA_fnc_addKeybind;
 
 ["ACRE2", "AltPTTKey3", [localize LSTRING(AltPTTKey3), localize LSTRING(AltPTTKey3_description)], {
     [2] call FUNC(handleMultiPttKeyPress)
 }, {
     [2] call FUNC(handleMultiPttKeyPressUp)
-}, [58, [false, false, true]]] call CBA_fnc_addKeybind;
+}, [DIK_CAPSLOCK, [false, false, true]]] call CBA_fnc_addKeybind;
 
+// Keybinds - Channel Switch
 ["ACRE2", "PreviousChannel", localize LSTRING(PreviousChannel), "", {
     [-1] call FUNC(switchChannelFast)
-}, [208, [false, true, false]]] call CBA_fnc_addKeybind;
+}, [DIK_DOWNARROW, [false, true, false]]] call CBA_fnc_addKeybind;
 
 ["ACRE2", "NextChannel", localize LSTRING(NextChannel), "", {
     [1] call FUNC(switchChannelFast)
-}, [200, [false, true, false]]] call CBA_fnc_addKeybind;
+}, [DIK_UPARROW, [false, true, false]]] call CBA_fnc_addKeybind;
 
+// Keybinds - Babel
 ["ACRE2", "BabelCycleKey", localize LSTRING(BabelCycleKey), "", {
     [] call FUNC(cycleLanguage)
-}, [0xDB, [false, false, false]]] call CBA_fnc_addKeybind;
+}, [DIK_LWIN, [false, false, false]]] call CBA_fnc_addKeybind;
 
+// Keybinds - Radio Ear
 ["ACRE2", "RadioLeftEar", localize LSTRING(RadioLeftEar), {
     [-1] call FUNC(switchRadioEar)
-}, "", [203, [true, true, false]]] call CBA_fnc_addKeybind;
+}, "", [DIK_LEFTARROW, [true, true, false]]] call CBA_fnc_addKeybind;
 
 ["ACRE2", "RadioCentertEar", localize LSTRING(RadioBothEars), {
     [0] call FUNC(switchRadioEar)
-}, "", [200, [true, true, false]]] call CBA_fnc_addKeybind;
+}, "", [DIK_UPARROW, [true, true, false]]] call CBA_fnc_addKeybind;
 
 ["ACRE2", "RightRightEar", localize LSTRING(RightRightEar), {
     [1] call FUNC(switchRadioEar)
-}, "", [205, [true, true, false]]] call CBA_fnc_addKeybind;
+}, "", [DIK_RIGHTARROW, [true, true, false]]] call CBA_fnc_addKeybind;
 
+// Keybinds - Head Set
 ["ACRE2", "HeadSet", localize LSTRING(HeadSet), "", {
     [] call FUNC(toggleHeadset)
-}, [208, [true, true, false]]] call CBA_fnc_addKeybind;
+}, [DIK_DOWNARROW, [true, true, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "acre_AntennaDirToggle", localize LSTRING(AntennaDirToggle), "", { [] call EFUNC(sys_components,toggleAntennaDir) }, [200, [false, true, true]]] call CBA_fnc_addKeybind;
+// Keybinds - Antenna Direction
+["ACRE2", "acre_AntennaDirToggle", localize LSTRING(AntennaDirToggle), "", {
+    [] call EFUNC(sys_components,toggleAntennaDir)
+}, [DIK_UPARROW, [false, true, true]]] call CBA_fnc_addKeybind;
 
 
 // Load map data

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -134,9 +134,9 @@ ACRE_PLAYER_INTERCOM = [];
 if (getClientStateNumber < 10) then { // Check before game has started (in briefing state or earlier)
     ["setSoundSystemMasterOverride", [1]] call EFUNC(sys_rpc,callRemoteProcedure);
     [{
-        if (getClientStateNumber > 9 && time > 0) then { // Briefing has been read AND Mission has started
+        if (getClientStateNumber > 9 && {CBA_missionTime > 0}) then { // Briefing has been read AND Mission has started
             ["setSoundSystemMasterOverride", [0]] call EFUNC(sys_rpc,callRemoteProcedure);
-            [(_this select 1)] call CBA_fnc_removePerFrameHandler;
+            [_this select 1] call CBA_fnc_removePerFrameHandler;
         } else {
             // Keep calling incase ACRE is not connected to TeamSpeak
             ["setSoundSystemMasterOverride", [1]] call EFUNC(sys_rpc,callRemoteProcedure);

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -25,17 +25,11 @@ DFUNC(gen) = {
 
 
 // Keybinds - PTT
-["ACRE2", "DefaultPTTKey", [localize LSTRING(DefaultPTTKey), localize LSTRING(DefaultPTTKey_description)], {
-    [-1] call FUNC(handleMultiPttKeyPress)
-}, {
-    [-1] call FUNC(handleMultiPttKeyPressUp)
-}, [DIK_CAPSLOCK, [false, false, false]]] call CBA_fnc_addKeybind;
-
 ["ACRE2", "AltPTTKey1", [localize LSTRING(AltPTTKey1), localize LSTRING(AltPTTKey1_description)], {
     [0] call FUNC(handleMultiPttKeyPress)
 }, {
     [0] call FUNC(handleMultiPttKeyPressUp)
-}, [DIK_CAPSLOCK, [true, false, false]]] call CBA_fnc_addKeybind;
+}, [DIK_CAPSLOCK, [false, false, false]]] call CBA_fnc_addKeybind;
 
 ["ACRE2", "AltPTTKey2", [localize LSTRING(AltPTTKey2), localize LSTRING(AltPTTKey2_description)], {
     [1] call FUNC(handleMultiPttKeyPress)
@@ -48,6 +42,12 @@ DFUNC(gen) = {
 }, {
     [2] call FUNC(handleMultiPttKeyPressUp)
 }, [DIK_CAPSLOCK, [false, false, true]]] call CBA_fnc_addKeybind;
+
+["ACRE2", "DefaultPTTKey", [localize LSTRING(DefaultPTTKey), localize LSTRING(DefaultPTTKey_description)], {
+    [-1] call FUNC(handleMultiPttKeyPress)
+}, {
+    [-1] call FUNC(handleMultiPttKeyPressUp)
+}, [DIK_CAPSLOCK, [false, true, true]]] call CBA_fnc_addKeybind;
 
 // Keybinds - Channel Switch
 ["ACRE2", "PreviousChannel", localize LSTRING(PreviousChannel), "", {

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -47,7 +47,7 @@ DFUNC(gen) = {
     [-1] call FUNC(handleMultiPttKeyPress)
 }, {
     [-1] call FUNC(handleMultiPttKeyPressUp)
-}, [DIK_CAPSLOCK, [false, true, true]]] call CBA_fnc_addKeybind;
+}, [0, [false, false, false]]] call CBA_fnc_addKeybind;
 
 // Keybinds - Channel Switch
 ["ACRE2", "PreviousChannel", localize LSTRING(PreviousChannel), "", {

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -23,39 +23,67 @@ DFUNC(gen) = {
 };
 
 
-///////////////////////////////////
-//
-// CBA KEYBINDS
-///////////////////////////////////
+// CBA Keybinds
+["ACRE2", "DefaultPTTKey", [localize LSTRING(DefaultPTTKey), localize LSTRING(DefaultPTTKey_description)], {
+    [-1] call FUNC(handleMultiPttKeyPress)
+}, {
+    [-1] call FUNC(handleMultiPttKeyPressUp)
+}, [58, [false, false, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "DefaultPTTKey",  [(localize LSTRING(DefaultPTTKey)), (localize LSTRING(DefaultPTTKey_description))], { [-1] call FUNC(handleMultiPttKeyPress) }, { [-1] call FUNC(handleMultiPttKeyPressUp) }, [58, [false, false, false]]] call CBA_fnc_addKeybind;
-["ACRE2", "AltPTTKey1", [(localize LSTRING(AltPTTKey1)), (localize LSTRING(AltPTTKey1_description))], { [0] call FUNC(handleMultiPttKeyPress) }, { [0] call FUNC(handleMultiPttKeyPressUp) }, [58, [true, false, false]]] call CBA_fnc_addKeybind;
-["ACRE2", "AltPTTKey2", [(localize LSTRING(AltPTTKey2)), (localize LSTRING(AltPTTKey2_description))], { [1] call FUNC(handleMultiPttKeyPress) }, { [1] call FUNC(handleMultiPttKeyPressUp) }, [58, [false, true, false]]] call CBA_fnc_addKeybind;
-["ACRE2", "AltPTTKey3", [(localize LSTRING(AltPTTKey3)), (localize LSTRING(AltPTTKey3_description))], { [2] call FUNC(handleMultiPttKeyPress) }, { [2] call FUNC(handleMultiPttKeyPressUp) }, [58, [false, false, true]]] call CBA_fnc_addKeybind;
+["ACRE2", "AltPTTKey1", [localize LSTRING(AltPTTKey1), localize LSTRING(AltPTTKey1_description)], {
+    [0] call FUNC(handleMultiPttKeyPress)
+}, {
+    [0] call FUNC(handleMultiPttKeyPressUp)
+}, [58, [true, false, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "PreviousChannel", (localize LSTRING(PreviousChannel)), "", { [-1] call FUNC(switchChannelFast) }, [208, [false, true, false]]] call CBA_fnc_addKeybind;
-["ACRE2", "NextChannel", (localize LSTRING(NextChannel)), "", { [1] call FUNC(switchChannelFast) }, [200, [false, true, false]]] call CBA_fnc_addKeybind;
+["ACRE2", "AltPTTKey2", [localize LSTRING(AltPTTKey2), localize LSTRING(AltPTTKey2_description)], {
+    [1] call FUNC(handleMultiPttKeyPress)
+}, {
+    [1] call FUNC(handleMultiPttKeyPressUp)
+}, [58, [false, true, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "BabelCycleKey", (localize LSTRING(BabelCycleKey)), "", { [] call FUNC(cycleLanguage) }, [0xDB, [false, false, false]]] call CBA_fnc_addKeybind;
+["ACRE2", "AltPTTKey3", [localize LSTRING(AltPTTKey3), localize LSTRING(AltPTTKey3_description)], {
+    [2] call FUNC(handleMultiPttKeyPress)
+}, {
+    [2] call FUNC(handleMultiPttKeyPressUp)
+}, [58, [false, false, true]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "RadioLeftEar", (localize LSTRING(RadioLeftEar)), { [-1] call FUNC(switchRadioEar) }, "", [203, [true, true, false]]] call CBA_fnc_addKeybind;
-["ACRE2", "RadioCentertEar", (localize LSTRING(RadioBothEars)), { [0] call FUNC(switchRadioEar) }, "", [200, [true, true, false]]] call CBA_fnc_addKeybind;
-["ACRE2", "RightRightEar", (localize LSTRING(RightRightEar)), { [1] call FUNC(switchRadioEar) }, "", [205, [true, true, false]]] call CBA_fnc_addKeybind;
+["ACRE2", "PreviousChannel", localize LSTRING(PreviousChannel), "", {
+    [-1] call FUNC(switchChannelFast)
+}, [208, [false, true, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "HeadSet", (localize LSTRING(HeadSet)), "", { [] call FUNC(toggleHeadset) }, [208, [true, true, false]]] call CBA_fnc_addKeybind;
+["ACRE2", "NextChannel", localize LSTRING(NextChannel), "", {
+    [1] call FUNC(switchChannelFast)
+}, [200, [false, true, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "acre_AntennaDirToggle", (localize LSTRING(AntennaDirToggle)), "", { [] call EFUNC(sys_components,toggleAntennaDir) }, [200, [false, true, true]]] call CBA_fnc_addKeybind;
+["ACRE2", "BabelCycleKey", localize LSTRING(BabelCycleKey), "", {
+    [] call FUNC(cycleLanguage)
+}, [0xDB, [false, false, false]]] call CBA_fnc_addKeybind;
 
-///////////////////////////////////
-///////////////////////////////////
+["ACRE2", "RadioLeftEar", localize LSTRING(RadioLeftEar), {
+    [-1] call FUNC(switchRadioEar)
+}, "", [203, [true, true, false]]] call CBA_fnc_addKeybind;
 
+["ACRE2", "RadioCentertEar", localize LSTRING(RadioBothEars), {
+    [0] call FUNC(switchRadioEar)
+}, "", [200, [true, true, false]]] call CBA_fnc_addKeybind;
+
+["ACRE2", "RightRightEar", localize LSTRING(RightRightEar), {
+    [1] call FUNC(switchRadioEar)
+}, "", [205, [true, true, false]]] call CBA_fnc_addKeybind;
+
+["ACRE2", "HeadSet", localize LSTRING(HeadSet), "", {
+    [] call FUNC(toggleHeadset)
+}, [208, [true, true, false]]] call CBA_fnc_addKeybind;
+
+["ACRE2", "acre_AntennaDirToggle", localize LSTRING(AntennaDirToggle), "", { [] call EFUNC(sys_components,toggleAntennaDir) }, [200, [false, true, true]]] call CBA_fnc_addKeybind;
+
+
+// Load map data
 ACRE_MAP_LOADED = false;
 // Do not load map in Main Menu, allDisplays only returns display 0 in main menu
 if (!([findDisplay 0] isEqualTo allDisplays)) then {
-    [
-        "init",
-        []
-    ] call FUNC(callExt);
+    ["init", []] call FUNC(callExt);
 
     private _wrpLocation = getText(configFile >> "CfgAcreWorlds" >> worldName >> "wrp");
     if (_wrpLocation == "") then {
@@ -87,13 +115,14 @@ if (!([findDisplay 0] isEqualTo allDisplays)) then {
 };
 [] call FUNC(getClientIdLoop);
 
+
 // Check whether ACRE2 is fully loaded
 ADDPFH(DFUNC(coreInitPFH), 0, []);
 
 //Store objects occupying crew seats, note this is empty if the player is not a crew member
 ACRE_PLAYER_INTERCOM = [];
 
-// Disable positional audio whilst in briefing.
+// Disable positional audio whilst in briefing
 if (getClientStateNumber < 10) then { // Check before game has started (in briefing state or earlier)
     ["setSoundSystemMasterOverride", [1]] call EFUNC(sys_rpc,callRemoteProcedure);
     [{

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -113,124 +113,28 @@
             <Portuguese>Desabilitar Dica de Dessincronização do Equipamento</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey">
-            <English>Default Radio Key</English>
-            <Spanish>Tecla de radio predeterminada</Spanish>
-            <Czech>Defaultní klávesa rádia</Czech>
-            <German>Standard Sprechtaste</German>
-            <Japanese>標準の無線送信キー</Japanese>
-            <Italian>Tasto Radio Standard</Italian>
-            <French>Touche radio par défaut</French>
-            <Korean>기본 무전 단축키</Korean>
-            <Polish>Domyślny klawisz nadawania</Polish>
-            <Russian>Стандартная радио кнопка</Russian>
-            <Chinese>預設無線電按鍵</Chinese>
-            <Chinesesimp>预设无线电按键</Chinesesimp>
-            <Portuguese>Tecla Padrão do Rádio</Portuguese>
+            <English>Active Radio PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey_description">
-            <English>Use currently selected radio to talk.</English>
-            <Spanish>Utilizar la radio seleccionada actualmente para hablar</Spanish>
-            <Czech>Použít právě zvolené rádio k mluvení.</Czech>
-            <German>Das ausgewählte Funkgerät zum Sprechen nutzen.</German>
-            <Japanese>選択している無線機を使って話します。</Japanese>
-            <Italian>Trasmetti sulla Radio selezionata.</Italian>
-            <French>Utiliser la radio actuellement sélectionnée pour parler.</French>
-            <Korean>현재 선택한 무전기 사용해 대화하세요.</Korean>
-            <Polish>Użyj aktualnie wybranego radia aby nadawać.</Polish>
-            <Russian>Использовать текущее радио для разговора.</Russian>
-            <Chinese>使用目前選擇的無線電進行通話。</Chinese>
-            <Chinesesimp>使用目前选择的无线电进行通话。</Chinesesimp>
-            <Portuguese>Usar o rádio atualmente selecionado para falar.</Portuguese>
+            <English>Activate currently selected radio push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1">
-            <English>Alt Radio Key 1</English>
-            <Spanish>Tecla de transmisión alternativa 1</Spanish>
-            <Czech>Alternativní klávesa rádia 1</Czech>
-            <German>Alternative Sprechtaste 1</German>
-            <Japanese>代替無線キー 1</Japanese>
-            <Italian>Trasmetti sulla Radio alternativa n.1</Italian>
-            <French>Touche radio alternative 1</French>
-            <Korean>대체 무전 단축키 1</Korean>
-            <Polish>Dodatkowy klawisz radia 1</Polish>
-            <Russian>Альт. радио кнопка 1</Russian>
-            <Chinese>設置備用無線電按鍵1</Chinese>
-            <Chinesesimp>设置备用无线电按键1</Chinesesimp>
-            <Portuguese>Tecla do  Rádio Alternativa 1</Portuguese>
+            <English>Radio 1 PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey2">
-            <English>Alt Radio Key 2</English>
-            <Spanish>Tecla de transmisión alternativa 2</Spanish>
-            <Czech>Alternativní klávesa rádia 2</Czech>
-            <German>Alternative Sprechtaste 2</German>
-            <Japanese>代替無線キー 2</Japanese>
-            <Italian>Trasmetti sulla Radio alternativa n.2</Italian>
-            <French>Touche radio alternative 2</French>
-            <Korean>대체 무전 단축키 2</Korean>
-            <Polish>Dodatkowy klawisz radia 2</Polish>
-            <Russian>Альт. радио кнопка 2</Russian>
-            <Chinese>設置備用無線電按鍵2</Chinese>
-            <Chinesesimp>设置备用无线电按键2</Chinesesimp>
-            <Portuguese>Tecla do  Rádio Alternativa 2</Portuguese>
+            <English>Radio 2 PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey3">
-            <English>Alt Radio Key 3</English>
-            <Spanish>Tecla de transmisión alternativa 3</Spanish>
-            <Czech>Alternativní klávesa rádia 3</Czech>
-            <German>Alternative Sprechtaste 3</German>
-            <Japanese>代替無線キー 3</Japanese>
-            <Italian>Trasmetti sulla Radio alternativa n.3</Italian>
-            <French>Touche radio alternative 3</French>
-            <Korean>대체 무전 단축키 3</Korean>
-            <Polish>Dodatkowy klawisz radia 3</Polish>
-            <Russian>Альт. радио кнопка 3</Russian>
-            <Chinese>設置備用無線電按鍵3</Chinese>
-            <Chinesesimp>设置备用无线电按键3</Chinesesimp>
-            <Portuguese>Tecla do  Rádio Alternativa 3</Portuguese>
+            <English>Radio 3 PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1_description">
-            <English>Use the first radio in your inventory to talk.</English>
-            <Spanish>Utiliza la primera radio en el inventario para hablar</Spanish>
-            <Czech>Použít první rádio v inventáři k mluvení.</Czech>
-            <German>Das erste Funkgerät zum Sprechen verwenden.</German>
-            <Japanese>インベントリの1番目にある無線機を使って話します。</Japanese>
-            <Italian>Trasmetti sulla Prima Radio nel tuo equipaggiamento.</Italian>
-            <French>Utiliser la première radio dans l'inventaire pour parler.</French>
-            <Korean>인벤토리의 첫 번째에 위치한 무전기를 사용해 대화하세요.</Korean>
-            <Polish>Użyj aby nadawać na pierwszym radiu z Twojego ekwipunku.</Polish>
-            <Russian>Использовать первое радио из инвентаря.</Russian>
-            <Chinese>使用物品欄內第一個無線電進行通話。</Chinese>
-            <Chinesesimp>使用物品栏内第一个无线电进行通话。</Chinesesimp>
-            <Portuguese>Usar o primeiro rádio do inventário para falar.</Portuguese>
+            <English>Activate first radio push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey2_description">
-            <English>Use the second radio in your inventory to talk.</English>
-            <Spanish>Utiliza la segunda radio en el inventario para hablar</Spanish>
-            <Czech>Použít druhé rádio v inventáři k mluvení.</Czech>
-            <German>Das zweite Funkgerät zum Sprechen verwenden.</German>
-            <Japanese>インベントリの2番目にある無線機を使って話します。</Japanese>
-            <Italian>Trasmetti sulla Seconda Radio nel tuo equipaggiamento.</Italian>
-            <French>Utiliser la seconde radio dans l'inventaire pour parler.</French>
-            <Korean>인벤토리의 두 번째에 위치한 무전기를 사용해 대화하세요.</Korean>
-            <Polish>Użyj aby nadawać na drugim radiu z Twojego ekwipunku.</Polish>
-            <Russian>Использовать второе радио из инвентаря.</Russian>
-            <Chinese>使用物品欄內第二個無線電進行通話。</Chinese>
-            <Chinesesimp>使用物品栏内第二个无线电进行通话。</Chinesesimp>
-            <Portuguese>Usar o segundo rádio do inventário para falar.</Portuguese>
+            <English>Activate second radio push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey3_description">
-            <English>Use the third radio in your inventory to talk.</English>
-            <Spanish>Utiliza la tercera radio en el inventario para hablar</Spanish>
-            <Czech>Použít třetí rádio v inventáři k mluvení.</Czech>
-            <German>Das dritte Funkgerät zum Sprechen verwenden.</German>
-            <Japanese>インベントリの3番目にある無線機を使って話します。</Japanese>
-            <Italian>Trasmetti sulla Terza Radio nel tuo equipaggiamento.</Italian>
-            <French>Utiliser la troisième radio dans l'inventaire pour parler.</French>
-            <Korean>인벤토리의 세 번째에 위치한 무전기를 사용해 대화하세요.</Korean>
-            <Polish>Użyj aby nadawać na trzecim radiu z Twojego ekwipunku.</Polish>
-            <Russian>Использовать третье радио из инвентаря.</Russian>
-            <Chinese>使用物品欄內第三個無線電進行通話。</Chinese>
-            <Chinesesimp>使用物品栏内第三个无线电进行通话。</Chinesesimp>
-            <Portuguese>Usar o terceiro rádio do inventário para falar.</Portuguese>
+            <English>Activate third radio push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_PreviousChannel">
             <English>Previous Channel (Active Radio)</English>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -182,49 +182,13 @@
             <Portuguese>Mudar Idioma (Babel)</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioLeftEar">
-            <English>Radio Left Ear</English>
-            <Spanish>Radio auricular izquierdo</Spanish>
-            <Czech>Rádio do levého ucha</Czech>
-            <German>Linker Ohrhörer</German>
-            <Japanese>音声を左側から</Japanese>
-            <Italian>Imposta Auricolare Sinistro</Italian>
-            <French>Radio oreille gauche</French>
-            <Korean>왼쪽 이어폰</Korean>
-            <Polish>Odsłuch tylko na lewym uchu</Polish>
-            <Russian>Радио левое ухо</Russian>
-            <Chinese>用左耳收聽無線電</Chinese>
-            <Chinesesimp>用左耳收听无线电</Chinesesimp>
-            <Portuguese>Rádio Orelha Esquerda</Portuguese>
+            <English>Radio Left Ear (Active Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioBothEars">
-            <English>Radio Both Ears</English>
-            <Spanish>Radio ambas auriculares</Spanish>
-            <Czech>Rádio do prostředního ucha</Czech>
-            <German>Beide Ohrhörer</German>
-            <Japanese>音声を両側から</Japanese>
-            <Italian>Centra gli Auricolari</Italian>
-            <French>Radio oreille centre</French>
-            <Korean>양쪽 이어폰</Korean>
-            <Polish>Odsłuch stereo</Polish>
-            <Russian>Радио оба уха</Russian>
-            <Chinese>用雙耳收聽無線電</Chinese>
-            <Chinesesimp>用双耳收听无线电</Chinesesimp>
-            <Portuguese>Rádio Ambas Orelhas</Portuguese>
+            <English>Radio Both Ears (Active Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_RightRightEar">
-            <English>Radio Right Ear</English>
-            <Spanish>Radio auricular derecho</Spanish>
-            <Czech>Rádio do pravého ucha</Czech>
-            <German>Rechter Ohrhörer</German>
-            <Japanese>音声を右側から</Japanese>
-            <Italian>Imposta Auricolare Destro</Italian>
-            <French>Radio oreille droite</French>
-            <Korean>오른쪽 이어폰</Korean>
-            <Polish>Odsłuch tylko na prawym uchu</Polish>
-            <Russian>Радио правое ухо</Russian>
-            <Chinese>用右耳收聽無線電</Chinese>
-            <Chinesesimp>用右耳收听无线电</Chinesesimp>
-            <Portuguese>Rádio Orelha Direita</Portuguese>
+            <English>Radio Right Ear (Active Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_HeadSet">
             <English>Toggle Headset/Toggle Spectators</English>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -129,30 +129,127 @@
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey_description">
             <English>Activate currently selected radio's push-to-talk.</English>
+            <Spanish>Utilizar la radio seleccionada actualmente para hablar</Spanish>
+            <Czech>Použít právě zvolené rádio k mluvení.</Czech>
+            <German>Das ausgewählte Funkgerät zum Sprechen nutzen.</German>
+            <Japanese>選択している無線機を使って話します。</Japanese>
+            <Italian>Trasmetti sulla Radio selezionata.</Italian>
+            <French>Utiliser la radio actuellement sélectionnée pour parler.</French>
+            <Korean>현재 선택한 무전기 사용해 대화하세요.</Korean>
+            <Polish>Użyj aktualnie wybranego radia aby nadawać.</Polish>
+            <Russian>Использовать текущее радио для разговора.</Russian>
+            <Chinese>使用目前選擇的無線電進行通話。</Chinese>
+            <Chinesesimp>使用目前选择的无线电进行通话。</Chinesesimp>
+            <Portuguese>Usar o rádio atualmente selecionado para falar.</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1">
             <English>Radio 1 PTT</English>
-        </Key>
-        <Key ID="STR_ACRE_sys_core_AltPTTKey2">
-            <English>Radio 2 PTT</English>
-        </Key>
-        <Key ID="STR_ACRE_sys_core_AltPTTKey3">
-            <English>Radio 3 PTT</English>
+            <Spanish>Tecla de transmisión 1</Spanish>
+            <Czech>Klávesa rádia 1</Czech>
+            <German>Sprechtaste 1</German>
+            <Italian>Trasmetti sulla Radio n.1</Italian>
+            <French>Touche radio 1</French>
+            <Polish>Klawisz radia 1</Polish>
+            <Russian>радио кнопка 1</Russian>
+            <Portuguese>Tecla do Rádio 1</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1_description">
             <English>Select first radio and activate its push-to-talk.</English>
+            <Spanish>Utiliza la primera radio en el inventario para hablar</Spanish>
+            <Czech>Použít první rádio v inventáři k mluvení.</Czech>
+            <German>Das erste Funkgerät zum Sprechen verwenden.</German>
+            <Japanese>インベントリの1番目にある無線機を使って話します。</Japanese>
+            <Italian>Trasmetti sulla Prima Radio nel tuo equipaggiamento.</Italian>
+            <French>Utiliser la première radio dans l'inventaire pour parler.</French>
+            <Korean>인벤토리의 첫 번째에 위치한 무전기를 사용해 대화하세요.</Korean>
+            <Polish>Użyj aby nadawać na pierwszym radiu z Twojego ekwipunku.</Polish>
+            <Russian>Использовать первое радио из инвентаря.</Russian>
+            <Chinese>使用物品欄內第一個無線電進行通話。</Chinese>
+            <Chinesesimp>使用物品栏内第一个无线电进行通话。</Chinesesimp>
+            <Portuguese>Usar o primeiro rádio do inventário para falar.</Portuguese>
+        </Key>
+        <Key ID="STR_ACRE_sys_core_AltPTTKey2">
+            <English>Radio 2 PTT</English>
+            <Spanish>Tecla de transmisión 2</Spanish>
+            <Czech>Klávesa rádia 2</Czech>
+            <German>Sprechtaste 2</German>
+            <Italian>Trasmetti sulla Radio n.2</Italian>
+            <French>Touche radio 2</French>
+            <Polish>Klawisz radia 2</Polish>
+            <Russian>радио кнопка 2</Russian>
+            <Portuguese>Tecla do Rádio 2</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey2_description">
             <English>Select second radio and activate its push-to-talk.</English>
+            <Spanish>Utiliza la segunda radio en el inventario para hablar</Spanish>
+            <Czech>Použít druhé rádio v inventáři k mluvení.</Czech>
+            <German>Das zweite Funkgerät zum Sprechen verwenden.</German>
+            <Japanese>インベントリの2番目にある無線機を使って話します。</Japanese>
+            <Italian>Trasmetti sulla Seconda Radio nel tuo equipaggiamento.</Italian>
+            <French>Utiliser la seconde radio dans l'inventaire pour parler.</French>
+            <Korean>인벤토리의 두 번째에 위치한 무전기를 사용해 대화하세요.</Korean>
+            <Polish>Użyj aby nadawać na drugim radiu z Twojego ekwipunku.</Polish>
+            <Russian>Использовать второе радио из инвентаря.</Russian>
+            <Chinese>使用物品欄內第二個無線電進行通話。</Chinese>
+            <Chinesesimp>使用物品栏内第二个无线电进行通话。</Chinesesimp>
+            <Portuguese>Usar o segundo rádio do inventário para falar.</Portuguese>
+        </Key>
+        <Key ID="STR_ACRE_sys_core_AltPTTKey3">
+            <English>Radio 3 PTT</English>
+            <Spanish>Tecla de transmisión 3</Spanish>
+            <Czech>Klávesa rádia 3</Czech>
+            <German>Sprechtaste 3</German>
+            <Italian>Trasmetti sulla Radio n.3</Italian>
+            <French>Touche radio 3</French>
+            <Polish>Klawisz radia 3</Polish>
+            <Russian>радио кнопка 3</Russian>
+            <Portuguese>Tecla do Rádio 3</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey3_description">
             <English>Select third radio and activate its push-to-talk.</English>
+            <English>Use the third radio in your inventory to talk.</English>
+            <Spanish>Utiliza la tercera radio en el inventario para hablar</Spanish>
+            <Czech>Použít třetí rádio v inventáři k mluvení.</Czech>
+            <German>Das dritte Funkgerät zum Sprechen verwenden.</German>
+            <Japanese>インベントリの3番目にある無線機を使って話します。</Japanese>
+            <Italian>Trasmetti sulla Terza Radio nel tuo equipaggiamento.</Italian>
+            <French>Utiliser la troisième radio dans l'inventaire pour parler.</French>
+            <Korean>인벤토리의 세 번째에 위치한 무전기를 사용해 대화하세요.</Korean>
+            <Polish>Użyj aby nadawać na trzecim radiu z Twojego ekwipunku.</Polish>
+            <Russian>Использовать третье радио из инвентаря.</Russian>
+            <Chinese>使用物品欄內第三個無線電進行通話。</Chinese>
+            <Chinesesimp>使用物品栏内第三个无线电进行通话。</Chinesesimp>
+            <Portuguese>Usar o terceiro rádio do inventário para falar.</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_PreviousChannel">
             <English>Previous Channel (Selected Radio)</English>
+            <Spanish>Canal anterior (Radio activa)</Spanish>
+            <Czech>Předchozí kanál</Czech>
+            <German>Vorheriger Funkkanal (aktives Funkgerät)</German>
+            <Japanese>前のチャンネル (選択している無線機)</Japanese>
+            <Italian>Canale Precedente (Ricetrasmittente Attiva)</Italian>
+            <French>Canal précédent (radio active)</French>
+            <Korean>이전 채널 (활성화된 무전기)</Korean>
+            <Polish>Poprzedni kanał</Polish>
+            <Russian>Предыдущий канал (Активное радио)</Russian>
+            <Chinese>上一個頻道 (目前使用的無線電)</Chinese>
+            <Chinesesimp>上一个频道 (目前使用的无线电)</Chinesesimp>
+            <Portuguese>Canal Anterior (Rádio Ativo)</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_NextChannel">
-            <English>Next Channel (Selected Radio)</English>
+            <English>Nexit Channel (Selected Radio)</English>
+            <Spanish>Siguiente canal (Radio activa)</Spanish>
+            <Czech>Další kanál</Czech>
+            <German>Nächster Funkkanal (aktives Funkgerät)</German>
+            <Japanese>次のチャンネル (選択している無線機)</Japanese>
+            <Italian>Canale Successivo (Ricetrasmittente Attiva)</Italian>
+            <French>Canal suivant (radio active)</French>
+            <Korean>다음 채널 (활성화된 무전기)</Korean>
+            <Polish>Następny kanał</Polish>
+            <Russian>Следующий канал (Активное радио)</Russian>
+            <Chinese>下一個頻道 (目前使用的無線電)</Chinese>
+            <Chinesesimp>下一个频道 (目前使用的无线电)</Chinesesimp>
+            <Portuguese>Canal Posterior (Rádio Ativo)</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_BabelCycleKey">
             <English>Babel Cycle Language</English>
@@ -171,12 +268,48 @@
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioLeftEar">
             <English>Radio Left Ear (Selected Radio)</English>
+            <Spanish>Radio auricular izquierdo</Spanish>
+            <Czech>Rádio do levého ucha</Czech>
+            <German>Linker Ohrhörer</German>
+            <Japanese>音声を左側から</Japanese>
+            <Italian>Imposta Auricolare Sinistro</Italian>
+            <French>Radio oreille gauche</French>
+            <Korean>왼쪽 이어폰</Korean>
+            <Polish>Odsłuch tylko na lewym uchu</Polish>
+            <Russian>Радио левое ухо</Russian>
+            <Chinese>用左耳收聽無線電</Chinese>
+            <Chinesesimp>用左耳收听无线电</Chinesesimp>
+            <Portuguese>Rádio Orelha Esquerda</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioBothEars">
             <English>Radio Both Ears (Selected Radio)</English>
+            <Spanish>Radio ambas auriculares</Spanish>
+            <Czech>Rádio do prostředního ucha</Czech>
+            <German>Beide Ohrhörer</German>
+            <Japanese>音声を両側から</Japanese>
+            <Italian>Centra gli Auricolari</Italian>
+            <French>Radio oreille centre</French>
+            <Korean>양쪽 이어폰</Korean>
+            <Polish>Odsłuch stereo</Polish>
+            <Russian>Радио оба уха</Russian>
+            <Chinese>用雙耳收聽無線電</Chinese>
+            <Chinesesimp>用双耳收听无线电</Chinesesimp>
+            <Portuguese>Rádio Ambas Orelhas</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_RightRightEar">
             <English>Radio Right Ear (Selected Radio)</English>
+            <Spanish>Radio auricular derecho</Spanish>
+            <Czech>Rádio do pravého ucha</Czech>
+            <German>Rechter Ohrhörer</German>
+            <Japanese>音声を右側から</Japanese>
+            <Italian>Imposta Auricolare Destro</Italian>
+            <French>Radio oreille droite</French>
+            <Korean>오른쪽 이어폰</Korean>
+            <Polish>Odsłuch tylko na prawym uchu</Polish>
+            <Russian>Радио правое ухо</Russian>
+            <Chinese>用右耳收聽無線電</Chinese>
+            <Chinesesimp>用右耳收听无线电</Chinesesimp>
+            <Portuguese>Rádio Orelha Direita</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_HeadSet">
             <English>Toggle Headset/Spectators</English>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -114,6 +114,18 @@
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey">
             <English>Selected Radio PTT</English>
+            <Spanish>Tecla de radio seleccionada</Spanish>
+            <Czech>Vybrané klávesa rádia</Czech>
+            <German>Ausgewähltes Sprechtaste</German>
+            <Japanese>標準の無線送信キー</Japanese>
+            <Italian>Tasto Radio Selezionata</Italian>
+            <French>Touche radio sélectionnée</French>
+            <Korean>기본 무전 단축키</Korean>
+            <Polish>Wybrane klawisz nadawania</Polish>
+            <Russian>Bыбранное радио кнопка</Russian>
+            <Chinese>預設無線電按鍵</Chinese>
+            <Chinesesimp>预设无线电按键</Chinesesimp>
+            <Portuguese>Tecla Selecionado do Rádio</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey_description">
             <English>Activate currently selected radio's push-to-talk.</English>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -113,22 +113,22 @@
             <Portuguese>Desabilitar Dica de Dessincronização do Equipamento</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey">
-            <English>Selected Radio PTT</English>
-            <Spanish>Tecla de radio seleccionada</Spanish>
-            <Czech>Vybrané klávesa rádia</Czech>
-            <German>Ausgewähltes Sprechtaste</German>
+            <English>Active Radio Transmit</English>
+            <Spanish>Tecla de radio activa</Spanish>
+            <Czech>Aktivní klávesa rádia</Czech>
+            <German>Aktives Sprechtaste</German>
             <Japanese>標準の無線送信キー</Japanese>
-            <Italian>Tasto Radio Selezionata</Italian>
-            <French>Touche radio sélectionnée</French>
+            <Italian>Tasto Radio Attiva</Italian>
+            <French>Touche radio active</French>
             <Korean>기본 무전 단축키</Korean>
-            <Polish>Wybrane klawisz nadawania</Polish>
-            <Russian>Bыбранное радио кнопка</Russian>
+            <Polish>Aktywne klawisz nadawania</Polish>
+            <Russian>активное радио кнопка</Russian>
             <Chinese>預設無線電按鍵</Chinese>
             <Chinesesimp>预设无线电按键</Chinesesimp>
-            <Portuguese>Tecla Selecionado do Rádio</Portuguese>
+            <Portuguese>Tecla Activo do Rádio</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey_description">
-            <English>Activate currently selected radio's push-to-talk.</English>
+            <English>Transmit on currently active radio.</English>
             <Spanish>Utilizar la radio seleccionada actualmente para hablar</Spanish>
             <Czech>Použít právě zvolené rádio k mluvení.</Czech>
             <German>Das ausgewählte Funkgerät zum Sprechen nutzen.</German>
@@ -143,7 +143,7 @@
             <Portuguese>Usar o rádio atualmente selecionado para falar.</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1">
-            <English>Radio 1 PTT</English>
+            <English>Radio 1 Transmit (PTT 1)</English>
             <Spanish>Tecla de transmisión 1</Spanish>
             <Czech>Klávesa rádia 1</Czech>
             <German>Sprechtaste 1</German>
@@ -154,7 +154,7 @@
             <Portuguese>Tecla do Rádio 1</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1_description">
-            <English>Select first radio and activate its push-to-talk.</English>
+            <English>Transmit on first radio and set it as active.</English>
             <Spanish>Utiliza la primera radio en el inventario para hablar</Spanish>
             <Czech>Použít první rádio v inventáři k mluvení.</Czech>
             <German>Das erste Funkgerät zum Sprechen verwenden.</German>
@@ -169,7 +169,7 @@
             <Portuguese>Usar o primeiro rádio do inventário para falar.</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey2">
-            <English>Radio 2 PTT</English>
+            <English>Radio 2 Transmit (PTT 2)</English>
             <Spanish>Tecla de transmisión 2</Spanish>
             <Czech>Klávesa rádia 2</Czech>
             <German>Sprechtaste 2</German>
@@ -180,7 +180,7 @@
             <Portuguese>Tecla do Rádio 2</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey2_description">
-            <English>Select second radio and activate its push-to-talk.</English>
+            <English>Transmit on second radio and set it as active.</English>
             <Spanish>Utiliza la segunda radio en el inventario para hablar</Spanish>
             <Czech>Použít druhé rádio v inventáři k mluvení.</Czech>
             <German>Das zweite Funkgerät zum Sprechen verwenden.</German>
@@ -195,7 +195,7 @@
             <Portuguese>Usar o segundo rádio do inventário para falar.</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey3">
-            <English>Radio 3 PTT</English>
+            <English>Radio 3 Transmit (PTT 3)</English>
             <Spanish>Tecla de transmisión 3</Spanish>
             <Czech>Klávesa rádia 3</Czech>
             <German>Sprechtaste 3</German>
@@ -206,7 +206,7 @@
             <Portuguese>Tecla do Rádio 3</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey3_description">
-            <English>Select third radio and activate its push-to-talk.</English>
+            <English>Transmit on third radio and set it as active.</English>
             <English>Use the third radio in your inventory to talk.</English>
             <Spanish>Utiliza la tercera radio en el inventario para hablar</Spanish>
             <Czech>Použít třetí rádio v inventáři k mluvení.</Czech>
@@ -222,7 +222,7 @@
             <Portuguese>Usar o terceiro rádio do inventário para falar.</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_PreviousChannel">
-            <English>Previous Channel (Selected Radio)</English>
+            <English>Previous Channel (Active Radio)</English>
             <Spanish>Canal anterior (Radio activa)</Spanish>
             <Czech>Předchozí kanál</Czech>
             <German>Vorheriger Funkkanal (aktives Funkgerät)</German>
@@ -237,7 +237,7 @@
             <Portuguese>Canal Anterior (Rádio Ativo)</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_NextChannel">
-            <English>Nexit Channel (Selected Radio)</English>
+            <English>Nexit Channel (Active Radio)</English>
             <Spanish>Siguiente canal (Radio activa)</Spanish>
             <Czech>Další kanál</Czech>
             <German>Nächster Funkkanal (aktives Funkgerät)</German>
@@ -267,7 +267,7 @@
             <Portuguese>Mudar Idioma (Babel)</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioLeftEar">
-            <English>Radio Left Ear (Selected Radio)</English>
+            <English>Radio Left Ear (Active Radio)</English>
             <Spanish>Radio auricular izquierdo</Spanish>
             <Czech>Rádio do levého ucha</Czech>
             <German>Linker Ohrhörer</German>
@@ -282,7 +282,7 @@
             <Portuguese>Rádio Orelha Esquerda</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioBothEars">
-            <English>Radio Both Ears (Selected Radio)</English>
+            <English>Radio Both Ears (Active Radio)</English>
             <Spanish>Radio ambas auriculares</Spanish>
             <Czech>Rádio do prostředního ucha</Czech>
             <German>Beide Ohrhörer</German>
@@ -297,7 +297,7 @@
             <Portuguese>Rádio Ambas Orelhas</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_RightRightEar">
-            <English>Radio Right Ear (Selected Radio)</English>
+            <English>Radio Right Ear (Active Radio)</English>
             <Spanish>Radio auricular derecho</Spanish>
             <Czech>Rádio do pravého ucha</Czech>
             <German>Rechter Ohrhörer</German>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -113,10 +113,10 @@
             <Portuguese>Desabilitar Dica de Dessincronização do Equipamento</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey">
-            <English>Active Radio PTT</English>
+            <English>Selected Radio PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_DefaultPTTKey_description">
-            <English>Activate currently selected radio push-to-talk.</English>
+            <English>Activate currently selected radio's push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1">
             <English>Radio 1 PTT</English>
@@ -128,43 +128,19 @@
             <English>Radio 3 PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey1_description">
-            <English>Activate first radio push-to-talk.</English>
+            <English>Select first radio and activate its push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey2_description">
-            <English>Activate second radio push-to-talk.</English>
+            <English>Select second radio and activate its push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_AltPTTKey3_description">
-            <English>Activate third radio push-to-talk.</English>
+            <English>Select third radio and activate its push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_PreviousChannel">
-            <English>Previous Channel (Active Radio)</English>
-            <Spanish>Canal anterior (Radio activa)</Spanish>
-            <Czech>Předchozí kanál</Czech>
-            <German>Vorheriger Funkkanal (aktives Funkgerät)</German>
-            <Japanese>前のチャンネル (選択している無線機)</Japanese>
-            <Italian>Canale Precedente (Ricetrasmittente Attiva)</Italian>
-            <French>Canal précédent (radio active)</French>
-            <Korean>이전 채널 (활성화된 무전기)</Korean>
-            <Polish>Poprzedni kanał</Polish>
-            <Russian>Предыдущий канал (Активное радио)</Russian>
-            <Chinese>上一個頻道 (目前使用的無線電)</Chinese>
-            <Chinesesimp>上一个频道 (目前使用的无线电)</Chinesesimp>
-            <Portuguese>Canal Anterior (Rádio Ativo)</Portuguese>
+            <English>Previous Channel (Selected Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_NextChannel">
-            <English>Next Channel (Active Radio)</English>
-            <Spanish>Siguiente canal (Radio activa)</Spanish>
-            <Czech>Další kanál</Czech>
-            <German>Nächster Funkkanal (aktives Funkgerät)</German>
-            <Japanese>次のチャンネル (選択している無線機)</Japanese>
-            <Italian>Canale Successivo (Ricetrasmittente Attiva)</Italian>
-            <French>Canal suivant (radio active)</French>
-            <Korean>다음 채널 (활성화된 무전기)</Korean>
-            <Polish>Następny kanał</Polish>
-            <Russian>Следующий канал (Активное радио)</Russian>
-            <Chinese>下一個頻道 (目前使用的無線電)</Chinese>
-            <Chinesesimp>下一个频道 (目前使用的无线电)</Chinesesimp>
-            <Portuguese>Canal Posterior (Rádio Ativo)</Portuguese>
+            <English>Next Channel (Selected Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_BabelCycleKey">
             <English>Babel Cycle Language</English>
@@ -182,25 +158,25 @@
             <Portuguese>Mudar Idioma (Babel)</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioLeftEar">
-            <English>Radio Left Ear (Active Radio)</English>
+            <English>Radio Left Ear (Selected Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_RadioBothEars">
-            <English>Radio Both Ears (Active Radio)</English>
+            <English>Radio Both Ears (Selected Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_RightRightEar">
-            <English>Radio Right Ear (Active Radio)</English>
+            <English>Radio Right Ear (Selected Radio)</English>
         </Key>
         <Key ID="STR_ACRE_sys_core_HeadSet">
-            <English>Toggle Headset/Toggle Spectators</English>
-            <Spanish>Activar auriculares/Activar espectadores</Spanish>
-            <Czech>Přepnout headset/Přepnout diváky</Czech>
-            <German>Headset umschalten/Zuschauer umschalten</German>
-            <Japanese>ヘッドセットの切り替え/スペクテイターの切り替え</Japanese>
-            <Italian>Attiva/Disattiva Cuffia - Attiva/Disattiva Spettatori</Italian>
+            <English>Toggle Headset/Spectators</English>
+            <Spanish>Activar auriculares/espectadores</Spanish>
+            <Czech>Přepnout headset/diváky</Czech>
+            <German>Headset umschalten / Zuschauer umschalten</German>
+            <Japanese>ヘッドセットの切り替え / スペクテイターの切り替え</Japanese>
+            <Italian>Attiva/Disattiva Cuffia/Spettatori</Italian>
             <French>Alterner Casque/Spectateurs</French>
-            <Korean>헤드셋 전환/관전자 전환</Korean>
+            <Korean>헤드셋 전환 / 관전자 전환</Korean>
             <Polish>Zdejmij/załóż słuchawki. / Wł/wył widzów.</Polish>
-            <Russian>Переключить наушники/Переключить спектаторов</Russian>
+            <Russian>Переключить наушники/спектаторов</Russian>
             <Chinese>切換耳機 / 切換觀戰</Chinese>
             <Chinesesimp>切换耳机 / 切换观战</Chinesesimp>
             <Portuguese>Alternar Fones/Espectadores</Portuguese>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -237,7 +237,7 @@
             <Portuguese>Canal Anterior (Rádio Ativo)</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_core_NextChannel">
-            <English>Nexit Channel (Active Radio)</English>
+            <English>Next Channel (Active Radio)</English>
             <Spanish>Siguiente canal (Radio activa)</Spanish>
             <Czech>Další kanál</Czech>
             <German>Nächster Funkkanal (aktives Funkgerät)</German>

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
 if (!hasInterface) exitWith {};
 
@@ -8,11 +9,11 @@ if (!hasInterface) exitWith {};
 // TODO - Look into this below.
 acre_player addEventHandler ["Take", {call FUNC(handleTake)}];
 
-// Register volume control key handlers
+// Keybinds - Volume Control
 ["ACRE2", "VolumeControl", localize LSTRING(VolumeControl),
     FUNC(onVolumeControlKeyPress),
     FUNC(onVolumeControlKeyPressUp),
-[15, [false, false, false]], true] call CBA_fnc_addKeybind;
+[DIK_TAB, [false, false, false]], true] call CBA_fnc_addKeybind;
 
 ["unit", FUNC(onVolumeControlKeyPressUp)] call CBA_fnc_addPlayerEventHandler;
 

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
 // Exit if ACE3 not loaded
 if (!isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) exitWith {};
@@ -10,26 +11,34 @@ if (!isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) exitWith {};
 
 if (!hasInterface) exitWith {};
 
-[
-    "ACRE2",
-    "IntercomPTTKey",
-    [(localize LSTRING(intercomPttKey)), (localize LSTRING(intercomPttKey_description))],
-    {[ACTION_INTERCOM_PTT] call FUNC(handlePttKeyPress)},
-    {[ACTION_INTERCOM_PTT] call FUNC(handlePttKeyPressUp)}
-] call cba_fnc_addKeybind;
+// Keybinds - Intercom
+["ACRE2", "IntercomPTTKey", [localize LSTRING(intercomPttKey), localize LSTRING(intercomPttKey_description)], {
+    [ACTION_INTERCOM_PTT] call FUNC(handlePttKeyPress)
+}, {
+    [ACTION_INTERCOM_PTT] call FUNC(handlePttKeyPressUp)
+}] call CBA_fnc_addKeybind;
 
-[
-    "ACRE2",
-    "IntercomBroadcastKey",
-    [(localize LSTRING(intercomBroadcastKey)), (localize LSTRING(intercomBroadcastKey_description))],
-    {[ACTION_BROADCAST] call FUNC(handlePttKeyPress)},
-    {[ACTION_BROADCAST] call FUNC(handlePttKeyPressUp)}
-] call cba_fnc_addKeybind;
+["ACRE2", "IntercomBroadcastKey", [localize LSTRING(intercomBroadcastKey), localize LSTRING(intercomBroadcastKey_description)], {
+    [ACTION_BROADCAST] call FUNC(handlePttKeyPress)
+}, {
+    [ACTION_BROADCAST] call FUNC(handlePttKeyPressUp)
+}] call CBA_fnc_addKeybind;
 
-["ACRE2", "PreviousIntercom", (localize LSTRING(previousIntercom)), "", { [-1, true] call FUNC(switchIntercomFast) }, [51, [true, false, false]]] call cba_fnc_addKeybind;
-["ACRE2", "NextIntercom", (localize LSTRING(nextIntercom)), "", {[1, true] call FUNC(switchIntercomFast)}, [51, [false, true, false]]] call cba_fnc_addKeybind;
-["ACRE2", "AddPreviousIntercom", (localize LSTRING(addPreviousIntercom)), "", {[-1, false] call FUNC(switchIntercomFast)}, [51, [true, false, true]]] call cba_fnc_addKeybind;
-["ACRE2", "AddNextIntercom", (localize LSTRING(addNextIntercom)), "", {[1, false] call FUNC(switchIntercomFast)}, [51, [false, true, true]]] call cba_fnc_addKeybind;
+["ACRE2", "PreviousIntercom", localize LSTRING(previousIntercom), "", {
+    [-1, true] call FUNC(switchIntercomFast)
+}, [DIK_COMMA, [true, false, false]]] call CBA_fnc_addKeybind;
+
+["ACRE2", "NextIntercom", localize LSTRING(nextIntercom), "", {
+    [1, true] call FUNC(switchIntercomFast)
+}, [DIK_COMMA, [false, true, false]]] call CBA_fnc_addKeybind;
+
+["ACRE2", "AddPreviousIntercom", localize LSTRING(addPreviousIntercom), "", {
+    [-1, false] call FUNC(switchIntercomFast)
+}, [DIK_COMMA, [true, false, true]]] call CBA_fnc_addKeybind;
+
+["ACRE2", "AddNextIntercom", localize LSTRING(addNextIntercom), "", {
+    [1, false] call FUNC(switchIntercomFast)
+}, [DIK_COMMA, [false, true, true]]] call CBA_fnc_addKeybind;
 
 // Intercom configuration
 ["vehicle", {

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -344,7 +344,7 @@
             <French>Activation de la voix</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomPttKey">
-            <English>Intercom PTT</English>
+            <English>Intercom Transmit</English>
             <Spanish>Tecla de intercom</Spanish>
             <Polish>Klawisz interkomu</Polish>
             <Italian>Pulsante intercom</Italian>
@@ -354,7 +354,7 @@
             <French>Clé de l'interphone</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomPttKey_description">
-            <English>Activate intercom station's push-to-talk.</English>
+            <English>Transmit on intercom station.</English>
             <Spanish>Usa la estación de intercom para hablar.</Spanish>
             <Polish>Mów przez interkom</Polish>
             <Italian>Usa la stazione intercom per parlare.</Italian>
@@ -364,7 +364,7 @@
             <French>Utiliser le poste d'interphone pour parler.</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey">
-            <English>Intercom Broadcast PTT</English>
+            <English>Intercom Broadcast</English>
             <Spanish>Tecla para mensaje prioritario</Spanish>
             <Polish>Klawisz nadawania interkomu</Polish>
             <Italian>Pulsante trasmissione intercom</Italian>
@@ -374,7 +374,7 @@
             <French>Clé de diffusion de l'interphone</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey_description">
-            <English>Activate intercom station's broadcast push-to-talk (priority message).</English>
+            <English>Transmit a priority message on intercom station.</English>
             <Spanish>Usa la estación de intercom para enviar un mensaje prioritario.</Spanish>
             <Polish>Użyj interkomu, aby wysłać wiadomość priorytetową.</Polish>
             <Italian>Usa la stazione intercom per trasmettere un messaggio prioritario</Italian>

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -347,13 +347,13 @@
             <English>Intercom PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomPttKey_description">
-            <English>Activate intercom station push-to-talk.</English>
+            <English>Activate intercom station's push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey">
             <English>Intercom Broadcast PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey_description">
-            <English>Activate intercom station broadcast push-to-talk (priority message).</English>
+            <English>Activate intercom station's broadcast push-to-talk (priority message).</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_previousIntercom">
             <English>Previous Intercom Network</English>

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="ACRE">
     <Package name="sys_intercom">
         <Key ID="STR_ACRE_sys_intercom_infantryPhone">
@@ -344,44 +344,16 @@
             <French>Activation de la voix</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomPttKey">
-            <English>Intercom Key</English>
-            <Spanish>Tecla de intercom</Spanish>
-            <Polish>Klawisz interkomu</Polish>
-            <Italian>Pulsante intercom</Italian>
-            <Japanese>インターコム キー</Japanese>
-            <Chinese>無線電按鍵</Chinese>
-            <Chinesesimp>无线电按键</Chinesesimp>
-            <French>Clé de l'interphone</French>
+            <English>Intercom PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomPttKey_description">
-            <English>Use the intercom station to talk.</English>
-            <Spanish>Usa la estación de intercom para hablar.</Spanish>
-            <Polish>Mów przez interkom</Polish>
-            <Italian>Usa la stazione intercom per parlare.</Italian>
-            <Japanese>インターコム内で会話する為に使用します。</Japanese>
-            <Chinese>使用通訊機台來講話</Chinese>
-            <Chinesesimp>使用通讯机台来讲话</Chinesesimp>
-            <French>Utiliser le poste d'interphone pour parler.</French>
+            <English>Activate intercom station push-to-talk.</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey">
-            <English>Intercom Broadcast Key</English>
-            <Spanish>Tecla para mensaje prioritario</Spanish>
-            <Polish>Klawisz nadawania interkomu</Polish>
-            <Italian>Pulsante trasmissione intercom</Italian>
-            <Japanese>インターコムのブロードキャスト キー</Japanese>
-            <Chinese>無線電廣播按鍵</Chinese>
-            <Chinesesimp>无线电广播按键</Chinesesimp>
-            <French>Clé de diffusion de l'interphone</French>
+            <English>Intercom Broadcast PTT</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey_description">
-            <English>Use the intercom station to broadcast a priority message.</English>
-            <Spanish>Usa la estación de intercom para enviar un mensaje prioritario.</Spanish>
-            <Polish>Użyj interkomu, aby wysłać wiadomość priorytetową.</Polish>
-            <Italian>Usa la stazione intercom per trasmettere un messaggio prioritario</Italian>
-            <Japanese>インターコム内で優先メッセージをブロードキャストをする為に使用します。</Japanese>
-            <Chinese>使用通訊機台來廣播重要訊息</Chinese>
-            <Chinesesimp>使用通讯机台来广播重要讯息</Chinesesimp>
-            <French>Utiliser le poste d'interphone pour diffuser un message prioritaire.</French>
+            <English>Activate intercom station broadcast push-to-talk (priority message).</English>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_previousIntercom">
             <English>Previous Intercom Network</English>

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -345,15 +345,43 @@
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomPttKey">
             <English>Intercom PTT</English>
+            <Spanish>Tecla de intercom</Spanish>
+            <Polish>Klawisz interkomu</Polish>
+            <Italian>Pulsante intercom</Italian>
+            <Japanese>インターコム キー</Japanese>
+            <Chinese>無線電按鍵</Chinese>
+            <Chinesesimp>无线电按键</Chinesesimp>
+            <French>Clé de l'interphone</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomPttKey_description">
             <English>Activate intercom station's push-to-talk.</English>
+            <Spanish>Usa la estación de intercom para hablar.</Spanish>
+            <Polish>Mów przez interkom</Polish>
+            <Italian>Usa la stazione intercom per parlare.</Italian>
+            <Japanese>インターコム内で会話する為に使用します。</Japanese>
+            <Chinese>使用通訊機台來講話</Chinese>
+            <Chinesesimp>使用通讯机台来讲话</Chinesesimp>
+            <French>Utiliser le poste d'interphone pour parler.</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey">
             <English>Intercom Broadcast PTT</English>
+            <Spanish>Tecla para mensaje prioritario</Spanish>
+            <Polish>Klawisz nadawania interkomu</Polish>
+            <Italian>Pulsante trasmissione intercom</Italian>
+            <Japanese>インターコムのブロードキャスト キー</Japanese>
+            <Chinese>無線電廣播按鍵</Chinese>
+            <Chinesesimp>无线电广播按键</Chinesesimp>
+            <French>Clé de diffusion de l'interphone</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_intercomBroadcastKey_description">
             <English>Activate intercom station's broadcast push-to-talk (priority message).</English>
+            <Spanish>Usa la estación de intercom para enviar un mensaje prioritario.</Spanish>
+            <Polish>Użyj interkomu, aby wysłać wiadomość priorytetową.</Polish>
+            <Italian>Usa la stazione intercom per trasmettere un messaggio prioritario</Italian>
+            <Japanese>インターコム内で優先メッセージをブロードキャストをする為に使用します。</Japanese>
+            <Chinese>使用通訊機台來廣播重要訊息</Chinese>
+            <Chinesesimp>使用通讯机台来广播重要讯息</Chinesesimp>
+            <French>Utiliser le poste d'interphone pour diffuser un message prioritaire.</French>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_previousIntercom">
             <English>Previous Intercom Network</English>

--- a/addons/sys_list/XEH_postInit.sqf
+++ b/addons/sys_list/XEH_postInit.sqf
@@ -1,8 +1,13 @@
 #include "script_component.hpp"
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
 if (!hasInterface) exitWith {};
 
-LOG("ADDING KEY HANDLERS FOR LIST");
+["ACRE2", "CycleRadio", localize LSTRING(CycleRadio), {
+    [1] call FUNC(cycleRadios)
+}, "", [DIK_CAPSLOCK, [true, false, true]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "CycleRadio", (localize LSTRING(CycleRadio)), { [1] call FUNC(cycleRadios) }, "", [58, [true, false, true]]] call cba_fnc_addKeybind;
-["ACRE2", "OpenRadio", (localize LSTRING(OpenRadio)), { [ACRE_ACTIVE_RADIO] call EFUNC(sys_radio,openRadio); false }, "", [58, [false, true, true]]] call cba_fnc_addKeybind;
+["ACRE2", "OpenRadio", localize LSTRING(OpenRadio), {
+    [ACRE_ACTIVE_RADIO] call EFUNC(sys_radio,openRadio);
+    false
+}, "", [DIK_CAPSLOCK, [false, true, true]]] call CBA_fnc_addKeybind;

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -2,34 +2,10 @@
 <Project name="ACRE">
     <Package name="sys_list">
         <Key ID="STR_ACRE_sys_list_CycleRadio">
-            <English>Cycle Radio</English>
-            <Spanish>Cambiar Radio</Spanish>
-            <Czech>Změnit rádio</Czech>
-            <German>Funkgeräte durchschalten</German>
-            <Japanese>無線機を切り替え</Japanese>
-            <Italian>Cambia Ricetrasmittente</Italian>
-            <French>Cycler radio</French>
-            <Korean>무전 채널 변경</Korean>
-            <Polish>Następne radio</Polish>
-            <Russian>Листать радио</Russian>
-            <Chinese>切換無線電</Chinese>
-            <Chinesesimp>切换无线电</Chinesesimp>
-            <Portuguese>Trocar Rádio</Portuguese>
+            <English>Cycle Radios</English>
         </Key>
         <Key ID="STR_ACRE_sys_list_OpenRadio">
-            <English>Open Radio</English>
-            <Spanish>Abrir radio</Spanish>
-            <Czech>Otevřít rádio</Czech>
-            <German>Funkgerät öffnen</German>
-            <Japanese>無線機を開く</Japanese>
-            <Italian>Apri Ricetrasmittente</Italian>
-            <French>Ouvrir radio</French>
-            <Korean>무전기 열기</Korean>
-            <Polish>Otwórz panel radia</Polish>
-            <Russian>Открыть радио</Russian>
-            <Chinese>打開無線電</Chinese>
-            <Chinesesimp>打开无线电</Chinesesimp>
-            <Portuguese>Abrir Rádio</Portuguese>
+            <English>Open Active Radio</English>
         </Key>
         <Key ID="STR_ACRE_sys_list_NotificationGrid">
             <English>ACRE2 - Radio Notifications</English>

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -2,10 +2,34 @@
 <Project name="ACRE">
     <Package name="sys_list">
         <Key ID="STR_ACRE_sys_list_CycleRadio">
-            <English>Cycle Radios</English>
+            <English>Cycle/Next Radio</English>
+            <Spanish>Cambiar Radio</Spanish>
+            <Czech>Změnit rádio</Czech>
+            <German>Funkgeräte durchschalten</German>
+            <Japanese>無線機を切り替え</Japanese>
+            <Italian>Cambia Ricetrasmittente</Italian>
+            <French>Cycler radio</French>
+            <Korean>무전 채널 변경</Korean>
+            <Polish>Następne radio</Polish>
+            <Russian>Листать радио</Russian>
+            <Chinese>切換無線電</Chinese>
+            <Chinesesimp>切换无线电</Chinesesimp>
+            <Portuguese>Trocar Rádio</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_list_OpenRadio">
             <English>Open Selected Radio</English>
+            <Spanish>Abrir radio seleccionadai</Spanish>
+            <Czech>Otevřít vybrané rádio</Czech>
+            <German>Ausgewähltes funkgerät öffnen</German>
+            <Japanese>無線機を開く</Japanese>
+            <Italian>Apri Ricetrasmittente Selezionata</Italian>
+            <French>Ouvrir radio sélectionnée</French>
+            <Korean>무전기 열기</Korean>
+            <Polish>Otwórz panel wybrane radia</Polish>
+            <Russian>Oткрыто pеадио</Russian>
+            <Chinese>打開無線電</Chinese>
+            <Chinesesimp>打开无线电</Chinesesimp>
+            <Portuguese>Abrir Rádio Selecionado</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_list_NotificationGrid">
             <English>ACRE2 - Radio Notifications</English>

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -17,19 +17,19 @@
             <Portuguese>Trocar Rádio</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_list_OpenRadio">
-            <English>Open Selected Radio</English>
-            <Spanish>Abrir radio seleccionadai</Spanish>
-            <Czech>Otevřít vybrané rádio</Czech>
-            <German>Ausgewähltes funkgerät öffnen</German>
+            <English>Open Active Radio</English>
+            <Spanish>Abrir radio</Spanish>
+            <Czech>Otevřít aktivní rádio</Czech>
+            <German>Funkgerät öffnen</German>
             <Japanese>無線機を開く</Japanese>
-            <Italian>Apri Ricetrasmittente Selezionata</Italian>
-            <French>Ouvrir radio sélectionnée</French>
+            <Italian>Apri Ricetrasmittente Attiva</Italian>
+            <French>Ouvrir radio active</French>
             <Korean>무전기 열기</Korean>
-            <Polish>Otwórz panel wybrane radia</Polish>
-            <Russian>Oткрыто pеадио</Russian>
+            <Polish>Otwórz panel aktywne radia</Polish>
+            <Russian>Открыть радио</Russian>
             <Chinese>打開無線電</Chinese>
             <Chinesesimp>打开无线电</Chinesesimp>
-            <Portuguese>Abrir Rádio Selecionado</Portuguese>
+            <Portuguese>Abrir Rádio</Portuguese>
         </Key>
         <Key ID="STR_ACRE_sys_list_NotificationGrid">
             <English>ACRE2 - Radio Notifications</English>

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -5,7 +5,7 @@
             <English>Cycle Radios</English>
         </Key>
         <Key ID="STR_ACRE_sys_list_OpenRadio">
-            <English>Open Active Radio</English>
+            <English>Open Selected Radio</English>
         </Key>
         <Key ID="STR_ACRE_sys_list_NotificationGrid">
             <English>ACRE2 - Radio Notifications</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Close #635 - Change default keybinds from-to:
  - Default Radio Key: `Caps Lock` -> Active Radio Transmit: `unbound` (and moved below the other 3)
  - Alt Radio Key 1: `Shift + Caps Lock` -> Radio 1 Transmit (PTT 1): `Caps Lock`
  - Alt Radio Key 2: `Ctrl + Caps Lock` -> Radio 2 Transmit (PTT 2): `Ctrl + Caps Lock`
  - Alt Radio Key 3: `Alt + Caps Lock`- > Radio 3 Transmit (PTT 3): `Alt + Caps Lock`
- Descriptions (tooltips) also changed to:
  - `Transmit on currently active radio.`
  - `Transmit on first/second/third radio and set it as active.`
- Streamline key names and descriptions
  - Use `Active Radio` on keys that only work on currently active/selected radio (Channel Switch already used that)
   - Removed `Key` from names (Radio and Intercom) and changed to `Transmit/Broadcast`
- Prettify keybind adding post inits

~~Should we keep all or some of the translated strings (they aren't wrong, just different - not as clear as new ones)?~~ Kept all, changed some (might not be fully correct).