### PR TITLE
Events - Remote Speaking

### DIFF
--- a/addons/sys_core/fnc_remoteStartSpeaking.sqf
+++ b/addons/sys_core/fnc_remoteStartSpeaking.sqf
@@ -86,6 +86,9 @@ private _result = false;
     TRACE_1("unit pos", getPosASL _unit);
     private _isMuted = IS_MUTED(_unit);
     _unit setRandomLip true;
+
+    ["acre_remoteStartedSpeaking", [_unit, _onRadio, _radioId]] call CBA_fnc_localEvent; // [unit, on radio, radio ID]
+
     if (!_isMuted) then {
         TRACE_3("REMOTE STARTED SPEAKING",_speakingId,_onRadio,(_unit distance acre_player));
         _unit setVariable [QGVAR(lastSpeakingEventTime), diag_tickTime, false];

--- a/addons/sys_core/fnc_remoteStopSpeaking.sqf
+++ b/addons/sys_core/fnc_remoteStopSpeaking.sqf
@@ -25,6 +25,9 @@ _speakingId = parseNumber _speakingId;
 
         _found = true;
         _unit setRandomLip false;
+
+        ["acre_remoteStoppedSpeaking", [_unit]] call CBA_fnc_localEvent; // [unit]
+
         REM(GVAR(speakers),_unit);
         private _radioId = _unit getVariable [QGVAR(currentSpeakingRadio), ""];
 

--- a/docs/wiki/frameworks/events-list.md
+++ b/docs/wiki/frameworks/events-list.md
@@ -6,5 +6,7 @@ title: Events List
 
 | Name  | Arguments | Type | Version |
 | ----- |---------- | ---- | ------- |
-| `acre_startedSpeaking` | Unit <OBJECT>, On Radio <BOOL>, Radio ID <NUMBER> | Local | 2.7.0 |
-| `acre_stoppedSpeaking` | Unit <OBJECT>, On Radio <BOOL> | Local | 2.7.0 |
+| `acre_startedSpeaking`        | Unit <OBJECT>, On Radio <BOOL>, Radio ID <NUMBER> | Local | 2.7.0 |
+| `acre_stoppedSpeaking`        | Unit <OBJECT>, On Radio <BOOL> | Local | 2.7.0 |
+| `acre_remoteStartedSpeaking`  | Unit <OBJECT>, On Radio <BOOL>, Radio ID <NUMBER> | Local | 2.7.2 |
+| `acre_remoteStoppedSpeaking`  | Unit <OBJECT> | Local | 2.7.2 |


### PR DESCRIPTION
**When merged this pull request will:**
- Add `acre_remoteStartedSpeaking` and `acre_remoteStoppedSpeaking`

They are local events that fire when someone else begins talking.
