### PR TITLE
Correct config warning for rack short name length

### DIFF
--- a/addons/sys_rack/fnc_initVehicle.sqf
+++ b/addons/sys_rack/fnc_initVehicle.sqf
@@ -33,8 +33,8 @@ if (!_initialized) then {
         private _isRadioRemovable = getNumber (_x >> "isRadioRemovable") == 1;
         private _intercoms = [_vehicle, _x] call FUNC(configWiredIntercoms);
 
-        if (count _shortName > 4) then {
-            WARNING_2("Rack short name %1 is longer than 4 characters for %2",_shortName,_vehicle);
+        if (count _shortName > 5) then {
+            WARNING_2("Rack short name %1 is longer than 5 characters for %2",_shortName,_vehicle);
         };
 
         [_vehicle, _componentName, _displayName, _shortName, _isRadioRemovable, _allowed, _disabled, _mountedRadio, _components, _intercoms] call FUNC(addRack);


### PR DESCRIPTION
**When merged this pull request will:**
- Adjust warning of rack names to be inline with intercom configuration
