### PR TITLE
Add volume control color scale setting

### DIFF
--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -9,6 +9,7 @@
             <Turkish>ACRE2 UI</Turkish>
             <Japanese>ACRE2 UI</Japanese>
             <Italian>ACRE2 IU</Italian>
+            <Spanish>ACRE2 Interfaz</Spanish>
         </Key>
         <Key ID="STR_ACRE_sys_core_postmixGlobalVolume_displayName">
             <English>Post-Mix Global Volume</English>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="ACRE">
     <Package name="sys_core">
+        <Key ID="STR_ACRE_sys_core_CategoryUI">
+            <English>ACRE2 UI</English>
+            <German>ACRE2 Nutzeroberfläche</German>
+            <Polish>ACRE2 UI</Polish>
+            <French>ACRE2 IU</French>
+            <Turkish>ACRE2 UI</Turkish>
+            <Japanese>ACRE2 UI</Japanese>
+            <Italian>ACRE2 IU</Italian>
+        </Key>
         <Key ID="STR_ACRE_sys_core_postmixGlobalVolume_displayName">
             <English>Post-Mix Global Volume</English>
             <Spanish>Volumen Global Post-Mix</Spanish>

--- a/addons/sys_core/stringtable.xml
+++ b/addons/sys_core/stringtable.xml
@@ -8,6 +8,7 @@
             <French>ACRE2 IU</French>
             <Turkish>ACRE2 UI</Turkish>
             <Japanese>ACRE2 UI</Japanese>
+            <Czech>ACRE2 UI</Czech>
             <Italian>ACRE2 IU</Italian>
             <Spanish>ACRE2 Interfaz</Spanish>
         </Key>

--- a/addons/sys_gui/XEH_preInit.sqf
+++ b/addons/sys_gui/XEH_preInit.sqf
@@ -6,6 +6,8 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 if (hasInterface) then {
     ACRE_HOLD_OFF_ITEMRADIO_CHECK = false;
 

--- a/addons/sys_gui/fnc_getVolumeColor.sqf
+++ b/addons/sys_gui/fnc_getVolumeColor.sqf
@@ -17,4 +17,4 @@
 
 params ["_level"];
 
-VOLUME_COLOR_SCALE select (0 max ceil (count VOLUME_COLOR_SCALE * (_level min 1) - 1))
+GVAR(volumeColorScale) select (0 max ceil (count GVAR(volumeColorScale) * (_level min 1) - 1));

--- a/addons/sys_gui/initSettings.sqf
+++ b/addons/sys_gui/initSettings.sqf
@@ -1,0 +1,20 @@
+[
+    QGVAR(volumeColorScale),
+    "LIST",
+    [LSTRING(VolumeColorScale_DisplayName), LSTRING(VolumeColorScale_Description)],
+    "ACRE2",
+    [
+        [
+            VOLUME_COLOR_SCALE_YELLOW_ORANGE_RED,
+            VOLUME_COLOR_SCALE_GREEN_ORANGE_RED,
+            VOLUME_COLOR_SCALE_BLUE_MAGENTA_RED
+        ],
+        [
+            LSTRING(YellowOrangeRed),
+            LSTRING(GreenOrangeRed),
+            LSTRING(BlueMagentaRed)
+        ],
+        0
+    ],
+    false
+] call CBA_fnc_addSetting;

--- a/addons/sys_gui/initSettings.sqf
+++ b/addons/sys_gui/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(volumeColorScale),
     "LIST",
     [LSTRING(VolumeColorScale_DisplayName), LSTRING(VolumeColorScale_Description)],
-    "ACRE2",
+    localize ELSTRING(sys_list,Category),
     [
         [
             VOLUME_COLOR_SCALE_YELLOW_ORANGE_RED,

--- a/addons/sys_gui/initSettings.sqf
+++ b/addons/sys_gui/initSettings.sqf
@@ -2,7 +2,7 @@
     QGVAR(volumeColorScale),
     "LIST",
     [LSTRING(VolumeColorScale_DisplayName), LSTRING(VolumeColorScale_Description)],
-    localize ELSTRING(sys_list,Category),
+    ELSTRING(sys_core,CategoryUI),
     [
         [
             VOLUME_COLOR_SCALE_YELLOW_ORANGE_RED,

--- a/addons/sys_gui/script_component.hpp
+++ b/addons/sys_gui/script_component.hpp
@@ -31,13 +31,28 @@
 
 #define VOLUME_CONTROL_LAYER (QGVAR(VolumeControl) call BIS_fnc_rscLayer)
 
-// Color scale for the volume control (yellow -> orange -> red)
-#define VOLUME_COLOR_SCALE [ \
+// Color scales for the volume control
+#define VOLUME_COLOR_SCALE_YELLOW_ORANGE_RED [ \
     [1, 1, 0, 0.5], \
     [1, 0.83, 0, 0.5], \
     [1, 0.65, 0, 0.5], \
     [1, 0.44, 0, 0.5], \
     [1, 0, 0, 0.5] \
+]
+
+#define VOLUME_COLOR_SCALE_GREEN_ORANGE_RED [ \
+    [1, 1, 1, 0.5], \
+    [0.96, 1, 0, 0.5], \
+    [0.61, 0.8, 0, 0.5], \
+    [1, 0.46, 0, 0.5], \
+    [1, 0, 0, 0.5] \
+]
+
+#define VOLUME_COLOR_SCALE_BLUE_MAGENTA_RED [ \
+    [0, 0, 0.7, 0.5], \
+    [0.6, 0, 0.76, 0.5], \
+    [0.84, 0, 0.46, 0.5], \
+    [0.9, 0, 0, 0.5] \
 ]
 
 // Amount that the volume level changes on every scroll wheel action

--- a/addons/sys_gui/stringtable.xml
+++ b/addons/sys_gui/stringtable.xml
@@ -46,5 +46,20 @@
             <French>Statut des interphones et des supports disponibles dans le véhicule.</French>
             <German>Informationen bezüglich verfügbarer Interkommunikations- oder Festfunkgeräte.</German>
         </Key>
+        <Key ID="STR_ACRE_sys_gui_VolumeColorScale_DisplayName">
+            <English>Volume Color Scale</English>
+        </Key>
+        <Key ID="STR_ACRE_sys_gui_VolumeColorScale_Description">
+            <English>Color scale used by the Volume Control UI.</English>
+        </Key>
+        <Key ID="STR_ACRE_sys_gui_YellowOrangeRed">
+            <English>Yellow, Orange, Red</English>
+        </Key>
+        <Key ID="STR_ACRE_sys_gui_GreenOrangeRed">
+            <English>Green, Orange, Red</English>
+        </Key>
+        <Key ID="STR_ACRE_sys_gui_BlueMagentaRed">
+            <English>Blue, Magenta, Red</English>
+        </Key>
     </Package>
 </Project>

--- a/addons/sys_list/initSettings.sqf
+++ b/addons/sys_list/initSettings.sqf
@@ -5,7 +5,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(HintTextFont),
     "LIST",
     localize LSTRING(HintTextFont_DisplayName),
-    localize LSTRING(Category),
+    ELSTRING(sys_core,CategoryUI),
     [_fonts, _fontNames, 7],
     false,
     {}
@@ -16,7 +16,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(HintBackgroundColor),
     "COLOR",
     localize LSTRING(HintBackgroundColor_DisplayName),
-    localize LSTRING(Category),
+    ELSTRING(sys_core,CategoryUI),
     [ACRE_NOTIFICATION_BG_BLACK],
     false,
     {}
@@ -27,7 +27,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(SwitchChannelColor),
     "COLOR",
     localize LSTRING(SwitchChannelColor_DisplayName),
-    localize LSTRING(Category),
+    ELSTRING(sys_core,CategoryUI),
     [ACRE_NOTIFICATION_PURPLE],
     false,
     {}
@@ -38,7 +38,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(ToggleHeadsetColor),
     "COLOR",
     localize LSTRING(ToggleHeadsetColor_DisplayName),
-    localize LSTRING(Category),
+    ELSTRING(sys_core,CategoryUI),
     [ACRE_NOTIFICATION_PURPLE],
     false,
     {}
@@ -49,7 +49,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(CycleRadiosColor),
     "COLOR",
     localize LSTRING(CycleRadiosColor_DisplayName),
-    localize LSTRING(Category),
+    ELSTRING(sys_core,CategoryUI),
     [ACRE_NOTIFICATION_PURPLE],
     false,
     {}
@@ -60,7 +60,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(LanguageColor),
     "COLOR",
     localize LSTRING(LanguageColor_DisplayName),
-    localize LSTRING(Category),
+    ELSTRING(sys_core,CategoryUI),
     [ACRE_NOTIFICATION_RED],
     false,
     {}
@@ -71,7 +71,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(PTT1Color),
     "COLOR",
     localize LSTRING(PTT1Color_DisplayName),
-    [localize LSTRING(Category), "PTT"],
+    [ELSTRING(sys_core,CategoryUI), "PTT"],
     [ACRE_NOTIFICATION_YELLOW],
     false,
     {}
@@ -82,7 +82,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(PTT2Color),
     "COLOR",
     localize LSTRING(PTT2Color_DisplayName),
-    [localize LSTRING(Category), "PTT"],
+    [ELSTRING(sys_core,CategoryUI), "PTT"],
     [ACRE_NOTIFICATION_YELLOW],
     false,
     {}
@@ -93,7 +93,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(PTT3Color),
     "COLOR",
     localize LSTRING(PTT3Color_DisplayName),
-    [localize LSTRING(Category), "PTT"],
+    [ELSTRING(sys_core,CategoryUI), "PTT"],
     [ACRE_NOTIFICATION_YELLOW],
     false,
     {}
@@ -104,7 +104,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     QGVAR(DefaultPTTColor),
     "COLOR",
     localize LSTRING(DefaultPTTColor_DisplayName),
-    [localize LSTRING(Category), "PTT"],
+    [ELSTRING(sys_core,CategoryUI), "PTT"],
     [ACRE_NOTIFICATION_YELLOW],
     false,
     {}

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -41,15 +41,6 @@
             <German>Zeigt Benachrichtigungen für Funk und Funkgeräte.</German>
             <Japanese>無線機と送信に関する通知を表示します。</Japanese>
         </Key>
-        <Key ID="STR_ACRE_sys_list_Category">
-            <English>ACRE2 UI</English>
-            <German>ACRE2 Nutzeroberfläche</German>
-            <Polish>ACRE2 UI</Polish>
-            <French>ACRE2 IU</French>
-            <Turkish>ACRE2 UI</Turkish>
-            <Japanese>ACRE2 UI</Japanese>
-            <Italian>ACRE2 IU</Italian>
-        </Key>
         <Key ID="STR_ACRE_sys_list_HintBackgroundColor_DisplayName">
             <English>Notification Background Color</English>
             <German>Hintergrundfarbe der visuellen Benachrichtigung</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Add `acre_sys_gui_volumeColorScale` setting to control the color scale used by the volume control UI
- Add two new color scale presets - "Green, Orange, Red", "Blue, Magenta, Red" (from #812)

<details>
<summary>Images</summary>

![green_orange_red](https://user-images.githubusercontent.com/34453221/63641536-19a60380-c67e-11e9-9298-e08d65813ee5.png)

![blue_magenta_red](https://user-images.githubusercontent.com/34453221/63641537-1b6fc700-c67e-11e9-8bc7-3e795b729c96.png)


</details>