### PR TITLE
Intercom - Fix missing variable for JIP player

### DIFF
--- a/addons/sys_intercom/fnc_configIntercom.sqf
+++ b/addons/sys_intercom/fnc_configIntercom.sqf
@@ -119,7 +119,11 @@ private _accent = [];
 
 if (didJIP) then {
     // Do not configure the stations if the player is JIP and information is already there.
-    if ((_vehicle getVariable[QGVAR(station_driver), []]) isEqualTo []) then {
+    if (
+        (_vehicle getVariable [QGVAR(intercomNames), []]) findIf {
+            _vehicle getVariable [_x, []] isEqualTo []; 
+        } > -1
+    ) then {
         [_vehicle, _intercomPositions, _intercomExceptions, _intercomLimitedPositions, _intercomConnectByDefault, _intercomMasterStation] call FUNC(configIntercomStations);
     };
 

--- a/addons/sys_intercom/fnc_configIntercom.sqf
+++ b/addons/sys_intercom/fnc_configIntercom.sqf
@@ -117,16 +117,9 @@ private _accent = [];
     _accent pushBack false;
 } forEach _intercoms;
 
-if (didJIP) then {
-    // Do not configure the stations if the player is JIP and information is already there.
-    if (
-        (_vehicle getVariable [QGVAR(intercomNames), []]) findIf {
-            _vehicle getVariable [_x, []] isEqualTo []; 
-        } > -1
-    ) then {
-        [_vehicle, _intercomPositions, _intercomExceptions, _intercomLimitedPositions, _intercomConnectByDefault, _intercomMasterStation] call FUNC(configIntercomStations);
-    };
+[_vehicle, _intercomPositions, _intercomExceptions, _intercomLimitedPositions, _intercomConnectByDefault, _intercomMasterStation] call FUNC(configIntercomStations);
 
+if (didJIP) then {
     if ((_vehicle getVariable [QGVAR(intercomNames), []]) isEqualTo []) then {
         _vehicle setVariable [QGVAR(intercomNames), _intercomNames];
     };
@@ -143,12 +136,8 @@ if (didJIP) then {
         _vehicle setVariable [QGVAR(accent), _accent];
     };
 } else {
-    [_vehicle, _intercomPositions, _intercomExceptions, _intercomLimitedPositions, _intercomConnectByDefault, _intercomMasterStation] call FUNC(configIntercomStations);
-
     _vehicle setVariable [QGVAR(intercomNames), _intercomNames];
     _vehicle setVariable [QGVAR(numLimitedPositions), _numLimitedPositions];
     _vehicle setVariable [QGVAR(broadcasting), _broadcasting];
     _vehicle setVariable [QGVAR(accent), _accent];
 };
-
-

--- a/addons/sys_intercom/fnc_configIntercomStations.sqf
+++ b/addons/sys_intercom/fnc_configIntercomStations.sqf
@@ -82,8 +82,10 @@ private _intercomStations = [];
     } forEach _allowedPositions;
 
     private _varname = format [QGVAR(station_%1), _role];
+    if (isNil {_vehicle getVariable _varname}) then {
+        _vehicle setVariable [_varName, _seatConfiguration];
+    };
     _intercomStations pushBack _varName;  // List of seat variable names
-    _vehicle setVariable [_varName, _seatConfiguration];
 } forEach (fullCrew [_vehicle, "", true]);
 
-_vehicle setVariable [QGVAR(intercomStations), _intercomStations, true];
+_vehicle setVariable [QGVAR(intercomStations), _intercomStations];


### PR DESCRIPTION
Before only `"acre_sys_intercom_station_driver"` was checked but there are many other to check. For exemple:
```sqf
["acre_sys_intercom_station_driver","acre_sys_intercom_station_cargo_0","acre_sys_intercom_station_cargo_1","acre_sys_intercom_station_cargo_2","acre_sys_intercom_station_cargo_3","acre_sys_intercom_station_cargo_4","acre_sys_intercom_station_cargo_5","acre_sys_intercom_station_cargo_6","acre_sys_intercom_station_cargo_7","acre_sys_intercom_station_cargo_8","acre_sys_intercom_station_cargo_9","acre_sys_intercom_station_cargo_10","acre_sys_intercom_station_cargo_11","acre_sys_intercom_station_cargo_12","acre_sys_intercom_station_cargo_13","acre_sys_intercom_station_turret_[0]","acre_sys_intercom_station_gunner","acre_sys_intercom_station_turret_[2]","acre_sys_intercom_station_turret_[3]","acre_sys_intercom_station_turret_[4]"]
```

Don't know if it is the best fix...

**When merged this pull request will:**
- Fixe #942
- Check all variable available in `"acre_sys_intercom_intercomStations"` to make sure there is no missing variable for JIP player

Code use to check if all variable named in `acre_sys_intercom_intercomStations` are correctly broadcasted
```sqf
b = [];
{
    if (cursorObject getVariable [_x, []] isEqualTo []) then {
        b pushBack _x;
    };
} forEach (cursorObject getVariable ["acre_sys_intercom_intercomStations", []]);
```