### PR TITLE
Core - Add outgoing spectator transmissions

### DIFF
--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -100,7 +100,7 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
     private _compiledParams = HASH_CREATE;
     {
         private _recRadio = _x;
-        if (_recRadio != ACRE_BROADCASTING_RADIOID || {GVAR(fullDuplex)} || {toLower(_recRadio) in ACRE_SPECTATOR_RADIOS}) then {
+        if (_recRadio != ACRE_BROADCASTING_RADIOID || {GVAR(fullDuplex)} || {(toLower _recRadio) in ACRE_SPECTATOR_RADIOS}) then {
             #ifdef ENABLE_PERFORMANCE_COUNTERS
                 BEGIN_COUNTER(radio_loop_single_radio);
             #endif
@@ -128,7 +128,7 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
                 // if (!GVAR(speaking_cache_valid)) then {
                 private _sourceRadios = _sources select _forEachIndex;
                 private _hearableRadios = [_recRadio, "handleMultipleTransmissions", _sourceRadios] call EFUNC(sys_data,transEvent);
-                if (GVAR(fullDuplex) || {toLower(_recRadio) in ACRE_SPECTATOR_RADIOS}) then {
+                if (GVAR(fullDuplex) || {(toLower _recRadio) in ACRE_SPECTATOR_RADIOS}) then {
                     _hearableRadios = _sourceRadios;
                 };
                 // HASH_SET(GVAR(coreCache), _recRadio + "hmt_cache", _hearableRadios);

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -100,7 +100,7 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
     private _compiledParams = HASH_CREATE;
     {
         private _recRadio = _x;
-        if (_recRadio != ACRE_BROADCASTING_RADIOID || {GVAR(fullDuplex)} || toLower(_recRadio) in ACRE_SPECTATOR_RADIOS) then {
+        if (_recRadio != ACRE_BROADCASTING_RADIOID || {GVAR(fullDuplex)} || {toLower(_recRadio) in ACRE_SPECTATOR_RADIOS}) then {
             #ifdef ENABLE_PERFORMANCE_COUNTERS
                 BEGIN_COUNTER(radio_loop_single_radio);
             #endif
@@ -128,7 +128,7 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
                 // if (!GVAR(speaking_cache_valid)) then {
                 private _sourceRadios = _sources select _forEachIndex;
                 private _hearableRadios = [_recRadio, "handleMultipleTransmissions", _sourceRadios] call EFUNC(sys_data,transEvent);
-                if (GVAR(fullDuplex) || toLower(_recRadio) in ACRE_SPECTATOR_RADIOS) then {
+                if (GVAR(fullDuplex) || {toLower(_recRadio) in ACRE_SPECTATOR_RADIOS}) then {
                     _hearableRadios = _sourceRadios;
                 };
                 // HASH_SET(GVAR(coreCache), _recRadio + "hmt_cache", _hearableRadios);

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -1,4 +1,3 @@
-#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team
@@ -211,19 +210,15 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
     #endif
 
     {
-        diag_log format ["compiledParams: %1", _x];
         private _unit = objectFromNetId _x;
-        diag_log format ["Unit compiledParams: %1", _unit];
         if (!isNull _unit) then {
             _sentMicRadios pushBack _unit;
             private _params = HASH_GET(_compiledParams, _x);
-            diag_log format ["params %1", _params];
             private _canUnderstand = [_unit] call FUNC(canUnderstand);
             private _paramArray = ["r", GET_TS3ID(_unit), !_canUnderstand, count _params];
             {
                 _paramArray append _x;
             } forEach _params;
-            diag_log format ["paramArray %1", _paramArray];
             CALL_RPC("updateSpeakingData", _paramArray);
         };
     } forEach HASH_KEYS(_compiledParams);

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -1,3 +1,4 @@
+#define DEBUG_MODE_FULL
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team
@@ -100,7 +101,7 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
     private _compiledParams = HASH_CREATE;
     {
         private _recRadio = _x;
-        if (_recRadio != ACRE_BROADCASTING_RADIOID || {GVAR(fullDuplex)}) then {
+        if (_recRadio != ACRE_BROADCASTING_RADIOID || {GVAR(fullDuplex)} || toLower(_recRadio) in ACRE_SPECTATOR_RADIOS) then {
             #ifdef ENABLE_PERFORMANCE_COUNTERS
                 BEGIN_COUNTER(radio_loop_single_radio);
             #endif
@@ -128,7 +129,7 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
                 // if (!GVAR(speaking_cache_valid)) then {
                 private _sourceRadios = _sources select _forEachIndex;
                 private _hearableRadios = [_recRadio, "handleMultipleTransmissions", _sourceRadios] call EFUNC(sys_data,transEvent);
-                if (GVAR(fullDuplex)) then {
+                if (GVAR(fullDuplex) || toLower(_recRadio) in ACRE_SPECTATOR_RADIOS) then {
                     _hearableRadios = _sourceRadios;
                 };
                 // HASH_SET(GVAR(coreCache), _recRadio + "hmt_cache", _hearableRadios);
@@ -210,15 +211,19 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
     #endif
 
     {
+        diag_log format ["compiledParams: %1", _x];
         private _unit = objectFromNetId _x;
+        diag_log format ["Unit compiledParams: %1", _unit];
         if (!isNull _unit) then {
             _sentMicRadios pushBack _unit;
             private _params = HASH_GET(_compiledParams, _x);
+            diag_log format ["params %1", _params];
             private _canUnderstand = [_unit] call FUNC(canUnderstand);
             private _paramArray = ["r", GET_TS3ID(_unit), !_canUnderstand, count _params];
             {
                 _paramArray append _x;
             } forEach _params;
+            diag_log format ["paramArray %1", _paramArray];
             CALL_RPC("updateSpeakingData", _paramArray);
         };
     } forEach HASH_KEYS(_compiledParams);

--- a/addons/sys_core/script_component.hpp
+++ b/addons/sys_core/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\idi\acre\addons\main\script_mod.hpp"
 
 // #define USE_DEBUG_EXTENSIONS
-// #define DEBUG_MODE_FULL
+//#define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/sys_core/script_component.hpp
+++ b/addons/sys_core/script_component.hpp
@@ -3,7 +3,7 @@
 #include "\idi\acre\addons\main\script_mod.hpp"
 
 // #define USE_DEBUG_EXTENSIONS
-//#define DEBUG_MODE_FULL
+// #define DEBUG_MODE_FULL
 // #define DISABLE_COMPILE_CACHE
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/sys_modes/fnc_sc_speaking.sqf
+++ b/addons/sys_modes/fnc_sc_speaking.sqf
@@ -28,6 +28,11 @@ private _maxSignal = [0, -993];
 
 if (_rxRadioId != _txRadioId) then {
     _maxSignal = [_txFreq, _txPower, _rxRadioId, _txRadioId] call EFUNC(sys_signal,getSignal);
+} else {
+    systemChat format ["%1, %2, %3", _rxRadioId, _txRadioId, (toLower _txRadioId) in ACRE_SPECTATOR_RADIOS];
+    if ((toLower _txRadioId) in ACRE_SPECTATOR_RADIOS) then {
+        _maxSignal = [1, 0];
+    };
 };
 
 private _return = [_txRadioId, _rxRadioId, _maxSignal select 0, _maxSignal select 1, 0];

--- a/addons/sys_modes/fnc_sc_speaking.sqf
+++ b/addons/sys_modes/fnc_sc_speaking.sqf
@@ -29,7 +29,6 @@ private _maxSignal = [0, -993];
 if (_rxRadioId != _txRadioId) then {
     _maxSignal = [_txFreq, _txPower, _rxRadioId, _txRadioId] call EFUNC(sys_signal,getSignal);
 } else {
-    systemChat format ["%1, %2, %3", _rxRadioId, _txRadioId, (toLower _txRadioId) in ACRE_SPECTATOR_RADIOS];
     if ((toLower _txRadioId) in ACRE_SPECTATOR_RADIOS) then {
         _maxSignal = [1, 0];
     };

--- a/addons/sys_modes/fnc_sem70akw_speaking.sqf
+++ b/addons/sys_modes/fnc_sem70akw_speaking.sqf
@@ -28,6 +28,10 @@ private _maxSignal = [0, -993];
 
 if (_rxRadioId != _txRadioId) then {
     _maxSignal = [_txFreq, _txPower, _rxRadioId, _txRadioId] call EFUNC(sys_signal,getSignal);
+} else {
+    if ((toLower _txRadioId) in ACRE_SPECTATOR_RADIOS) then {
+        _maxSignal = [1, 0];
+    };
 };
 
 private _return = [_txRadioId, _rxRadioId, _maxSignal select 0, _maxSignal select 1, 0];


### PR DESCRIPTION
**When merged this pull request will:**
- Add the ability to hear outgoing transmissions on radios selected as Specator Radios

**Things to do and comments**
- Spectator Radios are persistent after quitting spectator -> This leads to double radio sounds if the own radio is in Spectator Radios
- As outgoing transmissions have radio effects (they are exactly like if the spectator has a radio) it's hard to distinguish which radio is currently transmitting. We should maybe add a visualization on that.