### PR TITLE
Allow some notifications to be skipped

### DIFF
--- a/addons/sys_components/fnc_toggleAntennaDir.sqf
+++ b/addons/sys_components/fnc_toggleAntennaDir.sqf
@@ -20,8 +20,8 @@ private _dir = acre_player getVariable [QEGVAR(sys_core,antennaDirUp), false];
 // We need to set player variable globally cause we need to check for the antenna direction on every client
 if (_dir) then {
     acre_player setVariable [QEGVAR(sys_core,antennaDirUp), false, true];
-    [localize ELSTRING(sys_core,AntennaDirStraight)] call CBA_fnc_notify;
+    [[localize ELSTRING(sys_core,AntennaDirStraight)], true] call CBA_fnc_notify;
 } else {
     acre_player setVariable [QEGVAR(sys_core,antennaDirUp), true, true];
-    [localize ELSTRING(sys_core,AntennaDirBent)] call CBA_fnc_notify;
+    [[localize ELSTRING(sys_core,AntennaDirBent)], true] call CBA_fnc_notify;
 };

--- a/addons/sys_core/fnc_switchRadioEar.sqf
+++ b/addons/sys_core/fnc_switchRadioEar.sqf
@@ -20,13 +20,13 @@ params ["_ear", ["_radioId", ACRE_ACTIVE_RADIO, [""]]];
 
 switch (_ear) do {
     case -1: {
-        [[ICON_RADIO_CALL], [localize LSTRING(switchRadioEarLeft)]] call CBA_fnc_notify;
+        [[ICON_RADIO_CALL], [localize LSTRING(switchRadioEarLeft)], true] call CBA_fnc_notify;
     };
     case 0: {
-        [[ICON_RADIO_CALL], [localize LSTRING(switchRadioEarBoth)]] call CBA_fnc_notify;
+        [[ICON_RADIO_CALL], [localize LSTRING(switchRadioEarBoth)], true] call CBA_fnc_notify;
     };
     case 1: {
-        [[ICON_RADIO_CALL], [localize LSTRING(switchRadioEarRight)]] call CBA_fnc_notify;
+        [[ICON_RADIO_CALL], [localize LSTRING(switchRadioEarRight)], true] call CBA_fnc_notify;
     };
 };
 

--- a/addons/sys_core/fnc_toggleHeadset.sqf
+++ b/addons/sys_core/fnc_toggleHeadset.sqf
@@ -19,10 +19,10 @@ TRACE_1("enter", _this);
 if (!ACRE_IS_SPECTATOR) then {
     if (GVAR(lowered) == 1) then {
         GVAR(lowered) = 0;
-        [localize LSTRING(headsetRaised)] call CBA_fnc_notify;
+        [[localize LSTRING(headsetRaised)], true] call CBA_fnc_notify;
     } else {
         GVAR(lowered) = 1;
-        [localize LSTRING(headsetLowered)] call CBA_fnc_notify;
+        [[localize LSTRING(headsetLowered)], true] call CBA_fnc_notify;
     };
 } else {
     ACRE_MUTE_SPECTATORS = !ACRE_MUTE_SPECTATORS;

--- a/addons/sys_external/XEH_postInit.sqf
+++ b/addons/sys_external/XEH_postInit.sqf
@@ -39,12 +39,12 @@ if (!hasInterface) exitWith {};
         ACRE_EXTERNALLY_USED_PERSONAL_RADIOS = ACRE_EXTERNALLY_USED_PERSONAL_RADIOS - [_radioId];
     };
 
-    [[ICON_RADIO_CALL], [_message]] call CBA_fnc_notify;
+    [[ICON_RADIO_CALL], [_message], true] call CBA_fnc_notify;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(giveRadioLocal), {
     params ["_message"];
-    [[ICON_RADIO_CALL], [_message]] call CBA_fnc_notify;
+    [[ICON_RADIO_CALL], [_message], true] call CBA_fnc_notify;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(giveRadioAction), {_this call FUNC(startUsingExternalRadio)}] call CBA_fnc_addEventHandler;

--- a/addons/sys_external/fnc_startUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_startUsingExternalRadio.sqf
@@ -37,4 +37,4 @@ ACRE_ACTIVE_EXTERNAL_RADIOS pushBackUnique _radioId;
 // Set it as active radio.
 [_radioId] call EFUNC(api,setCurrentRadio);
 
-[[ICON_RADIO_CALL], [format [localize LSTRING(hintTake), _displayName, name _owner]]] call CBA_fnc_notify;
+[[ICON_RADIO_CALL], [format [localize LSTRING(hintTake), _displayName, name _owner]], true] call CBA_fnc_notify;

--- a/addons/sys_external/fnc_stopUsingExternalRadio.sqf
+++ b/addons/sys_external/fnc_stopUsingExternalRadio.sqf
@@ -26,7 +26,7 @@ ACRE_ACTIVE_EXTERNAL_RADIOS = ACRE_ACTIVE_EXTERNAL_RADIOS - [_radioId];
 
 private _baseRadio =  [_radioId] call EFUNC(api,getBaseRadio);
 private _displayName = getText (ConfigFile >> "CfgWeapons" >> _baseRadio >> "displayName");
-[[ICON_RADIO_CALL], [format [localize LSTRING(hintReturn), _displayName, name _owner]]] call CBA_fnc_notify;
+[[ICON_RADIO_CALL], [format [localize LSTRING(hintReturn), _displayName, name _owner]], true] call CBA_fnc_notify;
 
 if (_target == _owner) then {
     // Handle remote owner

--- a/addons/sys_intercom/fnc_updateInfantryPhoneStatus.sqf
+++ b/addons/sys_intercom/fnc_updateInfantryPhoneStatus.sqf
@@ -32,7 +32,7 @@ switch (_action) do {
         _unit setVariable [QGVAR(vehicleInfantryPhone), nil, true];
 
         ACRE_PLAYER_INTERCOM = [];
-        [[ICON_RADIO_CALL], [format [localize LSTRING(infantryPhoneDisconnected), _intercomText]]] call CBA_fnc_notify;
+        [[ICON_RADIO_CALL], [format [localize LSTRING(infantryPhoneDisconnected), _intercomText]], true] call CBA_fnc_notify;
         [GVAR(intercomPFH)] call CBA_fnc_removePerFrameHandler;
     };
     case 1: {
@@ -40,7 +40,7 @@ switch (_action) do {
         _vehicle setVariable [QGVAR(unitInfantryPhone), [_unit, _intercomNetwork], true];
         _unit setVariable [QGVAR(vehicleInfantryPhone), [_vehicle, _intercomNetwork], true];
 
-        [[ICON_RADIO_CALL], [format [localize LSTRING(infantryPhoneConnected), _intercomText]]] call CBA_fnc_notify;
+        [[ICON_RADIO_CALL], [format [localize LSTRING(infantryPhoneConnected), _intercomText]], true] call CBA_fnc_notify;
         GVAR(intercomPFH) = [DFUNC(intercomPFH), 1.1, [acre_player, _vehicle]] call CBA_fnc_addPerFrameHandler;
     };
     case 2: {

--- a/addons/sys_radio/fnc_handleRadioSpatialKeyPressed.sqf
+++ b/addons/sys_radio/fnc_handleRadioSpatialKeyPressed.sqf
@@ -29,6 +29,6 @@ if (!isNil "_currentSide") then {
     if (_currentSide != _side) then {
         [ACRE_ACTIVE_RADIO, _side] call FUNC(setRadioSpatial);
 
-        [format [localize LSTRING(radioSet), _side]] call CBA_fnc_notify;
+        [format [localize LSTRING(radioSet), _side], true] call CBA_fnc_notify;
     };
 };

--- a/addons/sys_server/fnc_openRadioCheckResult.sqf
+++ b/addons/sys_server/fnc_openRadioCheckResult.sqf
@@ -20,5 +20,5 @@ params ["_radioId", "_radioOpenedBy"];
 
 if (_radioOpenedBy != acre_player) then {
     [_radioId, "closeGui"] call EFUNC(sys_data,interactEvent);
-    [[ICON_RADIO_CALL], [localize ELSTRING(sys_radio,alreadyOpenRadio)]] call CBA_fnc_notify;
+    [[ICON_RADIO_CALL], [localize ELSTRING(sys_radio,alreadyOpenRadio)], true] call CBA_fnc_notify;
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Allow some notifications to be skipped
  - Important for notifications coming from keybind actions, currently they will get display with their full time so if you switch quickly between things you will get notifications from some time, this makes them skippable so you see the action right away.

Regression from switching to `CBA_fnc_notify`.