### PR TITLE
Use RVExtensionRegisterCallback

### DIFF
--- a/addons/sys_core/XEH_preInit.sqf
+++ b/addons/sys_core/XEH_preInit.sqf
@@ -118,24 +118,6 @@ acre_sys_io_ioEventFnc = {
 "acre_dynload" callExtension format["load:%1", "idi\build\win32\Debug\acre.dll"];
 #endif
 
-private _monitorFnc = {
-    private _res = ["fetch_result", ""] call FUNC(callExt);
-    while {!isNil "_res"} do {
-        // diag_log text format["RES: %1", _res];
-        private _id = _res select 0;
-        private _callBack = GVAR(threadedExtCalls) select _id;
-        if (IS_ARRAY(_callBack)) then {
-            private _args = (_res select 1);
-            if !(_args isEqualTo []) then {
-                _args = _args select 0;
-            };
-            [_callBack select 0, _args] call (_callBack select 1);
-        };
-        _res = ["fetch_result", ""] call FUNC(callExt);
-    };
-};
-ADDPFH(_monitorFnc, 0, []);
-
 ACRE_TESTANGLES = [];
 private _m = 8;
 private _spread = 75;
@@ -147,6 +129,22 @@ for "_i" from 1 to (_m/2) do {
         ACRE_TESTANGLES pushBack _negative;
     };
 };
+
+addMissionEventHandler ["ExtensionCallback", {
+    params ["_name", "_function", "_data"];
+    if (_name != "ACRE_TR") exitWith {};
+    (parseSimpleArray _data) params ["_id", "_args"];
+    TRACE_2("ExtensionCallback",_function,_id);
+
+    private _callBack = GVAR(threadedExtCalls) select _id;
+
+    if (IS_ARRAY(_callBack)) then {
+        if !(_args isEqualTo []) then {
+            _args = _args select 0;
+        };
+        [_callBack select 0, _args] call (_callBack select 1);
+    };
+}];
 
 
 ADDON = true;

--- a/addons/sys_core/fnc_callExt.sqf
+++ b/addons/sys_core/fnc_callExt.sqf
@@ -53,9 +53,13 @@ _command = format["%1:%2", _command, _paramsString];
 #else
     private _res = "acre" callExtension _command;
 #endif
-_res = call compile _res;
+
 if (_threaded) then {
-    GVAR(threadedExtCalls) set [(_res select 1), [_callBackArgs, _callBack]];
+    (parseSimpleArray _res) params ["", "_index"];
+    GVAR(threadedExtCalls) set [_index, [_callBackArgs, _callBack]];
+    // TRACE_2("new thread",_res,_index);
+} else {
+    _res = call compile _res;
 };
 
 _res;

--- a/extensions/src/ACRE2Arma/acre/acre.cpp
+++ b/extensions/src/ACRE2Arma/acre/acre.cpp
@@ -14,8 +14,18 @@
 extern "C" {
     __declspec (dllexport) void __stdcall RVExtensionVersion(char *output, int outputSize);
     __declspec (dllexport) void __stdcall RVExtension(char *output, int outputSize, const char *function);
+    __declspec (dllexport) void __stdcall RVExtensionRegisterCallback(int(*callbackProc)(char const* name, char const* function, char const* data));
 };
 #endif
+
+std::function<int(char const*, char const*, char const*)> callbackFunc = [](char const*, char const*, char const*) {
+    LOG(ERROR) << "RVExtensionRegisterCallback never called";
+    return -2;
+};
+void __stdcall RVExtensionRegisterCallback(int(*callbackProc)(char const* name, char const* function, char const* data)) {
+    LOG(INFO) << "RVExtensionRegisterCallback called";
+    callbackFunc = callbackProc;
+}
 
 void __stdcall RVExtensionVersion(char *output, int outputSize) {
     sprintf_s(output, outputSize, "%s", ACRE_VERSION);

--- a/extensions/src/ACRE2Arma/controller/controller.cpp
+++ b/extensions/src/ACRE2Arma/controller/controller.cpp
@@ -16,8 +16,6 @@ namespace acre {
         add("reset", std::bind(&acre::controller::reset, this, std::placeholders::_1, std::placeholders::_2));
         add("ready", std::bind(&acre::controller::get_ready, this, std::placeholders::_1, std::placeholders::_2));
         add("stop", std::bind(&controller::do_stop, this, std::placeholders::_1, std::placeholders::_2));
-        // action results
-        add("fetch_result", std::bind(&acre::controller::fetch_result, this, std::placeholders::_1, std::placeholders::_2));
         _initiated = false;
         _ready = true;
     }
@@ -46,11 +44,7 @@ namespace acre {
 
 
         { 
-            std::lock_guard<std::mutex> lock_results(_results_lock);
-
-            while (!_results.empty()) {
-                _results.pop();
-            }
+            std::lock_guard<std::mutex> lock_results(_messages_lock);
 
             while (!_messages.empty()) {
                 _messages.pop();
@@ -59,19 +53,6 @@ namespace acre {
 
         _ready = true;
 
-        return true;
-    }
-
-    bool controller::fetch_result(const arguments &_args, std::string & result) {
-        result = "";
-        if (_results.size() > 0) {
-            std::lock_guard<std::mutex> _lock(_results_lock);
-            dispatch_result res = _results.front();
-            std::stringstream ss;
-            ss << "[" << res.id << ",[" << res.message << "]]";
-            result = ss.str();
-            _results.pop();
-        }
         return true;
     }
 }

--- a/extensions/src/ACRE2Arma/controller/controller.hpp
+++ b/extensions/src/ACRE2Arma/controller/controller.hpp
@@ -22,8 +22,6 @@ namespace acre {
         bool reset(const arguments &, std::string &);
         bool get_ready(const arguments &, std::string &);
 
-        bool fetch_result(const arguments &, std::string &);
-
         bool do_stop(const arguments &, std::string &) {
             stop();
             _worker.join();


### PR DESCRIPTION
Use RVExtensionRegisterCallback so extension can return data when ready instead of running polling loop in-game.

Can drop a PFEH, callExtension and call compile each frame. 
But these really aren't that expensive and this is a delicate area so this may not be worth it.