### PR TITLE
GUI - Close inventory context menu after using open radio action

### DIFF
--- a/addons/sys_gui/XEH_postInit.sqf
+++ b/addons/sys_gui/XEH_postInit.sqf
@@ -34,5 +34,6 @@ if (!hasInterface) exitWith {};
     {
         params ["", "", "_item"];
         [_item] call FUNC(openRadio);
+        false // Close menu
     }
 ] call CBA_fnc_addItemContextMenuOption;


### PR DESCRIPTION
**When merged this pull request will:**
- title, was kept open because `acre_sys_radio_fnc_openRadio` returns `true`