### PR TITLE
No racks in near radios

### DIFF
--- a/addons/sys_components/CfgAcreComponents.hpp
+++ b/addons/sys_components/CfgAcreComponents.hpp
@@ -73,18 +73,18 @@ class CfgAcreComponents {
             };
         };
     };
-    
+
     class ACRE_BaseRack : ACRE_ComponentBase {
         type = ACRE_COMPONENT_RACK;
         isAcre = 1;
         name = "ACRE Rack";
-        
+
         // Amplification
         // Speaker
         // Antenna slots.
         connectors[] = {};
         defaultComponents[] = {};
-        
+
         class Interfaces {
             class CfgAcreDataInterface {
                 getState                    = "acre_sys_rack_fnc_getState";

--- a/addons/sys_core/fnc_remoteStartSpeaking.sqf
+++ b/addons/sys_core/fnc_remoteStartSpeaking.sqf
@@ -104,6 +104,7 @@ private _result = false;
                 private _nearRadios = [ACRE_LISTENER_POS, NEAR_RADIO_RANGE] call EFUNC(sys_radio,nearRadios);
                 if (GVAR(zeusCommunicateViaCamera) && {call FUNC(inZeus)}) then {
                     _nearRadios append [(getPosASL curatorCamera), NEAR_RADIO_RANGE] call EFUNC(sys_radio,nearRadios);
+                    _nearRadios arrayIntersect _nearRadios;
                 };
                 {
                     if ([_x, "isExternalAudio"] call EFUNC(sys_data,dataEvent)) then {

--- a/addons/sys_radio/fnc_nearRadios.sqf
+++ b/addons/sys_radio/fnc_nearRadios.sqf
@@ -11,7 +11,7 @@
  * Array of near radios <ARRAY>
  *
  * Example:
- * ["ACRE_PRC343_ID_1"] call acre_sys_radio_fnc_nearRadioPos
+ * [[0, 0, 0], 150] call acre_sys_radio_fnc_nearRadios
  *
  * Public: No
  */
@@ -21,10 +21,12 @@ params ["_position", "_radius"];
 private _return = [];
 {
     private _radioId = _x;
-    private _object = HASH_GET(EGVAR(sys_server,objectIdRelationTable), _radioId);
+    if !(_radioId isKindOf "ACRE_BaseRack") then {
+        private _object = HASH_GET(EGVAR(sys_server,objectIdRelationTable), _radioId);
 
-    if ((getPosASL (_object select 0)) distance _position <= _radius) then {
-        PUSH(_return, _radioId);
+        if ((getPosASL (_object select 0)) distance _position <= _radius) then {
+            PUSH(_return, _radioId);
+        };
     };
 } forEach HASH_KEYS(EGVAR(sys_server,objectIdRelationTable));
 

--- a/addons/sys_radio/fnc_nearRadios.sqf
+++ b/addons/sys_radio/fnc_nearRadios.sqf
@@ -22,10 +22,10 @@ private _return = [];
 {
     private _radioId = _x;
     if (_radioId isKindOf ["ACRE_BaseRadio", configFile >> "CfgWeapons"]) then {
-        private _object = HASH_GET(EGVAR(sys_server,objectIdRelationTable), _radioId);
+        private _object = HASH_GET(EGVAR(sys_server,objectIdRelationTable),_radioId);
 
         if ((getPosASL (_object select 0)) distance _position <= _radius) then {
-            PUSH(_return, _radioId);
+            PUSH(_return,_radioId);
         };
     };
 } forEach HASH_KEYS(EGVAR(sys_server,objectIdRelationTable));

--- a/addons/sys_radio/fnc_nearRadios.sqf
+++ b/addons/sys_radio/fnc_nearRadios.sqf
@@ -21,7 +21,7 @@ params ["_position", "_radius"];
 private _return = [];
 {
     private _radioId = _x;
-    if !(_radioId isKindOf "ACRE_BaseRack") then {
+    if (_radioId isKindOf ["ACRE_BaseRadio", configFile >> "CfgWeapons"]) then {
         private _object = HASH_GET(EGVAR(sys_server,objectIdRelationTable), _radioId);
 
         if ((getPosASL (_object select 0)) distance _position <= _radius) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Avoid listing racks in near radios.

Rationale: Racks do not have external audio functions, nor they have any set of presets that is relevant for radio operation (sys_mode, external audio check,..).
This change may also avoid undefined calls and results in sys_data/getData function