### PR TITLE
Components - Fix receiving rack antenna search

### DIFF
--- a/addons/sys_components/fnc_findAntenna.sqf
+++ b/addons/sys_components/fnc_findAntenna.sqf
@@ -41,11 +41,7 @@ private _searchFunction = {
                             if (IS_STRING(_componentParentId)) then {
                                 private _groundSpikeAntenna = [_componentParentId] call EFUNC(sys_gsa,getConnectedGsa);
                                 if (isNull _groundSpikeAntenna) then {
-                                    if (HASH_HASKEY(_attributes,"worldObject")) then {
-                                        _componentObject = HASH_GET(_attributes,"worldObject");
-                                    } else {
-                                        _componentObject = [_componentParentId] call EFUNC(sys_radio,getRadioObject);
-                                    };
+                                    _componentObject = [_componentParentId] call EFUNC(sys_radio,getRadioObject);
                                 } else {
                                     _componentObject = _groundSpikeAntenna;
                                 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #523 by removing `"worldObject"`

_Note: enabled speaker is not necessary for this error to happen as the issue indicates._

Referencing this structure as discovered by following the code in `findAntenna`:
```
-> Rack/Radio ID (string)
  -> Component Data (hash)
    -> Connector Data (hash or array => ?)
      -> Connector Attributes (hash)
        -> `"worldObject"` attribute (component object)
```

`"worldObject"` is currently unused in ACRE2 (only those 2 getters in `findAntenna` function), but it was intended for fully functional ground radio components as part of the component system (source: @Sniperhid).

Script error in #523 shows that `Connector Attributes` is actually an Array instead of a Hash (Location): https://github.com/IDI-Systems/acre2/blob/0d2496df9424c7b25c4c981e58982d964ccfbbac/addons/sys_components/fnc_findAntenna.sqf#L44

So instead of searching for `"worldObject"` in the code-base, I searched for whatever sets `Connector Attributes` by searching for it's parent `acre_radioConnectionData` (key in `Connector Data`), found 2 cases where its set to `[]` Array instead of a Hash, [here](https://github.com/IDI-Systems/acre2/blob/c748d10ac11afe0aac9e71a28ef5df81795bf2f6/addons/sys_components/fnc_attachComponentHandler.sqf#L31) and [here](https://github.com/IDI-Systems/acre2/blob/c748d10ac11afe0aac9e71a28ef5df81795bf2f6/addons/sys_components/fnc_initializeComponent.sqf#L29). Both cases were unchanged since ACRE2 moved to GitHub, and `findAntenna` function only received formatting updates or further support for GSA in that location - nothing else relevant got changed.

It is most likely that racks just found the error. Looks like none of other code using `Connector Data` (mostly component framework itself) is expecting it to be a hash, but indeed expects it to be a normal array, iterating through it and setting data at specific indices. So my conclusion is that `"worldObject"` was added at some point very early in ACRE (probably ACRE1), never used and then some structure was changed and that stayed hidden until racks.
