### PR TITLE
Create .clang-format

### DIFF
--- a/extensions/src/.clang-format
+++ b/extensions/src/.clang-format
@@ -1,0 +1,20 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 200
+DerivePointerAlignment: false
+PointerAlignment: Left
+NamespaceIndentation: All
+IncludeBlocks: Merge
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  BeforeElse: true
+  AfterEnum: false
+  AfterExternBlock: false
+  AfterFunction: false
+  AfterStruct: false
+  SplitEmptyFunction: false
+
+#not yet supported on VS/VScode
+#IndentExternBlock: Indent
+#AllowShortEnumsOnASingleLine: false  #don't mangle enums


### PR DESCRIPTION
I think this should roughly match the style in the formatting guide (I'm no expert with this file-format)
Both VS and VScode w/ C++ Ext support it automatically

I don't really want to do anything extreme like format the entire codebase or enforce commits via validators
but I think it can be helpful to be able to auto-format sections.