### PR TITLE
Extensions - Fix freeze on start with Tobii EyeTracker

### DIFF
--- a/extensions/src/ACRE2Arma/common/pbo/search.cpp
+++ b/extensions/src/ACRE2Arma/common/pbo/search.cpp
@@ -309,11 +309,17 @@ namespace acre {
                     std::string object_name(tmp_name.begin(), tmp_name.end());
                     //LOG(INFO) << "File: " << object_name;
                     if (object_type == "File" && object_name.find(".pbo") != object_name.npos) {
-                        char buffer[MAX_PATH];
-                        GetFinalPathNameByHandle(dupHandle, buffer, sizeof(buffer), VOLUME_NAME_DOS);
 
-                        //LOG(INFO) << "Pbo: " << buffer;
-                        _active_pbo_list.push_back(std::string(buffer));
+                        /* Do not try to get the path of objects which are not disk files. */
+                        /* The GetFinalPathNameByHandle function will hang if the specified handle is not of the type FILE_TYPE_DISK. */
+                        DWORD fileType = GetFileType(dupHandle);
+                        if (fileType == FILE_TYPE_DISK) {
+                            char buffer[MAX_PATH];
+                            GetFinalPathNameByHandle(dupHandle, buffer, sizeof(buffer), VOLUME_NAME_DOS);
+
+                            //LOG(INFO) << "Pbo: " << buffer;
+                            _active_pbo_list.push_back(std::string(buffer));
+                        }
                     }
                 }
 


### PR DESCRIPTION
The aim of this Pull Request is to fix the freeze on start with Tobii EyeTracker. The problem is due to a wrong usage of the `GetFinalPathNameByHandle` function when building the pbo file list. Indeed, the `GetFinalPathNameByHandle` function will hang if the specified handle is not of the type `FILE_TYPE_DISK`.

Close #861 _edit by @Jonpas_