### PR TITLE
Fix and improve Vehicle Info UI for 1.94

### DIFF
--- a/addons/sys_gui/CfgRscTitles.hpp
+++ b/addons/sys_gui/CfgRscTitles.hpp
@@ -113,6 +113,12 @@ class RscTitles {
         };
     };
 
+    #define VEHICLE_INFO_POSITION \
+        x = QUOTE(profileNamespace getVariable [ARR_2('TRIPLES(IGUI,grid_ACRE_vehicleInfo,X)',VEHICLE_INFO_DEFAULT_X)]); \
+        y = QUOTE(profileNamespace getVariable [ARR_2('TRIPLES(IGUI,grid_ACRE_vehicleInfo,Y)',VEHICLE_INFO_DEFAULT_Y)]); \
+        w = QUOTE(profileNamespace getVariable [ARR_2('TRIPLES(IGUI,grid_ACRE_vehicleInfo,W)',VEHICLE_INFO_DEFAULT_W)]); \
+        h = QUOTE(profileNamespace getVariable [ARR_2('TRIPLES(IGUI,grid_ACRE_vehicleInfo,H)',VEHICLE_INFO_DEFAULT_H)]); \
+
     class GVAR(vehicleInfo) {
         idd = -1;
         movingEnable = 1;
@@ -123,29 +129,21 @@ class RscTitles {
         class controls {
             class VehicleInfoControlsGroup: RscControlsGroupNoScrollbars {
                 idc = -1;
-                x = "profileNamespace getVariable ['IGUI_grid_ACRE_vehicleInfo_X', profileNamespace getVariable ['IGUI_GRID_VEHICLE_X', safezoneX + 0.5 * (((safezoneW / safezoneH) min 1.2) / 40)]]";
-                y = "profileNamespace getVariable ['IGUI_grid_ACRE_vehicleInfo_Y', 4.3 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) + (profileNamespace getVariable ['IGUI_GRID_VEHICLE_Y', safezoneY + 0.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)])]";
-                w = "10 * (((safezoneW / safezoneH) min 1.2) / 40)";
-                onLoad = "uiNamespace setVariable ['ACRE_VehicleInfo', _this select 0];";
+                onLoad = QUOTE(with uiNamespace do {ACRE_VehicleInfo = _this select 0});
+                VEHICLE_INFO_POSITION
 
                 class Controls {
                     class VehicleInfoBackground: RscText {
                         idc = 1;
-                        x = 0;
-                        y = 0;
-                        w = "10 * (((safezoneW / safezoneH) min 1.2) / 40)";
                         colorBackground[] = {
-                            "profileNamespace getVariable ['IGUI_BCG_RGB_R', 0]",
-                            "profileNamespace getVariable ['IGUI_BCG_RGB_G', 1]",
-                            "profileNamespace getVariable ['IGUI_BCG_RGB_B', 1]",
-                            "profileNamespace getVariable ['IGUI_BCG_RGB_A', 0.8]"
+                            IGUI_BCG_RGB_R,
+                            IGUI_BCG_RGB_G,
+                            IGUI_BCG_RGB_B,
+                            IGUI_BCG_RGB_A
                         };
                     };
                     class VehicleInfoText: RscStructuredText {
                         idc = 2;
-                        x = 0;
-                        y = 0;
-                        w = "9.8 * (((safezoneW / safezoneH) min 1.2) / 40)";
                     };
                 };
             };

--- a/addons/sys_gui/CfgUIGrids.hpp
+++ b/addons/sys_gui/CfgUIGrids.hpp
@@ -5,13 +5,13 @@ class CfgUIGrids {
                 class Variables {
                     grid_ACRE_vehicleInfo[] = {
                         {
-                            "profileNamespace getVariable ['IGUI_GRID_VEHICLE_X', safezoneX + 0.5 * (((safezoneW / safezoneH) min 1.2) / 40)]",
-                            "4.3 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25) + (profileNamespace getVariable ['IGUI_GRID_VEHICLE_Y', safezoneY + 0.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)])",
-                            "profileNamespace getVariable ['IGUI_GRID_VEHICLE_W', 10 * (((safezoneW / safezoneH) min 1.2) / 40)]",
-                            "(((safezoneW / safezoneH) min 1.2) / 1.2) / 25"
+                            VEHICLE_INFO_DEFAULT_X,
+                            VEHICLE_INFO_DEFAULT_Y,
+                            VEHICLE_INFO_DEFAULT_W,
+                            VEHICLE_INFO_DEFAULT_H
                         },
-                        "((safezoneW / safezoneH) min 1.2) / 40",
-                        "(((safezoneW / safezoneH) min 1.2) / 1.2) / 25"
+                        IGUI_GRID_VEHICLE_W,
+                        IGUI_GRID_VEHICLE_H
                     };
                 };
             };
@@ -22,7 +22,7 @@ class CfgUIGrids {
                 displayName = CSTRING(VehicleInfoGrid);
                 description = CSTRING(VehicleInfoGridDesc);
                 preview = QPATHTOF(data\ui\IGUI_vehicleInfo_preview_ca.paa);
-                saveToProfile[] = {0, 1, 2, 3};
+                saveToProfile[] = {0, 1};
                 canResize = 0;
             };
         };

--- a/addons/sys_gui/script_component.hpp
+++ b/addons/sys_gui/script_component.hpp
@@ -16,6 +16,17 @@
 
 #include "\idi\acre\addons\main\script_macros.hpp"
 
+#include "\a3\ui_f\hpp\defineCommonGrids.inc"
+#include "\a3\ui_f\hpp\defineCommonColors.inc"
+
+// Using base definitions due to UI grids using BIS_fnc_parseNumberSafe
+// which believes profileNamespace/getVariable are unsafe and defaults to 0
+// https://feedback.bistudio.com/T142860
+#define VEHICLE_INFO_DEFAULT_X IGUI_GRID_VEHICLE_XDef
+#define VEHICLE_INFO_DEFAULT_Y IGUI_GRID_VEHICLE_YDef + 4.3 * IGUI_GRID_VEHICLE_H
+#define VEHICLE_INFO_DEFAULT_W IGUI_GRID_VEHICLE_WAbs
+#define VEHICLE_INFO_DEFAULT_H IGUI_GRID_VEHICLE_H
+
 #define INVENTORY_DISPLAY (findDisplay 602)
 
 #define IDC_FG_VEST_CONTAINER 638

--- a/addons/sys_list/CfgUIGrids.hpp
+++ b/addons/sys_list/CfgUIGrids.hpp
@@ -22,7 +22,7 @@ class CfgUIGrids {
                 displayName = CSTRING(NotificationGrid);
                 description = CSTRING(NotificationGridDesc);
                 preview = QPATHTOF(data\ui\IGUI_notification_preview_ca.paa);
-                saveToProfile[] = {0,1,2,3};
+                saveToProfile[] = {0, 1};
                 canResize = 0;
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #747 - Vehicle Info UI alignment for Arma 3 v1.94 ([Arma 3 bug since 1.94](https://feedback.bistudio.com/T142860))
- Use grid and color definitions in Vehicle Info UI (same style as #738)
- Save only X and Y layout coordinates for Notification UI and Vehicle Info UI (not resizeable)

This results in Vehicle Info UI no longer being "coupled" to vanilla vehicle info HUD, meaning if someone moves it and then loads ACRE2 for the first time, our Vehicle Info won't be below the vanilla one nicely attached, but floating where the default vanilla one is.