### PR TITLE
Extension - Fix map loading on 32-bit

### DIFF
--- a/extensions/src/ACRE2Arma/common/wrp/landscape.cpp
+++ b/extensions/src/ACRE2Arma/common/wrp/landscape.cpp
@@ -30,8 +30,11 @@ acre::wrp::landscape::~landscape() {
 
 bool acre::wrp::landscape::_read_binary_tree_block(std::istream &stream_, const uint32_t bit_length, const uint32_t block_size, const uint32_t cell_size, const uint32_t block_offset_x, const uint32_t block_offset_y)
 {
-    uint32_t blockSize = static_cast<uint32_t>(ceil((log10(block_size) / log10(2.0)) / 2.0));
-    blockSize = static_cast<uint32_t>(pow(2, 2.0 * blockSize));
+    uint32_t blockSize = 1;
+    if (block_size != 0) {
+        blockSize = static_cast<uint32_t>(ceil((log10(block_size) / log10(2.0)) / 2.0));
+        blockSize = static_cast<uint32_t>(pow(2, 2.0 * blockSize));
+    }
 
     const uint32_t current_block_size = blockSize / 4u;//256..64..16..1
 


### PR DESCRIPTION
Map parsing seems to be broken only on 32bit - `{ERROR}- WRP Parsing exception: bad allocation`
Added debug:
```
{INFO }- _read_binary_tree_block w/ blockSize: 16
{INFO }- _read_binary_tree_block w/ blockSize: 4
{INFO }- _read_binary_tree_block w/ blockSize: 1
{INFO }- _read_binary_tree_block w/ blockSize: 4294967295
{INFO }- Attemping new [peak_count: 1660969728] // lol 17 GB malloc 
{ERROR}- WRP Parsing exception: bad allocation
```

Error seems to be in the binary_tree_block recrusion when calcuating the new block size and `log(0)` is undefined. But I'm not sure why it's only x86 (and only in release).

Test code
```
#include <iostream>
#include <cmath>

int main()
{
    uint32_t block_size = 0;
    std::cout << "a: " << (log10(block_size) / log10(2.0)) / 2.0 << std::endl;
    std::cout << "b: " << ceil((log10(block_size) / log10(2.0)) / 2.0) << std::endl;
    std::cout << "c: " << static_cast<uint32_t>(ceil((log10(block_size) / log10(2.0)) / 2.0)) << std::endl;
    return 0;
}
```
VS19 x64 and g++
```
a: -inf
b: -inf
c: 0
```
VS19 x86 in Release
```
a: -inf
b: -inf
c: 4294967295 //  2^32 − 1
```

edit: cleaner example code to show diff between 32 and 64
```
#include <iostream>
#include <limits>
int main() {
    auto t3 = static_cast<uint32_t>(-std::numeric_limits<double>::infinity());
    std::cout << "t3: " << t3 << " - " << ((t3 > 100) ? "big" : "small") << std::endl;
    return 0;
}
```
but a better question is why are we taking the log of 0??