### PR TITLE
Intercom - fix exitWith if invalid unit

### DIFF
--- a/addons/sys_intercom/fnc_getStationConfiguration.sqf
+++ b/addons/sys_intercom/fnc_getStationConfiguration.sqf
@@ -21,12 +21,8 @@
 
 params ["_vehicle", "_unit", "_intercomNetwork", "_intercomFunctionality", ["_varName", ""]];
 
-if (_varName isEqualTo "") then {
-    _varName = [_vehicle, _unit] call FUNC(getStationVariableName);
-
-    if (_varName isEqualTo "") exitWith {
-        ERROR_2("unit %1 not found in vehicle %2",_unit,_vehicle);
-    };
+if ((_varName isEqualTo "") && {_varName = [_vehicle, _unit] call FUNC(getStationVariableName); _varName isEqualTo ""})  exitWith {
+    ERROR_2("getStationConfiguration: unit %1 not found in vehicle %2",_unit,_vehicle);
 };
 
 private _intercomArray = _vehicle getVariable [_varName, []];

--- a/addons/sys_intercom/fnc_saveStationConfiguration.sqf
+++ b/addons/sys_intercom/fnc_saveStationConfiguration.sqf
@@ -20,12 +20,8 @@
 
 params ["_vehicle", "_unit", ["_varName", ""]];
 
-if (_varName isEqualTo "") then {
-    _varName = [_vehicle, _unit] call FUNC(getStationVariableName);
-
-    if (_varName isEqualTo "") exitWith {
-        ERROR_2("unit %1 not found in vehicle %2",_unit,_vehicle);
-    };
+if ((_varName isEqualTo "") && {_varName = [_vehicle, _unit] call FUNC(getStationVariableName); _varName isEqualTo ""})  exitWith {
+    ERROR_2("saveStationConfiguration: unit %1 not found in vehicle %2",_unit,_vehicle);
 };
 
 // Only make public if GUI is not opened

--- a/addons/sys_intercom/fnc_setStationConfiguration.sqf
+++ b/addons/sys_intercom/fnc_setStationConfiguration.sqf
@@ -23,12 +23,8 @@
 
 params ["_vehicle", "_unit", "_intercomNetwork", "_intercomFunctionality", "_value", ["_varName", ""]];
 
-if (_varName isEqualTo "") then {
-    _varName = [_vehicle, _unit] call FUNC(getStationVariableName);
-
-    if (_varName isEqualTo "") exitWith {
-        ERROR_2("unit %1 not found in vehicle %2",_unit,_vehicle);
-    };
+if ((_varName isEqualTo "") && {_varName = [_vehicle, _unit] call FUNC(getStationVariableName); _varName isEqualTo ""})  exitWith {
+    ERROR_2("setStationConfiguration: unit %1 not found in vehicle %2",_unit,_vehicle);
 };
 
 private _intercomArray = _vehicle getVariable [_varName, []];

--- a/addons/sys_intercom/fnc_setStationUnit.sqf
+++ b/addons/sys_intercom/fnc_setStationUnit.sqf
@@ -20,12 +20,8 @@
 
 params ["_vehicle", "_unit", "_intercomNetwork", ["_varName", ""]];
 
-if (_varName isEqualTo "") then {
-    _varName = [_vehicle, _unit] call FUNC(getStationVariableName);
-
-    if (_varName isEqualTo "") exitWith {
-        ERROR_2("unit %1 not found in vehicle %2",_unit,_vehicle);
-    };
+if ((_varName isEqualTo "") && {_varName = [_vehicle, _unit] call FUNC(getStationVariableName); _varName isEqualTo ""})  exitWith {
+    ERROR_2("setStationUnit: unit %1 not found in vehicle %2",_unit,_vehicle);
 };
 
 private _intercomArray = _vehicle getVariable [_varName, []];


### PR DESCRIPTION
On 2.7.2 when exiting a vehicle I got script error
```
20:54:51 [ACRE] (sys_intercom) ERROR: unit bis_o12_94 not found in vehicle bis_o12_94
20:54:51 Error in expression <[]]], "_key"];
private _index = (_hash select 1) find _key;
if (_index >= 0) t>
20:54:51   Error position: <select 1) find _key;
if (_index >= 0) t>
20:54:51   Error Zero divisor
20:54:51 File \x\cba\addons\hashes\fnc_hashGet.sqf [CBA_fnc_hashGet]..., line 1865
```

Still not sure why player was passed as vehicle arg. 
But I noticed the `exitWith` was probably not doing what was expected and exiting the wrong scope.
This should prevent script error
Also, CBA no longer logs file/line on `ERROR` so this adds func descriptor to log

Can also write change as this which is more readable, but technically slower
```
if (_varName isEqualTo "") then {
    _varName = [_vehicle, _unit] call FUNC(getStationVariableName);
};
if (_varName isEqualTo "") exitWith {
    ERROR_2("setStationUnit: unit %1 not found in vehicle %2",_unit,_vehicle);
};
```