### PR TITLE
Various - Fix undefined functions

### DIFF
--- a/addons/ace_interact/fnc_generateConnectorActions.sqf
+++ b/addons/ace_interact/fnc_generateConnectorActions.sqf
@@ -29,7 +29,7 @@ switch (_connectorType) do {
             private _action = ["acre_con_action", _name, "", {
                 params ["_target", "", "_params"];
                 _params params ["_parentComponentId", "_parentConnector"];
-                [_parentComponentId, _parentConnector] call EFUNC(sys_components,fnc_detachComponent);
+                [_parentComponentId, _parentConnector] call EFUNC(sys_components,detachComponent);
             }, {true}, {}, [_parentComponent, _connectorIndex]] call ace_interact_menu_fnc_createAction;
             _actions pushBack [_action, [], _target];
         } else {
@@ -53,7 +53,7 @@ switch (_connectorType) do {
                         private _action = [format ["acre_con_rack_%1_action", _forEachIndex], _name, _icon, {
                             params ["_target","","_params"];
                             _params params ["_parentComponent","_connectorIndex","_radioId","_connectorRadioIdx"];
-                            [_parentComponent, _connectorIndex, _radioId, _connectorRadioIdx, HASH_CREATE] call EFUNC(sys_components,fnc_attachComplexComponent);
+                            [_parentComponent, _connectorIndex, _radioId, _connectorRadioIdx, HASH_CREATE] call EFUNC(sys_components,attachComplexComponent);
                         }, {true}, {}, [_parentComponent, _connectorIndex, _radioId, _connectorRadioIdx]] call ace_interact_menu_fnc_createAction;
                         _actions pushBack [_action, [], _target];
                     };
@@ -79,7 +79,7 @@ switch (_connectorType) do {
                         private _action = [format ["acre_con_radio_%1_action", _forEachIndex], _name, _icon, {
                             params ["_target","","_params"];
                             _params params ["_parentComponent","_connectorIndex","_rackId","_connectorRackIdx"];
-                            [_parentComponent, _connectorIndex, _rackId, _connectorRackIdx, HASH_CREATE] call EFUNC(sys_components,fnc_attachComplexComponent);
+                            [_parentComponent, _connectorIndex, _rackId, _connectorRackIdx, HASH_CREATE] call EFUNC(sys_components,attachComplexComponent);
                         }, {true}, {}, [_rackId, _connectorRackIdx, _parentComponent, _connectorIndex]] call ace_interact_menu_fnc_createAction;
                         _actions pushBack [_action, [], _target];
                     };

--- a/addons/sys_core/initSettings.sqf
+++ b/addons/sys_core/initSettings.sqf
@@ -99,8 +99,7 @@
     localize LSTRING(fullDuplex_displayName),
     "ACRE2",
     false,
-    true,
-    {[_this] call EFUNC(api,setFullDuplex)}
+    true
 ] call CBA_fnc_addSetting;
 
 // Antena direction

--- a/addons/sys_rack/XEH_postInit.sqf
+++ b/addons/sys_rack/XEH_postInit.sqf
@@ -120,7 +120,7 @@ if (vehicle acre_player != acre_player) then {
         false
     };
 
-    if ([_rackId] call FUNC(getMountedRackRadio) != "") exitWith {
+    if ([_rackId] call EFUNC(api,getMountedRackRadio) != "") exitWith {
         [QGVAR(logOnServer), format ["Rack ID %1 has already a radio mounted.", _rackId]] call CBA_fnc_serverEvent;
         false
     };

--- a/addons/sys_rack/XEH_postInit.sqf
+++ b/addons/sys_rack/XEH_postInit.sqf
@@ -120,7 +120,7 @@ if (vehicle acre_player != acre_player) then {
         false
     };
 
-    if ([_rackId] call EFUNC(api,getMountedRackRadio) != "") exitWith {
+    if ([_rackId] call FUNC(getMountedRadio) != "") exitWith {
         [QGVAR(logOnServer), format ["Rack ID %1 has already a radio mounted.", _rackId]] call CBA_fnc_serverEvent;
         false
     };

--- a/addons/sys_radio/fnc_handleRadioSpatialKeyPressed.sqf
+++ b/addons/sys_radio/fnc_handleRadioSpatialKeyPressed.sqf
@@ -29,6 +29,6 @@ if (!isNil "_currentSide") then {
     if (_currentSide != _side) then {
         [ACRE_ACTIVE_RADIO, _side] call FUNC(setRadioSpatial);
 
-        [format [localize LSTRING(radioSet), _side], true] call CBA_fnc_notify;
+        [[format [localize LSTRING(radioSetTo), _side]], true] call CBA_fnc_notify;
     };
 };

--- a/addons/sys_server/XEH_PREPServer.hpp
+++ b/addons/sys_server/XEH_PREPServer.hpp
@@ -11,3 +11,4 @@ PREP(stopRadioGarbageCollect);
 PREP(sendIntentToGarbageCollect);
 PREP(removeGCQueue);
 PREP(handlePlayerDisconnected);
+PREP(invalidGarbageCollect);


### PR DESCRIPTION
- ace/components: edit: `GVAR(connectorsEnabled) = false;` so this isn't used
- fullDuplex: api func didn't exist, no bug because everything just uses `GVAR(fullDuplex)`
- rack: still seems to work fine
- handleRadioSpatialKeyPressed: doesn't seem to be used anywhere
- invalidGarbageCollect: was just for returning logging from clients to server