### PR TITLE
Support infantry phone on very large vehicles

### DIFF
--- a/addons/sys_intercom/fnc_infantryPhoneAction.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneAction.sqf
@@ -48,7 +48,7 @@ private _infantryPhoneAction = [
         // Main interaction node is not shown on destroyed vehicle, so we only check that if not main node
         //USES_VARIABLES ["_target", "_player"];
         if !((_this select 2) isEqualTo [0, 0, 0]) exitWith {alive _target};
-        _player distance _target < PHONE_MAXDISTANCE_DEFAULT
+        ([_player, _target] call ace_interaction_fnc_getInteractionDistance) < PHONE_MAXDISTANCE_DEFAULT
     },
     {_this call FUNC(infantryPhoneChildrenActions)},
     _position,

--- a/addons/sys_intercom/script_component.hpp
+++ b/addons/sys_intercom/script_component.hpp
@@ -21,7 +21,7 @@
 #include "script_acre_rackIntercom_defines.hpp"
 #include "script_acre_intercom_defines.hpp"
 
-#define PHONE_MAXDISTANCE_DEFAULT 10 // @todo replace with ace_interaction_fnc_getInteractionDistance when ACE 3.9.1 releases
+#define PHONE_MAXDISTANCE_DEFAULT 10
 #define PHONE_MAXDISTANCE_HULL    3
 
 // Infantry phone default configuration (fnc_infantryPhoneRingingPFH.sqf)

--- a/addons/sys_signal/fnc_handleSignalReturn.sqf
+++ b/addons/sys_signal/fnc_handleSignalReturn.sqf
@@ -26,7 +26,6 @@ if (count _result > 0) then {
     private _maxSignal = missionNamespace getVariable [_bestSignalStr , -992];
     private _currentAntenna = missionNamespace getVariable [_bestAntStr, ""];
 
-    // TODO: Remove debug before release 2.7.0
     TRACE_4("%1: %2 ----- %3: %4",_bestSignalStr,_maxSignal,_bestAntStr,_currentAntenna);
 
     if ((_id == _currentAntenna) || {(_id != _currentAntenna) && {_signal > _maxSignal}}) then {

--- a/addons/sys_signal/script_component.hpp
+++ b/addons/sys_signal/script_component.hpp
@@ -2,7 +2,7 @@
 #define COMPONENT_BEAUTIFIED Signal
 #include "\idi\acre\addons\main\script_mod.hpp"
 
-//#define DEBUG_MODE_FULL
+// #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Use `ace_interaction_fnc_getInteractionDistance` to get effective distance off the hull of the vehicle in case of very large vehicle.
- Cleanup redundant 2.7.0 comment