### PR TITLE
Extensions - Parse Startup Parameters Config File

### DIFF
--- a/extensions/src/ACRE2Steam/CallExt_DllMain.cpp
+++ b/extensions/src/ACRE2Steam/CallExt_DllMain.cpp
@@ -52,7 +52,7 @@ inline std::string get_path() {
 std::vector<std::string> get_cmdline() {
     std::vector<std::string> cmdline(split(GetCommandLineA(), ' '));
 
-    std::string par_opt("-par=");
+    const std::string par_opt("-par=");
     std::string par_path;
     for (auto const& option : cmdline) {
         if (option.rfind(par_opt, 0) != std::string::npos) {


### PR DESCRIPTION
**When merged this pull request will:**
- Closes #959
- Parse parameters from a [startup parameter file](https://community.bistudio.com/wiki/Startup_Parameters_Config_File#Pre_build_86060)
- Ignore old style parameter files which are broken on dedicated servers anyway
- Make it easier to parse command line arguments in the future (argv style)