### PR TITLE
Extension - Fix a memory leak and error case in PIPE_COMMAND_READ

### DIFF
--- a/extensions/src/ACRE2Arma/arma2ts/CallExt_DllMain.cpp
+++ b/extensions/src/ACRE2Arma/arma2ts/CallExt_DllMain.cpp
@@ -198,24 +198,28 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
                     //DEBUG("ReadFile failed, [%08x]\r\n", err);
                     if (err == ERROR_NO_DATA) {
                         strncpy(output, "_JERR_NULL", outputSize);
-                    } else {
+                    }
+                    else {
                         if (err == ERROR_BROKEN_PIPE) {
                             ClosePipe();
                         }
                         strncpy(output, "_JERR_FALSE", outputSize);
                     }
-                } else if (cbRead != 0) {
+                }
+                else if (cbRead != 0) {
                     //DEBUG("Read data: %s\n", value);
 
                     // Ensure NUL terminated string (required by strncpy_s)
                     value[cbRead] = '\0';
 
                     strncpy_s(output, outputSize, value, _TRUNCATE);
-                } else {
+                }
+                else {
                     //DEBUG("No data read");
                     strncpy(output,"_JERR_NULL",outputSize);
                 }
-            } else {
+            }
+            else {
                 ClosePipe();
                 strncpy(output,"_JERR_NOCONNECT",outputSize);
             }

--- a/extensions/src/ACRE2Arma/arma2ts/CallExt_DllMain.cpp
+++ b/extensions/src/ACRE2Arma/arma2ts/CallExt_DllMain.cpp
@@ -187,15 +187,14 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
         case PIPE_COMMAND_READ: {
             if (readConnected) {
                 DWORD cbRead;
-                BOOL ret;
                 constexpr size_t read_length = 4097U;
                 char value[read_length]; // Allocate on stack to delegate memory management to compiler,
                 // allows up to 4096 char string (+1 to ensure NUL terminated), like initial version
 
                 //DEBUG("Read from pipe [%d]\n", hPipe);
-                ret = ReadFile(readHandle, (LPVOID)value, sizeof(char) * (read_length - 1U), &cbRead, NULL);
+                const BOOL ret = ReadFile(readHandle, (LPVOID)value, sizeof(char) * (read_length - 1U), &cbRead, NULL);
                 if (!ret) {
-                    DWORD err = GetLastError();
+                    const DWORD err = GetLastError();
                     //DEBUG("ReadFile failed, [%08x]\r\n", err);
                     if (err == ERROR_NO_DATA) {
                         strncpy(output, "_JERR_NULL", outputSize);
@@ -213,7 +212,7 @@ void __stdcall RVExtension(char *output, int outputSize, const char *function)
                         cbRead = outputSize - 1U;
                     }
 
-                    // Ensure NUL terminated string (required by strncpy_s)
+                    // Ensure NUL terminated string (required by strncpy)
                     value[cbRead] = '\0';
 
                     strncpy(output, value, cbRead);


### PR DESCRIPTION
I've detected two issues in PIPE_COMMAND_READ :
- It allocates a buffer with `new char[n]`, but release it with `delete` instead of `delete []`. The first change is to allocate on stack the buffer to avoid manual memory management.
- It uses an unallocated variable `err` if read length is 0. According to [ReadFile documentation](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile) this case can occurs with named pipes. As the `ERROR_NO_DATA` error case is handled, behave the same way.

The last issue seems to produce fewtimes the following error in game :
```
[ACRE] (sys_io) WARNING: Experienced a pipe error! Closing! idi\acre\addons\sys_io\fnc_serverReadLoop.sqf:27
[ACRE] (sys_io) INFO: Pipe opened.
```
leading to desynchronization. This should fix this issue.

Minor codes fixes have been included :
- Use of constant `ERROR_NO_DATA` instead of `232` 
- Remove unused variable `name`
- ~~Use of `strncpy_s` to prevent buffer overflow if `outputSize` is smaller than 4096~~
- Add `\0` to the end of the received value to ensure string is NUL terminated
- Modified code has been updated to current [coding guidelines](https://acre2.idi-systems.com/wiki/development/coding-guidelines-cpp) (All closing braces should be on their own line.)