### PR TITLE
Set default Intercom UI key to Ctrl+Shift+Tab

### DIFF
--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -42,7 +42,7 @@ if (!hasInterface) exitWith {};
 
 ["ACRE2", QGVAR(openGui), localize LSTRING(openGui), {
     [-1] call FUNC(openGui)
-}, ""] call CBA_fnc_addKeybind;
+}, "", [DIK_TAB, [true, true, false]] call CBA_fnc_addKeybind;
 
 // Intercom configuration
 ["vehicle", {

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -42,7 +42,7 @@ if (!hasInterface) exitWith {};
 
 ["ACRE2", QGVAR(openGui), localize LSTRING(openGui), {
     [-1] call FUNC(openGui)
-}, "", [DIK_TAB, [true, true, false]] call CBA_fnc_addKeybind;
+}, "", [DIK_TAB, [true, true, false]]] call CBA_fnc_addKeybind;
 
 // Intercom configuration
 ["vehicle", {


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Same as described in [documentation](https://acre2.idi-systems.com/wiki/user/vehicle-intercom#full-functional-crew-station-ffcs).