### PR TITLE
Fix ITM adiff function

### DIFF
--- a/extensions/src/ACRE2Arma/signal/models/longleyRice_itm.cpp
+++ b/extensions/src/ACRE2Arma/signal/models/longleyRice_itm.cpp
@@ -273,7 +273,7 @@ namespace acre {
 
                         // :11: Prepare initial diffraction constants, page 5
                         double q = prop.h_g[0] * prop.h_g[1];
-                        double qk = prop.h_e[0] * prop.h_e[1] - q;
+                        qk = prop.h_e[0] * prop.h_e[1] - q;
 
                         if (prop.mdp < 0.0)
                             q += 10.0; // "C" from [Alg 4.9]


### PR DESCRIPTION
**When merged this pull request will:**
The implementation of the ITM model that is used has a bug the way adiff() function is calculated. After contacting the maintainer this bug has been confirmed.

The current implementation shadows a static variable declaration.
