### PR TITLE
Revert terrain loss coefficient at 1.0 default

### DIFF
--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -129,7 +129,7 @@
     "SLIDER",
     localize LSTRING(terrainLoss_displayName),
     "ACRE2",
-    [0, 1, 0.50, 2],
+    [0, 1, 1, 2],
     true,
     {[_this] call FUNC(setLossModelScale)}
 ] call CBA_fnc_addSetting;


### PR DESCRIPTION
**When merged this pull request will:**
- Set default CBA setting terrain loss again at 1.0.

Rationale: We have now 4 models they can use. Arcade mode should be the one to use.
