### PR TITLE
Extension - Multi-thread init pbo/file scan

### DIFF
--- a/extensions/src/ACRE2Arma/common/pbo/search.cpp
+++ b/extensions/src/ACRE2Arma/common/pbo/search.cpp
@@ -138,8 +138,8 @@ namespace acre {
                 return { pbo_file_path, pbo_files_map };
             };
             acre::pbo::archive _archive(pbo_stream);
-            for (acre::pbo::entry_p& entry : _archive.entries) {
-                if (entry->filename != "") {
+            for (const acre::pbo::entry_p &entry : _archive.entries) {
+                if (!entry->filename.empty()) {
                     if (std::regex_match(entry->filename, txt_regex)) {
                         std::string full_virtual_path = _archive.info->header["prefix"] + "\\" + entry->filename;
                         std::transform(full_virtual_path.begin(), full_virtual_path.end(), full_virtual_path.begin(), ::tolower);
@@ -165,7 +165,7 @@ namespace acre {
                 std::string error_file_name;
                 std::unordered_map<std::string, std::string> result;
                 std::tie(error_file_name, result) = worker.get();
-                if (error_file_name.size()) {
+                if (!error_file_name.empty()) {
                     LOG(ERROR) << "Cannot open file - " << error_file_name;
                     continue;
                 };

--- a/extensions/src/ACRE2Arma/common/pbo/search.cpp
+++ b/extensions/src/ACRE2Arma/common/pbo/search.cpp
@@ -3,6 +3,7 @@
 #include <iterator>
 #include <algorithm>
 #include <regex>
+#include <future>
 
 #define NT_SUCCESS(x) ((x) >= 0)
 #define STATUS_INFO_LENGTH_MISMATCH 0xc0000004
@@ -128,35 +129,50 @@ namespace acre {
             return index_files(".*");
         }
 
-        bool search::index_files(const std::string &filter) {
+        using pbo_worker_result = std::tuple<std::string, std::unordered_map<std::string, std::string>>;
+        pbo_worker_result get_files_in_pbo(const std::string& pbo_file_path, const std::regex& txt_regex) {
+            std::unordered_map<std::string, std::string> pbo_files_map;
             std::ifstream pbo_stream;
+            pbo_stream.open(pbo_file_path, std::ios::binary | std::ios::in);
+            if (!pbo_stream.good()) {
+                return { pbo_file_path, pbo_files_map };
+            };
+            acre::pbo::archive _archive(pbo_stream);
+            for (acre::pbo::entry_p& entry : _archive.entries) {
+                if (entry->filename != "") {
+                    if (std::regex_match(entry->filename, txt_regex)) {
+                        std::string full_virtual_path = _archive.info->header["prefix"] + "\\" + entry->filename;
+                        std::transform(full_virtual_path.begin(), full_virtual_path.end(), full_virtual_path.begin(), ::tolower);
+                        pbo_files_map[full_virtual_path] = pbo_file_path;
+                    }
+                }
+            }
+            pbo_stream.close();
+            return { "", pbo_files_map };
+        }
+
+        bool search::index_files(const std::string& filter) {
             std::regex txt_regex(filter);
 
             if (_active_pbo_list.size() < 1)
                 return false;
 
+            std::vector<std::future<pbo_worker_result>> fWorkers;
             for (auto & pbo_file_path : _active_pbo_list) {
-                pbo_stream.open(pbo_file_path, std::ios::binary | std::ios::in);
-                if (!pbo_stream.good()) {
-                    LOG(ERROR) << "Cannot open file - " << pbo_file_path;
+                fWorkers.emplace_back(std::async(std::launch::async, &get_files_in_pbo, pbo_file_path, txt_regex));
+            }
+            for (auto& worker : fWorkers) {
+                std::string error_file_name;
+                std::unordered_map<std::string, std::string> result;
+                std::tie(error_file_name, result) = worker.get();
+                if (error_file_name.size()) {
+                    LOG(ERROR) << "Cannot open file - " << error_file_name;
                     continue;
-                }
-
-                acre::pbo::archive _archive(pbo_stream);
-                for (acre::pbo::entry_p & entry : _archive.entries) {
-                    if (entry->filename != "") {
-                        if (std::regex_match(entry->filename, txt_regex)) {
-                            std::string full_virtual_path = _archive.info->header["prefix"] + "\\" + entry->filename;
-                            std::transform(full_virtual_path.begin(), full_virtual_path.end(), full_virtual_path.begin(), ::tolower);
-                            _file_pbo_index[full_virtual_path] = pbo_file_path;
-                            //LOG(DEBUG) << full_virtual_path << " = " << pbo_file_path;
-                        }
-                    }
-                }
-                pbo_stream.close();
+                };
+                _file_pbo_index.insert(result.begin(), result.end()); // swap to merge() in c++17
             }
 
-            LOG(INFO) << "PBO Index complete";
+            LOG(INFO) << "PBO Index complete [" << _active_pbo_list.size() << " PBOs] [" << _file_pbo_index.size() << " files]";
 
             return true;
         }


### PR DESCRIPTION
Moderate improvements to pre-start loading time


test results for 45GB of mods (CUP+RHS)

-fast ssd:
8067 ms spent in callExtension calling name: "acre", function: "init:"
6502 ms spent in callExtension calling name: "acre", function: "init:"
6541 ms spent in callExtension calling name: "acre", function: "init:"

2003 ms spent in callExtension calling name: "acre", function: "init:"
2386 ms spent in callExtension calling name: "acre", function: "init:"
1972 ms spent in callExtension calling name: "acre", function: "init:"


-ancient spinning rust HD:
19270 ms spent in callExtension calling name: "acre", function: "init:"

13282 ms spent in callExtension calling name: "acre", function: "init:"