### PR TITLE
Extensions - Possible Fix for crashes with multiple connection tabs

### DIFF
--- a/extensions/src/ACRE2TS/TSCallbacks_init.cpp
+++ b/extensions/src/ACRE2TS/TSCallbacks_init.cpp
@@ -90,7 +90,7 @@ void ts3plugin_currentServerConnectionChanged(uint64 serverConnectionHandlerID) 
     //TRACE("currentServerConnectionChanged %llu (%llu)", (long long unsigned int)serverConnectionHandlerID, (long long unsigned int)ts3Functions.getCurrentServerConnectionHandlerID());
 }
 
-void ts3plugin_onConnectStatusChangeEvent(uint64 id, int status, unsigned int err) {
+void ts3plugin_onConnectStatusChangeEvent(uint64 serverConnectionHandlerID, int status, unsigned int err) {
 
     if (status == STATUS_CONNECTION_ESTABLISHED) {
 
@@ -98,13 +98,13 @@ void ts3plugin_onConnectStatusChangeEvent(uint64 id, int status, unsigned int er
         //
         // set ID on every new connection
         acre::id_t clientId = 0;
-        ts3Functions.getClientID(ts3Functions.getCurrentServerConnectionHandlerID(), (anyID *)&clientId);
+        ts3Functions.getClientID(serverConnectionHandlerID, (anyID *)&clientId);
         CEngine::getInstance()->getSelf()->setId(clientId);
 
         // subscribe to all channels to receive event
-        ts3Functions.requestChannelSubscribeAll(ts3Functions.getCurrentServerConnectionHandlerID(), NULL);
+        ts3Functions.requestChannelSubscribeAll(serverConnectionHandlerID, NULL);
         if (CEngine::getInstance()->getClient()->getState() != acre::State::running) {
-            CEngine::getInstance()->getClient()->start(static_cast<acre::id_t>(id));
+            CEngine::getInstance()->getClient()->start(static_cast<acre::id_t>(serverConnectionHandlerID));
         }
     } else if (status == STATUS_DISCONNECTED) {
         if (CEngine::getInstance()->getClient()->getState() != acre::State::stopped  && CEngine::getInstance()->getClient()->getState() != acre::State::stopping) {


### PR DESCRIPTION
**When merged this pull request will:**
- Possibly fix Teamspeak crashes on startup with multiple auto-connects (#855) 
See [this comment](https://github.com/IDI-Systems/acre2/issues/855#issuecomment-629826381) for further details.

This is **untested** as I do not have a build environment setup, but it is a simple enough change that someone with a build environment handy should be able to validate.