### PR TITLE
Documentation - Fix C++ undefined behavior

### DIFF
--- a/docs/wiki/development/coding-guidelines-cpp.md
+++ b/docs/wiki/development/coding-guidelines-cpp.md
@@ -61,11 +61,11 @@ void some_function() {
 
 ## Namespaces
 
-All namespaces should be descendants of `acre::`. Namespaces that are meant to hold internal or implementation specific code not exposed readily to end users should be prefixed with two (2) underscores `__`.
+All namespaces should be descendants of `acre::`. Namespaces that are meant to hold internal or implementation specific code not exposed readily to end users should be prefixed with `internal::`.
 
 ```c++
 namespace acre {
-    namespace __my_helpers {
+    namespace internal::my_helpers {
         // internal helper functions
     }
     namespace my_functionality {
@@ -80,7 +80,7 @@ All classes should strictly maintain separation between declarations and definit
 
 ### Protected/Private Members/Methods
 
-All protected/private members and methods should be prefixed with a single `_` to provide easy identification that the value is not in the public scope.
+All protected/private members and methods should use the same style as variable names.
 
 Example:
 
@@ -90,11 +90,11 @@ class test_class {
 public:
     test_class(uint32_t init_);
 protected:
-    uint32_t _val;
+    uint32_t val;
 };
 
 //test_class.cpp
-test_class::test_class(uint32_t init_) : _val(init_) {};
+test_class::test_class(uint32_t init_) : val(init_) {};
 ```
 
 ## Templates


### PR DESCRIPTION
Avoid guidelines which could lead to undefined behavior.

**When merged this pull request will:**
Give new developers cleaner and better guidelines to write C++ code.
I see 2 issues with current guidelines:
- Namespaces that are meant to hold internal or implementation specific code not exposed readily to end users should be prefixed with two (2) underscores `__`.

This is directly undefined behavior, as C++ standard states:
https://stackoverflow.com/a/228797

```
Each name that contains a double underscore (__) or begins with an underscore followed by an uppercase letter (2.11) is reserved to the implementation for any use.
```

I assume, we're not using C++17, so I propose a fix to prefix internal namespaces with `internal_`. Otherwise we could use `internal::` and simply nest it.

- All protected/private members and methods should be prefixed with a single `_` to provide easy identification that the value is not in the public scope.

This is not yet undefined behavior. But if someone makes a variable called `_Val`, then we'll have an undefined behavior. So to avoid this, we could revert to simpler syntax, simply call arguments same way as variable names and class member can have `_` suffix.

```
All identifiers that begin with an underscore and either an uppercase letter or another underscore are always reserved for any use.
```
