### PR TITLE
Signal - Fix excessive range bug described in #820 in multipath signal model 

### DIFF
--- a/addons/sys_signalmap/XEH_preInit.sqf
+++ b/addons/sys_signalmap/XEH_preInit.sqf
@@ -7,8 +7,6 @@ PREP_RECOMPILE_START;
 PREP_RECOMPILE_END;
 
 if (hasInterface) then {
-    #define TILE_SIZE 4000
-
     with uiNamespace do {
         GVAR(completedAreas) = [];
         GVAR(currentArgs) = [];

--- a/addons/sys_signalmap/script_component.hpp
+++ b/addons/sys_signalmap/script_component.hpp
@@ -20,3 +20,4 @@
 
 #define CTRL(var, type) var = GVAR(mapDisplay) ctrlCreate [type, GVAR(debugIdc), GVAR(ctrlGroup)]; GVAR(debugIdc) = GVAR(debugIdc) + 1; GVAR(signal_debug) pushBack var
 #define CTRLOVERLAY(var, type) var = GVAR(mapDisplay) ctrlCreate [type, GVAR(debugIdc), GVAR(overlayMessageGrp)]; GVAR(debugIdc) = GVAR(debugIdc) + 1; GVAR(signal_debug) pushBack var
+#define TILE_SIZE 4000

--- a/extensions/src/ACRE2Arma/signal/models/los_simple.cpp
+++ b/extensions/src/ACRE2Arma/signal/models/los_simple.cpp
@@ -4,6 +4,10 @@
 #include <glm/gtx/vector_angle.hpp>
 
 #include <cmath>
+#include <mutex>
+#include <thread>
+
+std::mutex peak_mutex;
 
 static const float32_t PI = 3.14159265f;
 static const float32_t magic = 10.0f;
@@ -130,9 +134,12 @@ void acre::signal::model::multipath::process(result *const result_, const glm::v
         search_size++;
     }
 
-    if ((tx_pos_.x != _cached_tx_pos.x) || (tx_pos_.y != _cached_tx_pos.y)) {
-        get_peaks_spiral(tx_pos_.x, tx_pos_.y, search_size, search_size, _cached_peaks);
-        _cached_tx_pos = tx_pos_;
+    {
+        const std::lock_guard<std::mutex> lock(peak_mutex);
+        if ((tx_pos_.x != _cached_tx_pos.x) || (tx_pos_.y != _cached_tx_pos.y)) {
+            get_peaks_spiral(tx_pos_.x, tx_pos_.y, search_size, search_size, _cached_peaks);
+            _cached_tx_pos = tx_pos_;
+        }
     }
 
     std::vector<float32_t> signals;

--- a/extensions/src/ACRE2Arma/signal/models/models_common.hpp
+++ b/extensions/src/ACRE2Arma/signal/models/models_common.hpp
@@ -113,7 +113,7 @@ namespace acre {
                 return sqrtf((r*.001f) * powf(10.0f, dBm * 0.1f));
             }
             float32_t v_to_dbm(const float32_t v, const float32_t r) {
-                return 10.0f * log10f((v*v) / (r * 0.001f)) / 2.3025f;
+                return 10.0f * logf((v*v) / (r * 0.001f)) / 2.3025f;
             }
 
             float32_t mW_to_dbm (const float32_t power_mW) {

--- a/extensions/src/ACRE2Arma/signal/signal.hpp
+++ b/extensions/src/ACRE2Arma/signal/signal.hpp
@@ -354,7 +354,7 @@ namespace acre {
                     return true;
                 }
 
-                uint32_t thread_count = 6;
+                uint32_t thread_count = 1;
 
                 uint32_t y_chunk_size, y_chunk_remainder;
                 if (count_y > thread_count) {
@@ -367,7 +367,7 @@ namespace acre {
                 }
                 std::vector<std::thread> thread_pool;
                 std::vector<std::vector<signal_map_result>> result_sets;
-                result_sets.resize(thread_count+1);
+                result_sets.resize(thread_count);
 
                 for (uint32_t i = 0; i < thread_count; ++i) {
                     std::vector<signal_map_result> *result_entry = &result_sets[i];
@@ -454,7 +454,10 @@ namespace acre {
                         result.rx_pos = glm::vec3(rx_x_pos, rx_y_pos, z);
                         result.tx_pos = glm::vec3(tx_pos_);
                         _signalProcessor_multipath.process(&result.result, tx_pos_, tx_dir_, result.rx_pos, glm::vec3(0.0f, 1.0f, 0.0f), tx_antenna_, rx_antenna_, frequency_, power_, 1.0f, omnidirectional_);
-                        results->at(y_val * x_size + x) = result;
+                        {
+                            std::lock_guard<std::mutex> lock(_signal_lock);
+                            results->at(y_val * x_size + x) = result;
+                        }
                     }
                     y_val++;
                     std::lock_guard<std::mutex> lock(_signal_lock);


### PR DESCRIPTION
This will fix the bug referenced in #820.

Fix was a typo when moving help functions for converting between dBm and volts. Volts to dBm uses the natural log of the square of the voltage. New code was using the base 10 log, creating an excessively high voltage.
