### PR TITLE
Fix Vehicle Info UI text cut-off and apply retroactive fix

### DIFF
--- a/addons/sys_gui/CfgUIGrids.hpp
+++ b/addons/sys_gui/CfgUIGrids.hpp
@@ -38,7 +38,7 @@ class CfgUIGrids {
                 displayName = CSTRING(VehicleInfoGrid_DisplayName);
                 description = CSTRING(VehicleInfoGrid_Description);
                 preview = QPATHTOF(data\ui\IGUI_vehicleInfo_preview_ca.paa);
-                saveToProfile[] = {0, 1};
+                saveToProfile[] = {0, 1, 2, 3}; // Save W and H as well due to 1.94 bug setting W to 0
                 canResize = 0;
             };
         };

--- a/addons/sys_gui/RscTitles.hpp
+++ b/addons/sys_gui/RscTitles.hpp
@@ -47,9 +47,11 @@ class RscTitles {
                     class VehicleInfoBackground: RscText {
                         idc = 1;
                         colorBackground[] = IGUI_BCG_COLOR;
+                        w = QUOTE(10 * VEHICLE_INFO_DEFAULT_W)
                     };
                     class VehicleInfoText: RscStructuredText {
                         idc = 2;
+                        w = QUOTE(9.8 * VEHICLE_INFO_DEFAULT_W)
                     };
                 };
             };

--- a/addons/sys_gui/RscTitles.hpp
+++ b/addons/sys_gui/RscTitles.hpp
@@ -47,11 +47,10 @@ class RscTitles {
                     class VehicleInfoBackground: RscText {
                         idc = 1;
                         colorBackground[] = IGUI_BCG_COLOR;
-                        w = QUOTE(10 * VEHICLE_INFO_DEFAULT_W);
                     };
                     class VehicleInfoText: RscStructuredText {
                         idc = 2;
-                        w = QUOTE(9.8 * VEHICLE_INFO_DEFAULT_W);
+                        w = QUOTE(10 * VEHICLE_INFO_DEFAULT_W); // Must be specifically widened
                     };
                 };
             };

--- a/addons/sys_gui/RscTitles.hpp
+++ b/addons/sys_gui/RscTitles.hpp
@@ -47,11 +47,11 @@ class RscTitles {
                     class VehicleInfoBackground: RscText {
                         idc = 1;
                         colorBackground[] = IGUI_BCG_COLOR;
-                        w = QUOTE(10 * VEHICLE_INFO_DEFAULT_W)
+                        w = QUOTE(10 * VEHICLE_INFO_DEFAULT_W);
                     };
                     class VehicleInfoText: RscStructuredText {
                         idc = 2;
-                        w = QUOTE(9.8 * VEHICLE_INFO_DEFAULT_W)
+                        w = QUOTE(9.8 * VEHICLE_INFO_DEFAULT_W);
                     };
                 };
             };

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -64,7 +64,7 @@ DFUNC(enterVehicle) = {
 }, true] call CBA_fnc_addPlayerEventHandler;
 
 
-// Fix Vehicle Info UI wrong saved values from: 2.7.0 and Arma 3 v1.94 combination - remove in 2.9.0
+// Fix Vehicle Info UI wrong saved values from: <=2.7.0 and Arma 3 v1.94 - remove in 2.9.0
 // https://feedback.bistudio.com/T142860
 // Only X and W entries were breaking
 private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfoX", 0];

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -66,11 +66,10 @@ DFUNC(enterVehicle) = {
 
 // Fix Vehicle Info UI wrong saved values from: <=2.7.0 and Arma 3 v1.94 - remove in 2.9.0
 // https://feedback.bistudio.com/T142860
-// Only X, Y and W entries were breaking - set to 0 as a result of BIS_fnc_parseNumberSafe
+// X, Y and W entries were breaking, but only X and W were to 0 as a result of BIS_fnc_parseNumberSafe
 private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_X", 0];
-private _vehicleInfoY = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_Y", 0];
-private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_w", 0];
-if (_vehicleInfoX == 0 && {_vehicleInfoY == 0} && {_vehicleInfoW == 0}) then {
+private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_W", 0];
+if (_vehicleInfoX == 0 && {_vehicleInfoW == 0}) then {
     // Reset all (H for redundancy)
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_X", VEHICLE_INFO_DEFAULT_X];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_Y", VEHICLE_INFO_DEFAULT_Y];

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -62,18 +62,3 @@ DFUNC(enterVehicle) = {
         (QGVAR(vehicleInfo) call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
     };
 }, true] call CBA_fnc_addPlayerEventHandler;
-
-
-// Fix Vehicle Info UI wrong saved values from: <=2.7.0 and Arma 3 v1.94 - remove in 2.9.0
-// https://feedback.bistudio.com/T142860
-// X, Y and W entries were breaking, but only X and W were to 0 as a result of BIS_fnc_parseNumberSafe
-private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_X", 0];
-private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_W", 0];
-if (_vehicleInfoX == 0 && {_vehicleInfoW == 0}) then {
-    // Reset all (H for redundancy)
-    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_X", VEHICLE_INFO_DEFAULT_X];
-    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_Y", VEHICLE_INFO_DEFAULT_Y];
-    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_W", VEHICLE_INFO_DEFAULT_W];
-    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_H", VEHICLE_INFO_DEFAULT_H];
-    INFO("Vehicle Info UI fixed (<=2.7.0 and Arma 3 v1.94 bug).");
-};

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -74,6 +74,8 @@ TRACE_2("Fix Vehicle Info UI",_vehicleInfoX,_vehicleInfoW);
 // Both entries were set to 0 as a result of BIS_fnc_parseNumberSafe
 if (_vehicleInfoX == 0 && {_vehicleInfoW == 0}) then {
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_X", VEHICLE_INFO_DEFAULT_X];
+    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_Y", VEHICLE_INFO_DEFAULT_Y];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_W", VEHICLE_INFO_DEFAULT_W];
-    INFO("Vehicle Info UI fixed (2.7.0 and Arma 3 v1.94 buG).");
+    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_H", VEHICLE_INFO_DEFAULT_H];
+    INFO("Vehicle Info UI fixed (2.7.0 and Arma 3 v1.94 bug).");
 };

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -70,7 +70,7 @@ DFUNC(enterVehicle) = {
 private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_X", 0];
 private _vehicleInfoY = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_Y", 0];
 private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_w", 0];
-if (_vehicleInfoX == 0 && {_vehicleInfoY} && {_vehicleInfoW == 0}) then {
+if (_vehicleInfoX == 0 && {_vehicleInfoY == 0} && {_vehicleInfoW == 0}) then {
     // Reset all (H for redundancy)
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_X", VEHICLE_INFO_DEFAULT_X];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_Y", VEHICLE_INFO_DEFAULT_Y];

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -62,3 +62,18 @@ DFUNC(enterVehicle) = {
         (QGVAR(vehicleInfo) call BIS_fnc_rscLayer) cutText ["", "PLAIN"];
     };
 }, true] call CBA_fnc_addPlayerEventHandler;
+
+
+// Fix Vehicle Info UI wrong saved values from: 2.7.0 and Arma 3 v1.94 combination - remove in 2.9.0
+// https://feedback.bistudio.com/T142860
+// Only X and W entries were breaking
+private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfoX", 0];
+private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfoW", 0];
+TRACE_2("Fix Vehicle Info UI",_vehicleInfoX,_vehicleInfoW);
+
+// Both entries were set to 0 as a result of BIS_fnc_parseNumberSafe
+if (_vehicleInfoX == 0 && {_vehicleInfoW == 0}) then {
+    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_X", VEHICLE_INFO_DEFAULT_X];
+    profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_W", VEHICLE_INFO_DEFAULT_W];
+    INFO("Vehicle Info UI fixed (2.7.0 and Arma 3 v1.94 buG).");
+};

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -70,8 +70,8 @@ DFUNC(enterVehicle) = {
 private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_X", 0];
 private _vehicleInfoY = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_Y", 0];
 private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_w", 0];
-// Reset all (H for redundancy)
 if (_vehicleInfoX == 0 && {_vehicleInfoY} && {_vehicleInfoW == 0}) then {
+    // Reset all (H for redundancy)
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_X", VEHICLE_INFO_DEFAULT_X];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_Y", VEHICLE_INFO_DEFAULT_Y];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_W", VEHICLE_INFO_DEFAULT_W];

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -67,8 +67,8 @@ DFUNC(enterVehicle) = {
 // Fix Vehicle Info UI wrong saved values from: <=2.7.0 and Arma 3 v1.94 - remove in 2.9.0
 // https://feedback.bistudio.com/T142860
 // Only X and W entries were breaking
-private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfoX", 0];
-private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfoW", 0];
+private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_X", 0];
+private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_w", 0];
 TRACE_2("Fix Vehicle Info UI",_vehicleInfoX,_vehicleInfoW);
 
 // Both entries were set to 0 as a result of BIS_fnc_parseNumberSafe
@@ -77,5 +77,5 @@ if (_vehicleInfoX == 0 && {_vehicleInfoW == 0}) then {
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_Y", VEHICLE_INFO_DEFAULT_Y];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_W", VEHICLE_INFO_DEFAULT_W];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_H", VEHICLE_INFO_DEFAULT_H];
-    INFO("Vehicle Info UI fixed (2.7.0 and Arma 3 v1.94 bug).");
+    INFO("Vehicle Info UI fixed (<=2.7.0 and Arma 3 v1.94 bug).");
 };

--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -66,13 +66,12 @@ DFUNC(enterVehicle) = {
 
 // Fix Vehicle Info UI wrong saved values from: <=2.7.0 and Arma 3 v1.94 - remove in 2.9.0
 // https://feedback.bistudio.com/T142860
-// Only X and W entries were breaking
+// Only X, Y and W entries were breaking - set to 0 as a result of BIS_fnc_parseNumberSafe
 private _vehicleInfoX = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_X", 0];
+private _vehicleInfoY = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_Y", 0];
 private _vehicleInfoW = profileNamespace getVariable ["IGUI_grid_ACRE_vehicleInfo_w", 0];
-TRACE_2("Fix Vehicle Info UI",_vehicleInfoX,_vehicleInfoW);
-
-// Both entries were set to 0 as a result of BIS_fnc_parseNumberSafe
-if (_vehicleInfoX == 0 && {_vehicleInfoW == 0}) then {
+// Reset all (H for redundancy)
+if (_vehicleInfoX == 0 && {_vehicleInfoY} && {_vehicleInfoW == 0}) then {
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_X", VEHICLE_INFO_DEFAULT_X];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_Y", VEHICLE_INFO_DEFAULT_Y];
     profileNamespace setVariable ["IGUI_grid_ACRE_vehicleInfo_W", VEHICLE_INFO_DEFAULT_W];

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -428,7 +428,7 @@
         </Key>
         <Key ID="STR_ACRE_sys_intercom_openGui">
             <English>Open Intercom GUI</English>
-             <Spanish>Abrir la interfaz de Intercom</Spanish>
+            <Spanish>Abrir la interfaz de Intercom</Spanish>
             <Japanese>インターコムの GUI を開く</Japanese>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_forcedStatus">


### PR DESCRIPTION
**When merged this pull request will:**
- Fix text width on Vehicle Info UI - was cutting text off right after first intercom name (regression from #764)
- Fix position on broken configurations from <=2.7.0 resulting from changes in Arma 3 v1.94 by resetting broken profile values - #747 
- _Remove intruding space in intercom stringtable_