### PR TITLE
API - Rename getAllRadioOfType to getAllRadiosByType

### DIFF
--- a/addons/api/CfgFunctions.hpp
+++ b/addons/api/CfgFunctions.hpp
@@ -38,6 +38,7 @@ class CfgFunctions {
 
         class Radios {
             PATHTO_FNC(getAllRadios);
+            PATHTO_FNC(getAllRadiosByType);
             PATHTO_FNC(getCurrentRadio);
             PATHTO_FNC(setCurrentRadio);
             PATHTO_FNC(getCurrentRadioList);

--- a/addons/api/fnc_getAllRadiosByType.sqf
+++ b/addons/api/fnc_getAllRadiosByType.sqf
@@ -12,8 +12,8 @@
  * Array of Radio IDs <ARRAY>
  *
  * Example:
- * _radioIds = ["ACRE_PRC152"] call acre_api_fnc_getAllRadioOfType
- * _radioIds = ["ACRE_PRC152", _unit] call acre_api_fnc_getAllRadioOfType
+ * _radioIds = ["ACRE_PRC152"] call acre_api_fnc_getAllRadiosByType
+ * _radioIds = ["ACRE_PRC152", _unit] call acre_api_fnc_getAllRadiosByType
  *
  * Public: Yes
  */

--- a/docs/_includes/custom/functions-list-api.html
+++ b/docs/_includes/custom/functions-list-api.html
@@ -113,35 +113,6 @@ __Example__
 
 ---
 
-### acre_api_fnc_getAllRadioOfType
-__Description__
-
-Returns a list of unique radio IDs of local player or unit possesses of a given type.
-In the case of a unit for the second parameter it will find the radio IDs for that unit instead of the local player.
-
-__Parameters__
-
-Index | Description | Datatype(s) | Default Value
---- | --- | --- | ---
-0 | Radio type  | STRING | 
-1 | Optional unit or List of String  | ARRAY, OBJECT | []
-
-__Return Value__
-
-Description | Datatype(s)
---- | ---
-Array of Radio IDs  | ARRAY
-
-__Example__
-
-```sqf
-_radioIds = ["ACRE_PRC152"] call acre_api_fnc_getAllRadioOfType
-_radioIds = ["ACRE_PRC152", _unit] call acre_api_fnc_getAllRadioOfType
-```
-
-
----
-
 ### acre_api_fnc_setCurveModelScale
 __Description__
 
@@ -684,6 +655,35 @@ __Example__
 
 ```sqf
 [] call acre_api_fnc_getGlobalVolume;
+```
+
+
+---
+
+### acre_api_fnc_getAllRadiosByType
+__Description__
+
+Returns a list of unique radio IDs of local player or unit possesses of a given type.
+In the case of a unit for the second parameter it will find the radio IDs for that unit instead of the local player.
+
+__Parameters__
+
+Index | Description | Datatype(s) | Default Value
+--- | --- | --- | ---
+0 | Radio type  | STRING | 
+1 | Optional unit or List of String  | ARRAY, OBJECT | []
+
+__Return Value__
+
+Description | Datatype(s)
+--- | ---
+Array of Radio IDs  | ARRAY
+
+__Example__
+
+```sqf
+_radioIds = ["ACRE_PRC152"] call acre_api_fnc_getAllRadiosByType
+_radioIds = ["ACRE_PRC152", _unit] call acre_api_fnc_getAllRadiosByType
 ```
 
 


### PR DESCRIPTION
**When merged this pull request will:**
- Standardise #988 
- Add `getAllRadiosByType` to `CfgFunctions`