### PR TITLE
ACE Interact - Only do a single call to getPlayerRadioList

### DIFF
--- a/addons/ace_interact/CfgVehicles.hpp
+++ b/addons/ace_interact/CfgVehicles.hpp
@@ -4,9 +4,9 @@ class CfgVehicles {
         class ACE_SelfActions {
             class ACRE_Interact {
                 displayName = CSTRING(radios);
-                condition = QUOTE(!((_player call EFUNC(sys_data,getPlayerRadioList)) isEqualTo []));
+                condition = QUOTE(true);
                 exceptions[] = {"isNotInside", "isNotSitting"};
-                statement = "true";
+                statement = ""; // With no statement the action will only show if it has children
                 insertChildren = QUOTE(_this call FUNC(radioListChildrenActions));
                 priority = 0.1;
                 icon = ICON_RADIO_CALL;

--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -1,13 +1,13 @@
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team
- * Adds child actions for self interaction
+ * Adds child actions for self-interaction. 
  *
  * Arguments:
  * 0: Interaction Target (player) <OBJECT>
  *
  * Return Value:
- * Ace Child Actions <ARRAY>
+ * ACE Child Actions <ARRAY>
  *
  * Example:
  * [player] call acre_ace_interact_fnc_radioListChildrenActions

--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team
- * Adds child actions for self-interaction. 
+ * Adds child actions for self-interaction.
  *
  * Arguments:
  * 0: Interaction Target (player) <OBJECT>

--- a/addons/ace_interact/fnc_radioListChildrenActions.sqf
+++ b/addons/ace_interact/fnc_radioListChildrenActions.sqf
@@ -1,27 +1,28 @@
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team
- * SHORT DESCRIPTION
+ * Adds child actions for self interaction
  *
  * Arguments:
- * 0: ARGUMENT ONE <TYPE>
- * 1: ARGUMENT TWO <TYPE>
+ * 0: Interaction Target (player) <OBJECT>
  *
  * Return Value:
- * RETURN VALUE <TYPE>
+ * Ace Child Actions <ARRAY>
  *
  * Example:
- * [ARGUMENTS] call acre_COMPONENT_fnc_FUNCTIONNAME
+ * [player] call acre_ace_interact_fnc_radioListChildrenActions
  *
  * Public: No
  */
 
 params ["_target"];
 
+private _radioList = [] call EFUNC(api,getCurrentRadioList);
+if (_radioList isEqualTo []) exitWith { [] }; // Quick exit if we have no radios
+
 private _actions = [];
 private _currentRadio = [] call EFUNC(api,getCurrentRadio);
 private _pttAssign = [] call EFUNC(api,getMultiPushToTalkAssignment);
-private _radioList = [] call EFUNC(api,getCurrentRadioList);
 
 {
     private _owner = "";
@@ -76,19 +77,18 @@ private _radioList = [] call EFUNC(api,getCurrentRadioList);
     _actions pushBack [_action, [], _target];
 } forEach _radioList;
 
-if !(_radioList isEqualTo []) then {
-    private _text = localize LSTRING(lowerHeadset);
-    if (EGVAR(sys_core,lowered)) then { _text = localize LSTRING(raiseHeadset); };
-    private _action = [QGVAR(toggleHeadset), _text, "", {[] call EFUNC(sys_core,toggleHeadset)}, {true}, {}, []] call ace_interact_menu_fnc_createAction;
-    _actions pushBack [_action, [], _target];
 
-    if (!EGVAR(sys_core,automaticAntennaDirection)) then {
-        _text = localize LSTRING(bendAntenna);
-        private _dir = acre_player getVariable [QEGVAR(sys_core,antennaDirUp), false];
-        if (_dir) then { _text = localize LSTRING(straightenAntenna);};
-        _action = [QGVAR(antennaDirUp), _text, "", {[] call EFUNC(sys_components,toggleAntennaDir)}, {true}, {}, []] call ace_interact_menu_fnc_createAction;
-        _actions pushBack [_action, [], _target];
-    };
+private _text = localize LSTRING(lowerHeadset);
+if (EGVAR(sys_core,lowered)) then { _text = localize LSTRING(raiseHeadset); };
+private _action = [QGVAR(toggleHeadset), _text, "", {[] call EFUNC(sys_core,toggleHeadset)}, {true}, {}, []] call ace_interact_menu_fnc_createAction;
+_actions pushBack [_action, [], _target];
+
+if (!EGVAR(sys_core,automaticAntennaDirection)) then {
+    _text = localize LSTRING(bendAntenna);
+    private _dir = acre_player getVariable [QEGVAR(sys_core,antennaDirUp), false];
+    if (_dir) then { _text = localize LSTRING(straightenAntenna);};
+    _action = [QGVAR(antennaDirUp), _text, "", {[] call EFUNC(sys_components,toggleAntennaDir)}, {true}, {}, []] call ace_interact_menu_fnc_createAction;
+    _actions pushBack [_action, [], _target];
 };
 
 _actions


### PR DESCRIPTION
`acre_sys_data_fnc_getPlayerRadioList` has some cost (0.3ms with a few items/radios)

before the func was called twice in a row by both `condition` and `insertChildren`
this skips condition check and just returns zero children if array is empty
ace will skip actions if their statement is empty and they have no children