### PR TITLE
Use Slack badge from shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
         <img src="https://img.shields.io/badge/Documentation-Home-lightgrey.svg?style=flat-square" alt="ACRE2 Wiki">
     </a>
     <a href="http://slackin.idi-systems.com:3000">
-        <img src="http://slackin.idi-systems.com:3000/badge.svg?style=flat-square&label=Slack" alt="ACRE2 Slack">
+        <img src="https://img.shields.io/badge/Slack-Join-darkviolet.svg?style=flat-square" alt="ACRE2 Slack">
     </a>
     <a href="https://travis-ci.org/IDI-Systems/acre2">
         <img src="https://img.shields.io/travis/IDI-Systems/acre2.svg?style=flat-square&label=Build" alt="ACRE2 Build Status">

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <a href="http://acre2.idi-systems.com">
         <img src="https://img.shields.io/badge/Documentation-Home-lightgrey.svg?style=flat-square" alt="ACRE2 Wiki">
     </a>
-    <a href="http://slackin.idi-systems.com:3000">
+    <a href="http://slackin.idi-systems.com">
         <img src="https://img.shields.io/badge/Slack-Join-darkviolet.svg?style=flat-square" alt="ACRE2 Slack">
     </a>
     <a href="https://travis-ci.org/IDI-Systems/acre2">

--- a/docs/_data/topnav.yml
+++ b/docs/_data/topnav.yml
@@ -22,7 +22,7 @@ topnav_dropdowns:
       folderitems:
 
         - title: Slack
-          external_url: http://slackin.idi-systems.com:3000
+          external_url: http://slackin.idi-systems.com
 
         - title: BI Forums
           external_url: https://forums.bistudio.com/topic/193813-acre2-v22-stable-steam-workshop-release


### PR DESCRIPTION
No longer using Slackin, Community Inviter does not provide a Markdown badge.