### PR TITLE
Signal - Improve calculation when antennas are at the same position

### DIFF
--- a/extensions/src/ACRE2Arma/common/arguments.hpp
+++ b/extensions/src/ACRE2Arma/common/arguments.hpp
@@ -48,11 +48,19 @@ namespace acre {
         arguments(const char** argv, std::int32_t argc) : _internal_index(0) {
             for (std::int32_t i = 0; i < argc; i++) {
                 std::string arg_string(argv[i]);
-                if (arg_string.size() > 2 && arg_string.at(0) == '\"' && arg_string.at(arg_string.size() - 1) == '\"') {
-                    arg_string = arg_string.substr(1, arg_string.size() - 2);  // callExtensionArgs will add quotes to strings
-                } 
-                std::vector<std::string> arg_split = acre::split(arg_string, ',');
-                _args.insert(_args.end(), arg_split.begin(), arg_split.end());
+                if (arg_string.size() > 2) {
+                    if (arg_string.at(0) == '\"' && arg_string.at(arg_string.size() - 1) == '\"') {
+                        // String: stip quotes - callExtensionArgs will add quotes to strings
+                        _args.push_back(arg_string.substr(1, arg_string.size() - 2));
+                        continue;
+                    } else if (arg_string.at(0) == '[' && arg_string.at(arg_string.size() - 1) == ']') {
+                        // Array: strip [] and split on commas - for now this only handles 1-deep arrays
+                        std::vector<std::string> arg_split = acre::split(arg_string.substr(1, arg_string.size() - 2), ',');
+                        _args.insert(_args.end(), arg_split.begin(), arg_split.end());
+                        continue;
+                    }
+                }
+                _args.push_back(arg_string);
             }
         }
 

--- a/extensions/src/ACRE2Arma/signal/antenna/antenna.cpp
+++ b/extensions/src/ACRE2Arma/signal/antenna/antenna.cpp
@@ -30,6 +30,9 @@ float32_t acre::signal::antenna::gain(const glm::vec3 dir_antenna_, const glm::v
     if ((f_ < _min_frequency) || ((f_ + _frequency_step) > _max_frequency)){
         return -1000.0f;
     }
+    if (glm::length(dir_signal_) <= 0.0f) {
+        return 0.0f; // cannot get direction if antennas have same position
+    }
 
     const glm::vec3 dir_antenna_v = glm::normalize(dir_antenna_);
     const float32_t elev_antenna = asinf(dir_antenna_v.z)*57.2957795f;

--- a/extensions/src/ACRE2Arma/signal/models/arcade.cpp
+++ b/extensions/src/ACRE2Arma/signal/models/arcade.cpp
@@ -13,7 +13,7 @@ void acre::signal::model::Arcade::process(result *const result_, const glm::vec3
     const float32_t distance_3d = glm::distance(tx_pos_, rx_pos_);
 
     // Free Space Path Loss model
-    float32_t lossFreeSpace = -27.55f + 20.0f*log10f(frequency_Hz) + 20.0f*log10f(distance_3d); /* Free Space Path Loss model */
+    float32_t lossFreeSpace = -27.55f + 20.0f*log10f(frequency_Hz) + ((distance_3d > 0.0f) ? (20.0f*log10f(distance_3d)) : 0); /* Free Space Path Loss model */
     const float32_t txPower = 10.0f*(log10f((power_mW) / 1000.0f)) + 30.0f; /* Transmitter Power (mW to dBm) */
 
     if (rx_antenna_name.find("ACRE_2HALFINCH_UHF_TNC") != std::string::npos) {

--- a/extensions/src/ACRE2Arma/signal/signal.hpp
+++ b/extensions/src/ACRE2Arma/signal/signal.hpp
@@ -221,7 +221,7 @@ namespace acre {
                 
                 // Sanatize numbers as arma will not be able to parse bad values (can remove if no more errors are reported)
                 if (!isfinite(signal_result.result_dbm) || !isfinite(signal_result.result_v)) {
-                    LOG(ERROR) << "Signal was NaN/infinite: " << args_.to_string() << ": " << signal_result.result_dbm << "," << signal_result.result_v;
+                    if (logging >= 1) { LOG(ERROR) << "Signal was NaN/infinite: " << args_.to_string() << ": " << signal_result.result_dbm << "," << signal_result.result_v; }
                     signal_result.result_dbm = 9000.0f; 
                     signal_result.result_v = 9000.0f; // ouch - don't touch the antenna
                 }

--- a/extensions/src/ACRE2Arma/signal/signal.hpp
+++ b/extensions/src/ACRE2Arma/signal/signal.hpp
@@ -193,36 +193,30 @@ namespace acre {
 
                 acre::signal::result signal_result;
 
-                if (tx_pos != rx_pos) {
-                    switch (model) {
-                        case PropagationModel::arcade: {
-                            _signalProcessor_arcade.process(&signal_result, tx_pos, rx_pos, rx_antenna_name, frequency_MHz, power_mW);
-                            break;
-                        }
-                        case PropagationModel::los: {
-                            _signalProcessor_los.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, scale, omnidirectional);
-                            break;
-                        }
-                        case PropagationModel::losMultipath: {
-                            _signalProcessor_multipath.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, scale, omnidirectional);
-                            break;
-                        }
-                        case PropagationModel::longleyRice_itm: {
-                            _signalProcessor_longleyRice.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, false, omnidirectional, true);
-                            break;
-                        }
-                        case PropagationModel::longleyRice_itwom: {
-                            _signalProcessor_longleyRice.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, true, omnidirectional, true);
-                            break;
-                        }
-                        default: {
-                            _signalProcessor_multipath.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, scale, omnidirectional);
-                        }
+                switch (model) {
+                    case PropagationModel::arcade: {
+                        _signalProcessor_arcade.process(&signal_result, tx_pos, rx_pos, rx_antenna_name, frequency_MHz, power_mW);
+                        break;
                     }
-                } else {
-                    // Handle TX and RX positions being the same by just returning a very high dBm, this avoids many calcs that will fail if distance == 0
-                    signal_result.result_dbm = 0.111f;
-                    signal_result.result_v = .223f;
+                    case PropagationModel::los: {
+                        _signalProcessor_los.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, scale, omnidirectional);
+                        break;
+                    }
+                    case PropagationModel::losMultipath: {
+                        _signalProcessor_multipath.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, scale, omnidirectional);
+                        break;
+                    }
+                    case PropagationModel::longleyRice_itm: {
+                        _signalProcessor_longleyRice.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, false, omnidirectional, true);
+                        break;
+                    }
+                    case PropagationModel::longleyRice_itwom: {
+                        _signalProcessor_longleyRice.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, true, omnidirectional, true);
+                        break;
+                    }
+                    default: {
+                        _signalProcessor_multipath.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, scale, omnidirectional);
+                    }
                 }
                 
                 // Sanatize numbers as arma will not be able to parse bad values (can remove if no more errors are reported)


### PR DESCRIPTION
Related to errors seen in #983 but signal calcs may just be unrelated

- Handle bad signals when antennas are at same position

Could reproduce error with model set to `LOS Simple`
```
[] spawn { 
    player addItem "ItemRadio"; 
    waitUntil {"ACRE_PRC343_ID_2" in (items player)}; 
    [2400, 5000, "ACRE_PRC343_ID_1", "ACRE_PRC343_ID_2"] call acre_sys_signal_fnc_getSignal; 
};
```

`parseSimpleArray` does not like `nan` returns from the extension
There were many places that would cause inf/-inf when positions were the exact same, 
so I figured this hacky offset fix was a lot simpler than handling it everywhere.  e.g.:

free space path loss:
```
const float32_t distance_3d = glm::distance(tx_pos_, rx_pos_);
... log10f(distance_3d) // fails
```
antenna gain:
```
glm::normalize(tx_pos - rx_pos); // fails
```

I also added a generic sanitizer as I also saw NaNs from LongRice but am not sure of the cause
```
{ERROR}- Signal was nan: 3,ACRE_PRC343_ID_2_ACRE_2HALFINCH_UHF_TNC_ACRE_PRC343_ID_1_ACRE_2HALFINCH_UHF_TNC,1701.47,5654.21,6.25005,0.0138816,0.951126,0.308492,ACRE_2HALFINCH_UHF_TNC,1601.18,5670.57,-2.10281,0.0315743,-0.0856666,-0.995823,ACRE_2HALFINCH_UHF_TNC,2400,5000,1,295.531,0,0,: -nan(ind),-nan(ind)
```

- Fix args from arrays
Needed to strip the [] from arrays
This caused problems with parsing first arg from arrays
