### PR TITLE
GSA - Fix PFEH not being removed under some conditions

### DIFF
--- a/addons/sys_gsa/XEH_postInit.sqf
+++ b/addons/sys_gsa/XEH_postInit.sqf
@@ -1,9 +1,5 @@
 #include "script_component.hpp"
 
-[QGVAR(disconnectGsa), FUNC(disconnectServer)] call CBA_fnc_addEventHandler;
-
-[QGVAR(connectGsa), FUNC(connectServer)] call CBA_fnc_addEventHandler;
-
 [QGVAR(notifyPlayer), {
     params ["_text"];
 

--- a/addons/sys_gsa/XEH_preInit.sqf
+++ b/addons/sys_gsa/XEH_preInit.sqf
@@ -12,6 +12,8 @@ if (hasInterface) then {
 
 if (isServer) then {
     GVAR(gsaPFH) = [] call CBA_fnc_hashCreate;
+    [QGVAR(disconnectGsa), LINKFUNC(disconnectServer)] call CBA_fnc_addEventHandler;
+    [QGVAR(connectGsa), LINKFUNC(connectServer)] call CBA_fnc_addEventHandler;
 };
 
 ADDON = true;

--- a/addons/sys_gsa/fnc_connectServer.sqf
+++ b/addons/sys_gsa/fnc_connectServer.sqf
@@ -19,6 +19,8 @@
 
 params ["_gsa", "_radioId", "_player"];
 
+if (_radioId == "") exitWith { ERROR_3("connectServer - bad radioID %1:%2:%3",_gsa,_radioId,_player); };
+
 private _classname = typeOf _gsa;
 private _componentName = getText (configFile >> "CfgVehicles" >> _classname >> "AcreComponents" >> "componentName");
 

--- a/addons/sys_gsa/fnc_disconnectServer.sqf
+++ b/addons/sys_gsa/fnc_disconnectServer.sqf
@@ -4,8 +4,9 @@
  * Disconnects the ground spike antenna and re-connects the default radio antenna. Server Event.
  *
  * Arguments:
- * 0: Ground Spike Antenna <OBJECT>
+ * 0: Ground Spike Antenna (could be null) <OBJECT>
  * 1: Player or unit <OBJECT>
+ * 2: RadioID <STRING><OPTIONAL>
  *
  * Return Value:
  * None
@@ -16,18 +17,28 @@
  * Public: No
  */
 
-params ["_gsa", "_unit"];
+params ["_gsa", "_unit", ["_radioId", ""]];
 
 private _success = false;
-private _radioId = _gsa getVariable [QGVAR(connectedRadio), ""];
+
+if (_radioId == "") then { _radioId = _gsa getVariable [QGVAR(connectedRadio), ""]; };
 if (_radioId isEqualTo "") exitWith {
-    ERROR("Empty unique radio ID");
+    ERROR_3("Empty unique radio ID %1:%2:%3",_gsa,_unit,_radioId);
     _success
 };
 
+private _fnc_removePFEH = {
+    private _pfh = [GVAR(gsaPFH), _radioId, _pfh] call CBA_fnc_hashGet;
+    if (!isNil "_pfh") then {
+        [_pfh] call CBA_fnc_removePerFrameHandler;
+        [GVAR(gsaPFH), _radioId, nil] call CBA_fnc_hashSet;
+    };
+};
+
 private _connectedUnit = [_radioId] call EFUNC(sys_radio,getRadioObject);
-if (isNull _connectedUnit) exitWith {
-    ERROR("Null connected object returned");
+if ((isNil "_connectedUnit") || {isNull _connectedUnit}) exitWith {
+    ERROR_3("Nil/Null connected object returned %1:%2:%3",_gsa,_unit,_radioId);
+    call _fnc_removePFEH;
     _success
 };
 
@@ -42,12 +53,7 @@ private _parentComponentClass = configFile >> "CfgAcreComponents" >> BASE_CLASS_
             _gsa setVariable [QGVAR(connectedRadio), "", true];
             [_radioId, "setState", ["externalAntennaConnected", [false, objNull]]] call EFUNC(sys_data,dataEvent);
 
-            // Support for having several radios connected to GSA
-            private _pfh = [GVAR(gsaPFH), _radioId, _pfh] call CBA_fnc_hashGet;
-            if !(isNil "_pfh") then {
-                [_pfh] call CBA_fnc_removePerFrameHandler;
-                [GVAR(gsaPFH), _radioId, nil] call CBA_fnc_hashSet;
-            };
+            call _fnc_removePFEH;
 
             if (_connectedUnit isKindOf "CAManBase" || {!(crew _connectedUnit isEqualTo [])}) then {
                 if (_connectedUnit isKindOf "CAManBase") then {

--- a/addons/sys_gsa/fnc_disconnectServer.sqf
+++ b/addons/sys_gsa/fnc_disconnectServer.sqf
@@ -25,7 +25,7 @@ if (_radioId == "") then {
     _radioId = _gsa getVariable [QGVAR(connectedRadio), ""];
 };
 if (_radioId isEqualTo "") exitWith {
-    ERROR_3("Empty unique radio ID %1:%2:%3",_gsa,_unit,_radioId);
+    ERROR_2("Empty unique radio ID %1:%2",_gsa,_unit);
     _success
 };
 

--- a/addons/sys_gsa/fnc_disconnectServer.sqf
+++ b/addons/sys_gsa/fnc_disconnectServer.sqf
@@ -6,7 +6,7 @@
  * Arguments:
  * 0: Ground Spike Antenna (could be null) <OBJECT>
  * 1: Player or unit <OBJECT>
- * 2: RadioID <STRING><OPTIONAL>
+ * 2: RadioID <STRING> (default: "")
  *
  * Return Value:
  * None
@@ -21,7 +21,9 @@ params ["_gsa", "_unit", ["_radioId", ""]];
 
 private _success = false;
 
-if (_radioId == "") then { _radioId = _gsa getVariable [QGVAR(connectedRadio), ""]; };
+if (_radioId == "") then {
+    _radioId = _gsa getVariable [QGVAR(connectedRadio), ""];
+};
 if (_radioId isEqualTo "") exitWith {
     ERROR_3("Empty unique radio ID %1:%2:%3",_gsa,_unit,_radioId);
     _success

--- a/addons/sys_gsa/fnc_externalAntennaPFH.sqf
+++ b/addons/sys_gsa/fnc_externalAntennaPFH.sqf
@@ -9,13 +9,14 @@
  *   - Antenna is picked up.
  *
  * Arguments:
- * 0: Ground Spike Antenna <OBJECT>
+ *  0,0: Ground Spike Antenna <OBJECT>
+ *  0,1: Radio ID <STRING>
  *
  * Return Value:
  * None
  *
  * Example:
- * [cursorTarget, "acre_prc152_id_1"] call acre_sys_gsa_externalAntennaPFH
+ * [[cursorTarget, "acre_prc152_id_1"]] call acre_sys_gsa_externalAntennaPFH
  *
  * Public: No
  */
@@ -23,21 +24,15 @@
 params ["_params"];
 _params params ["_gsa", "_radioId"];
 
-private _unit = objNull;
-if (_radioId != "") then {
-    _unit = [_radioId] call EFUNC(sys_radio,getRadioObject);
-};
+private _unit = [_radioId] call EFUNC(sys_radio,getRadioObject);
 
-if (!alive _gsa || {!alive _unit} || {_unit isKindOf "CAManBase" && {!(isPlayer _unit)}} || {_radioId isEqualTo ""}) then {
-    [QGVAR(disconnectGsa), [_gsa, _unit]] call CBA_fnc_localEvent;
-} else {
-    private _connectedRadioId = _gsa getVariable [QGVAR(connectedRadio), ""];
-
-    if (_connectedRadioId isEqualTo _radioId) then {
-        if ((_unit distance _gsa) > ANTENNA_MAXDISTANCE) then {
-            [QGVAR(disconnectGsa), [_gsa, _unit]] call CBA_fnc_localEvent;
-        };
-    } else {
-        [QGVAR(disconnectGsa), [_gsa, _unit]] call CBA_fnc_localEvent;
-    };
+if (
+(!alive _gsa) 
+|| {isNil "_unit"} // possible if radio was removed by script
+|| {!alive _unit} 
+|| {_unit isKindOf "CAManBase" && {!(isPlayer _unit)}}
+|| {_radioId != (_gsa getVariable [QGVAR(connectedRadio), ""])}
+|| {(_unit distance _gsa) > ANTENNA_MAXDISTANCE}
+) then {
+    [QGVAR(disconnectGsa), [_gsa, _unit, _radioId]] call CBA_fnc_localEvent;
 };

--- a/addons/sys_gsa/fnc_handleMast.sqf
+++ b/addons/sys_gsa/fnc_handleMast.sqf
@@ -23,7 +23,7 @@ if (_connectedRadio isEqualTo "") then {
 
 // Temporarily disconnect the GSA from the radio
 if (_connectedRadio != "") then {
-    [_player, _gsa, _connectedRadio] call FUNC(disconnect);
+    [_player, _gsa] call FUNC(disconnect);
 };
 
 // Delete the antenna
@@ -38,9 +38,7 @@ if (_mountMast) then {
 } else {
     _gsa = "vhf30108spike" createVehicle _pos;
 
-    if (_player canAdd "ACRE_VHF30108MAST") then {
-        _player addItem "ACRE_VHF30108MAST";
-    };
+    [_player, "ACRE_VHF30108MAST", true] call CBA_fnc_addItem;
 };
 
 // Reconnect the GSA to the radio


### PR DESCRIPTION
- GSA object deleted - PFEH now passes radioID to disconnect, so we can still remove the pfeh
- Radio removed by script - sys_radio,getRadioObject will return nil

also fix mast item being lost if no room in inventory
