### PR TITLE
Documentation - Use GitHub releases page as repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/IDI-Systems/acre2/releases/download/v2.7.2.1022/acre2_2.7.2.1022.zip">
+    <a href="https://github.com/IDI-Systems/acre2/releases/latest">
         <img src="https://img.shields.io/badge/Version-2.7.2-blue.svg?style=flat-square" alt="ACRE2 Version">
     </a>
     <a href="https://github.com/IDI-Systems/acre2/issues">


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Much cleaner, goes to release description. And no need to update one more link and watch out for that during development builds.