### PR TITLE
Respawn - Improve MenuPosition with Spectator

### DIFF
--- a/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
@@ -21,6 +21,6 @@ params ["_display"];
 [_display] call FUNC(addDisplayPassthroughKeys);
 
 // Do not switch the player into spectator if the "MenuPosition" respawn template is in use
-if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) AND !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
+if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) && !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
     [] call FUNC(spectatorOn);
 };

--- a/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
@@ -20,4 +20,7 @@ params ["_display"];
 // Key handling compatibility for Vanilla Spectator (EG Spectator)
 [_display] call FUNC(addDisplayPassthroughKeys);
 
-[] call FUNC(spectatorOn);
+// Do not switch the player into spectator if the "MenuPosition" respawn template is in use
+if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) AND !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
+	[] call FUNC(spectatorOn);
+};

--- a/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
@@ -21,6 +21,6 @@ params ["_display"];
 [_display] call FUNC(addDisplayPassthroughKeys);
 
 // Do not switch the player into spectator if the "MenuPosition" respawn template is in use
-if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) && !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
+if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) && {!(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])}) then {
     [] call FUNC(spectatorOn);
 };

--- a/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayLoad.sqf
@@ -22,5 +22,5 @@ params ["_display"];
 
 // Do not switch the player into spectator if the "MenuPosition" respawn template is in use
 if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) AND !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
-	[] call FUNC(spectatorOn);
+    [] call FUNC(spectatorOn);
 };

--- a/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
@@ -15,4 +15,7 @@
  * Public: No
  */
 
-[] call FUNC(spectatorOff);
+// Do not switch the player out of spectator if the "MenuPosition" respawn template is in use
+if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) AND !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
+	[] call FUNC(spectatorOff);
+};

--- a/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
@@ -16,6 +16,6 @@
  */
 
 // Do not switch the player out of spectator if the "MenuPosition" respawn template is in use
-if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) AND !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
+if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) && !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
     [] call FUNC(spectatorOff);
 };

--- a/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
@@ -17,5 +17,5 @@
 
 // Do not switch the player out of spectator if the "MenuPosition" respawn template is in use
 if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) AND !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
-	[] call FUNC(spectatorOff);
+    [] call FUNC(spectatorOff);
 };

--- a/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
+++ b/addons/sys_core/fnc_spectatorEGDisplayUnload.sqf
@@ -16,6 +16,6 @@
  */
 
 // Do not switch the player out of spectator if the "MenuPosition" respawn template is in use
-if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) && !(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])) then {
+if (!(missionNamespace getVariable ["BIS_RscRespawnControlsMap_shown", false]) && {!(missionNamespace getVariable ["BIS_RscRespawnControlsSpectate_shown", false])}) then {
     [] call FUNC(spectatorOff);
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent players from automatically being switched to ACRE Spectator if the `MenuPosition` *and* `Spectator` respawn templates are in use. This prevents dead players from being switched in and out of ACRE spectator while remaining dead. Fixes issue #916.