### PR TITLE
Radios - Cache module functions (`PREP_MODULE`)

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -124,8 +124,13 @@ Antenna Defines
 #define DVAR(varName) if (isNil "ACRE_DEBUG_NAMESPACE") then { ACRE_DEBUG_NAMESPACE = []; }; if (!(QUOTE(varName) in ACRE_DEBUG_NAMESPACE)) then { ACRE_DEBUG_NAMESPACE pushBack QUOTE(varName); }; varName
 
 // Dynamic sub-modules for systems
+// #define DISABLE_COMPILE_CACHE
+#ifdef DISABLE_COMPILE_CACHE
+    #define PREP_MODULE(module, fncName) DFUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(module\DOUBLES(fnc,fncName).sqf)
+#else
+    #define PREP_MODULE(module, fncName) [QPATHTOF(module\DOUBLES(fnc,fncName).sqf), QFUNC(fncName)] call CBA_fnc_compileFunction
+#endif
 #define PREP_FOLDER(folder) [] call compile preprocessFileLineNumbers QPATHTOF(folder\__PREP__.sqf)
-#define PREP_MODULE(module, fncName) DFUNC(fncName) = compile preprocessFileLineNumbers QPATHTOF(module\DOUBLES(fnc,fncName).sqf)
 #define PREP_STATE(stateFile) [] call compile preprocessFileLineNumbers format [QPATHTOF(states\%1.sqf), #stateFile]
 #define PREP_MENU(menuType) [] call compile preprocessFileLineNumbers QPATHTOF(menus\types\menuType.sqf)
 #define MENU_DEFINITION(folder,menu) [] call compile preprocessFileLineNumbers QPATHTOF(folder\menu.sqf);

--- a/addons/sys_server/CfgEventHandlers.hpp
+++ b/addons/sys_server/CfgEventHandlers.hpp
@@ -1,3 +1,9 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
 class Extended_PreInit_EventHandlers {
     class ADDON {
         clientInit = QUOTE(call COMPILE_FILE(XEH_preInitClient));

--- a/addons/sys_server/XEH_preStart.sqf
+++ b/addons/sys_server/XEH_preStart.sqf
@@ -4,6 +4,4 @@ if (hasInterface) then {
     #include "XEH_PREPClient.hpp"
 };
 
-if (isServer) then {
-    #include "XEH_PREPServer.hpp"
-};
+#include "XEH_PREPServer.hpp"


### PR DESCRIPTION
Ref #629
I'm not sure about the other macros, 
- many of them define multiple functions from within a single sqf file
- some are a mix of function definitions and `GVAR` setup and init code

combined cba+acre preInit XEH goes from 1900->900 ms
but also means you have to use `DISABLE_COMPILE_CACHE` to see changes on filepatching/dev
already on wiki https://acre2.idi-systems.com/wiki/development/building#disable-cba-function-caching