### PR TITLE
Fix cba prestart func optimization

### DIFF
--- a/addons/sys_external/CfgEventHandlers.hpp
+++ b/addons/sys_external/CfgEventHandlers.hpp
@@ -12,7 +12,7 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_postInit););
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };
 

--- a/addons/sys_signalmap/CfgEventHandlers.hpp
+++ b/addons/sys_signalmap/CfgEventHandlers.hpp
@@ -12,6 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        init = QUOTE(call COMPILE_FILE(XEH_postInit););
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };


### PR DESCRIPTION
Really trivial
```
XEH: Could not recompile [postInit-acre_sys_external]: call compile preProcessFileLineNumbers '\idi\acre\addons\sys_external\XEH_postInit.sqf';
XEH: Could not recompile [postInit-acre_sys_signalmap]: call compile preProcessFileLineNumbers '\idi\acre\addons\sys_signalmap\XEH_postInit.sqf';
```
ref https://github.com/CBATeam/CBA_A3/blob/master/addons/xeh/fnc_compileEventHandlers.sqf#L84-L96