### PR TITLE
Fix and improve Intercom and Rack configuration warnings

### DIFF
--- a/addons/sys_intercom/fnc_configInfantryPhone.sqf
+++ b/addons/sys_intercom/fnc_configInfantryPhone.sqf
@@ -31,13 +31,13 @@ private _configHelper = {
 
     private _returnArray = [];
     if (_configArray isEqualTo []) then {
-        WARNING_2("No intercom networks specified in %1 for vehicle type %2. Assuming all intercoms can be reached with the infantry phone",_type);
+        WARNING_1("No intercom networks specified for %1 - assuming all intercoms can be reached with the infantry phone",_type);
         _returnArray pushBack (_vehicle getVariable [QGVAR(intercomNames), []]);
     } else {
         // Check for a valid configuration
         if ("all" in _configArray) then {
             if (count _configArray != 1) then {
-                WARNING_2("Vehicle type %1 has %2 entry with the all wildcard in combination with other entries. All intercoms will be made available",_type,_configEntry);
+                WARNING_2("%1 has %2 entry with the all wildcard in combination with other entries - all intercoms will be made available",_type,_configEntry);
             };
 
             _returnArray append (_vehicle getVariable [QGVAR(intercomNames), []]);
@@ -53,7 +53,7 @@ private _configHelper = {
                     }
                 } forEach _intercom;
                 if (!_found) then {
-                    WARNING_3("Intercom %1 in %2 for vehicle type %3 is not found as a valid intercom identifier",_x,_configEntry,_type);
+                    WARNING_3("Intercom %1 in %2 is not found as a valid intercom identifier for %3",_x,_configEntry,_type);
                 };
             } forEach _configArray;
         };
@@ -71,10 +71,10 @@ _vehicle setVariable [QGVAR(infantryPhoneControlActions), _infantryPhoneControlA
 
 if !(_infantryPhoneCustomRinging isEqualTo []) then {
     if (_infantryPhoneDisableRinging) then {
-        WARNING_2("Vehicle type %1 has the ringing functionality disabled despite having a custom ringing tone entry %2",_type,_infantryPhoneCustomRinging);
+        WARNING_2("Ringing functionality disabled despite having a custom ringing tone entry %1 for %2",_infantryPhoneCustomRinging,_type);
     } else {
         if (count _infantryPhoneCustomRinging != 5) then {
-            WARNING_2("Badly formatted entry acre_infantryPhoneCustomRinging for vehicle type %1. It should have 5 arguments but it has %2.",_type,count _infantryPhoneCustomRinging);
+            WARNING_2("Badly formatted entry acre_infantryPhoneCustomRinging for %1 - should have 5 arguments but has %2",_type,count _infantryPhoneCustomRinging);
         } else {
             _vehicle setVariable [QGVAR(infPhoneCustomRinging), _infantryPhoneCustomRinging];
         };

--- a/addons/sys_intercom/fnc_configIntercom.sqf
+++ b/addons/sys_intercom/fnc_configIntercom.sqf
@@ -18,6 +18,8 @@
 
 params ["_vehicle", "_intercoms"];
 
+private _type = typeOf _vehicle;
+
 private _intercomNames = [];
 private _intercomPositions = [];
 private _intercomExceptions = [];
@@ -40,13 +42,14 @@ private _accent = [];
     private _masterPositions = getArray (_x >> "masterPositions");
     private _availabeIntercomPositions = [];
 
+
     if (count _shortName > 5) then {
-        WARNING_2("Intercom short name %1 is longer than 5 characters for vehicle %2",_shortName,_vehicle);
+        WARNING_3("Intercom %1 short name %2 is longer than 5 characters for %3",_name,_shortName,_type);
     };
 
     // Check if the entry in allowed positions is correct
     if (_allowedPositions isEqualTo []) then {
-        WARNING_2("Vehicle type %1 has no entry for allowed positions array. This is not supported. Defaulting to crew for intercom network %2.",_type,_name);
+        WARNING_2("Intercom %1 has no entry for allowed positions array for %2 - defaulting to crew",_name,_type);
 
         // Use Standard configuration
         // Driver, commander and gunner positions. Only select thoses that are defined.
@@ -72,7 +75,7 @@ private _accent = [];
     private _limitedIntercomPositions = [_vehicle, _limitedPositions] call EFUNC(sys_core,processVehicleSystemAccessArray);
     if (!(_limitedIntercomPositions isEqualto []) && {_numLimPositions isEqualTo []}) then {
         //_limitedIntercomPositions = [];
-        WARNING_2("Vehicle type %1 has limited positions defined but no actual limit of simultaneous connections. Ignoring limited positions for intercom network %2",_vehicle, _name);
+        WARNING_2("Intercom %1 has limited positions defined but no actual limit of simultaneous connections for %2 - ignoring limited positions",_name,_type);
     };
 
     // Remove all exceptions
@@ -91,7 +94,7 @@ private _accent = [];
     private _masterStationPositions = [_vehicle, _masterPositions] call EFUNC(sys_core,processVehicleSystemAccessArray);
     {
         if !(_x in _availabeIntercomPositions) exitWith {
-            WARNING_3("Vehicle type %1 has a master station entry (%2) that has no access to that intercom. Ignoring master positions for intercom network %3",_vehicle,_x,_name);
+            WARNING_3("Intercom %1 has a master station entry (%2) that has no access to that intercom for %3 - ignoring master positions",_name,_x,_vehicle);
         };
     } forEach _masterStationPositions;
 
@@ -99,7 +102,7 @@ private _accent = [];
     {
         if (_x in _availabeIntercomPositions) exitWith {
             _limitedIntercomPositions = [];
-            WARNING_3("Vehicle type %1 has limited positions defined (%2) that overlap with allowed positions. Ignoring limited positions for intercom network %3",_vehicle,_x,_name);
+            WARNING_3("Intercom %1 has limited positions defined (%2) that overlap with allowed positions for %3 - ignoring limited positions",_name,_x,_vehicle);
         };
     } forEach _limitedIntercomPositions;
 

--- a/addons/sys_rack/fnc_configWiredIntercoms.sqf
+++ b/addons/sys_rack/fnc_configWiredIntercoms.sqf
@@ -38,7 +38,7 @@ if (_intercoms isEqualTo [] || {"none" in _intercoms}) then {
             if (_int in (_configuredIntercoms select 0)) then {
                 _wiredIntercoms pushBack _x;
             } else {
-                WARNING_3("Vehicle type %1 does not have the intercom %2 but the rack %3 can have access to its network. Not adding it.",_type,_int,_rack)
+                WARNING_3("No intercom %1 defined but rack %2 can have access to its network for %3 - skipping",_int,_rack,_type)
             };
         } forEach _intercoms;
     };

--- a/addons/sys_rack/fnc_initVehicle.sqf
+++ b/addons/sys_rack/fnc_initVehicle.sqf
@@ -34,7 +34,7 @@ if (!_initialized) then {
         private _intercoms = [_vehicle, _x] call FUNC(configWiredIntercoms);
 
         if (count _shortName > 4) then {
-            WARNING_2("Rack short name %1 is longer than 4 characters for vehicle %2",_shortName,_vehicle);
+            WARNING_2("Rack short name %1 is longer than 4 characters for %2",_shortName,_vehicle);
         };
 
         [_vehicle, _componentName, _displayName, _shortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _components, _intercoms] call FUNC(addRack);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix some warnings (wrong macro or nil variable)
- Use classname instead of object serialization
- Follow CBA "standard" of warnings ("x is bla-bla for class")