### PR TITLE
Signal Map - Fix marker creating with `_`

### DIFF
--- a/addons/sys_signalmap/fnc_setRxAreaEnd.sqf
+++ b/addons/sys_signalmap/fnc_setRxAreaEnd.sqf
@@ -75,7 +75,7 @@ if (_this select 1 == 0) then {
 
                 private _markerPos = [(_start select 0) + ((TILE_SIZE * _xScale) / 2), (_start select 1) + ((TILE_SIZE * _yScale) / 2)];
 
-                private _marker = createMarkerLocal [format["rxarea_%1", (count GVAR(rxAreas))], _markerPos];
+                private _marker = createMarkerLocal [format["rxarea%1", (count GVAR(rxAreas))], _markerPos];
                 _marker setMarkerSizeLocal [(TILE_SIZE * _xScale) / 2, (TILE_SIZE * _yScale) / 2];
                 _marker setMarkerShapeLocal "RECTANGLE";
                 _marker setMarkerColorLocal "ColorRed";


### PR DESCRIPTION
The problem is when you exec : `[] call acre_sys_signalmap_fnc_open;`
You can set the **TX Position**, but not the **RX Area**.
We have the right error when create a too small area, but just nothing when create any area.

The reason is simple, the functions https://community.bistudio.com/wiki/createMarkerLocal doesn't support underscore anymore in the marker name.

You can try by executing this code :

```sqf
marker1 = createMarkerLocal ["rxarea_0",  position player];
marker1 setMarkerSizeLocal [400,400]; 
marker1 setMarkerShapeLocal "RECTANGLE"; 
marker1 setMarkerColorLocal "ColorRed";
```
Will return a marker : **marker1** == ""
But no error, because thx Bohemia.

But you can create a marker "**rxarea0**"
You can pass empty string... it works... like it is used for rxAreaStartMarker, txPosMarker in sys_signalmap. But it is not possible to use both of them, so no error.