### PR TITLE
Use the bent antenna icon when prone or crouch in automatic mode

### DIFF
--- a/addons/sys_gui/fnc_antennaElevationDisplay.sqf
+++ b/addons/sys_gui/fnc_antennaElevationDisplay.sqf
@@ -17,13 +17,11 @@
 
 // Need to run this every frame. Otherwise there will be noticeable delays
 [{
-    if (EGVAR(sys_core,automaticAntennaDirection)) exitWith {};
-    
     // Collect data from stance and antenna direction
     private _stance = tolower (stance acre_player);
-    if (_stance == "" || _stance == "undefined") exitWith {};
+    if (_stance == "" || {_stance == "undefined"}) exitWith {};
     private _antennaDirection = "_straight";
-    if (acre_player getVariable [QEGVAR(sys_core,antennaDirUp), false]) then {
+    if (acre_player getVariable [QEGVAR(sys_core,antennaDirUp), false] || {EGVAR(sys_core,automaticAntennaDirection) && {_stance != "stand"}}) then {
         _antennaDirection = "_bend";
     };
 


### PR DESCRIPTION
**When merged this pull request will:**
Right now, the antenna icon does not get updated  in automatic mode, showing always the "straight antenna" when stance is "standing" despite being  crouch  or prone. With this PR

- Use the bent antenna icon when prone or crouch in automatic mode
- When standing, show the straight icon.

![image](https://user-images.githubusercontent.com/11097475/61829126-8f913200-ae68-11e9-8bba-919bbf9f29d3.png)
