### PR TITLE
Core - Fix updateSelf position format (Zeus over water)

### DIFF
--- a/addons/sys_core/fnc_updateSelf.sqf
+++ b/addons/sys_core/fnc_updateSelf.sqf
@@ -16,16 +16,16 @@
  */
 
 // ref bug: http://feedback.arma3.com/view.php?id=15580
-private _projectPos = ATLtoASL positionCameraToWorld [0, 0, 0];
+private _projectPos = positionCameraToWorld [0, 0, 0];
 
-if (EGVAR(sys_zeus,zeusCommunicateViaCamera) && {call FUNC(inZeus)}) then {
+if (EGVAR(sys_zeus,zeusCommunicateViaCamera) && FUNC(inZeus)) then {
     ACRE_LISTENER_DIR = eyeDirection player;
 } else {
-    ACRE_LISTENER_DIR = (ATLtoASL positionCameraToWorld [0, 0, 1]) vectorDiff _projectPos;
+    ACRE_LISTENER_DIR = positionCameraToWorld [0, 0, 1] vectorDiff _projectPos;
 };
 
 if (ACRE_IS_SPECTATOR) then {
-    ACRE_LISTENER_POS = _projectPos;
+    ACRE_LISTENER_POS = AGLToASL _projectPos;
 } else {
     ACRE_LISTENER_POS = eyePos acre_player;
 };

--- a/addons/sys_core/fnc_updateSelf.sqf
+++ b/addons/sys_core/fnc_updateSelf.sqf
@@ -21,7 +21,7 @@ private _projectPos = AGLtoASL positionCameraToWorld [0, 0, 0];
 if (EGVAR(sys_zeus,zeusCommunicateViaCamera) && FUNC(inZeus)) then {
     ACRE_LISTENER_DIR = eyeDirection player;
 } else {
-    ACRE_LISTENER_DIR = AGLtoASL positionCameraToWorld [0, 0, 1] vectorDiff _projectPos;
+    ACRE_LISTENER_DIR = (AGLtoASL positionCameraToWorld [0, 0, 1]) vectorDiff _projectPos;
 };
 
 if (ACRE_IS_SPECTATOR) then {

--- a/addons/sys_core/fnc_updateSelf.sqf
+++ b/addons/sys_core/fnc_updateSelf.sqf
@@ -16,16 +16,16 @@
  */
 
 // ref bug: http://feedback.arma3.com/view.php?id=15580
-private _projectPos = positionCameraToWorld [0, 0, 0];
+private _projectPos = AGLtoASL positionCameraToWorld [0, 0, 0];
 
 if (EGVAR(sys_zeus,zeusCommunicateViaCamera) && FUNC(inZeus)) then {
     ACRE_LISTENER_DIR = eyeDirection player;
 } else {
-    ACRE_LISTENER_DIR = positionCameraToWorld [0, 0, 1] vectorDiff _projectPos;
+    ACRE_LISTENER_DIR = AGLtoASL positionCameraToWorld [0, 0, 1] vectorDiff _projectPos;
 };
 
 if (ACRE_IS_SPECTATOR) then {
-    ACRE_LISTENER_POS = AGLToASL _projectPos;
+    ACRE_LISTENER_POS = _projectPos;
 } else {
     ACRE_LISTENER_POS = eyePos acre_player;
 };
@@ -37,7 +37,7 @@ if (_height < 0) then {
     ACRE_LISTENER_DIVE = 0;
 };
 
-private _additionalValues = [([] call FUNC(getSpeakingLanguageId))];
+private _additionalValues = [[] call FUNC(getSpeakingLanguageId)];
 private _updateSelf = [];
 _updateSelf append ACRE_LISTENER_POS;
 _updateSelf append ACRE_LISTENER_DIR;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `updateSelf` function by using correct format when converting to ASL - `positionCameraToWorld` returns AGL not ATL
- Possibly fix #826 - since if the camera is underwater `AGL < 0` then `ATLtoASL` will return a position with `ATL < 0` (below the ocean floor)
