### PR TITLE
Return proper volume in API function.

### DIFF
--- a/addons/api/fnc_getRadioVolume.sqf
+++ b/addons/api/fnc_getRadioVolume.sqf
@@ -21,4 +21,7 @@ if (isNil "_radioId") exitWith { -1 };
 
 if (!([_radioId] call EFUNC(sys_data,isRadioInitialized))) exitWith { -1 };
 
-[_radioId] call EFUNC(sys_radio,getRadioVolume);
+private _volume = [_radioId] call EFUNC(sys_radio,getRadioVolume);
+
+// Volume functions return _volume^3
+_volume ^ (1/3)


### PR DESCRIPTION
**When merged this pull request will:**
- Internal volume functions return volume^3. This makes get/set API volume functions to  be  inconsistent.