### PR TITLE
Extensions - Fix loosing const-qualifier

### DIFF
--- a/extensions/src/ACRE2Arma/common/pbo/search.cpp
+++ b/extensions/src/ACRE2Arma/common/pbo/search.cpp
@@ -117,7 +117,7 @@ typedef struct _OBJECT_TYPE_INFORMATION
     ULONG NonPagedPoolUsage;
 } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
 
-PVOID GetLibraryProcAddress(PSTR LibraryName, PSTR ProcName)
+PVOID GetLibraryProcAddress(LPCSTR LibraryName, LPCSTR ProcName)
 {
     return GetProcAddress(GetModuleHandleA(LibraryName), ProcName);
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Fixed invalid type being passed
GetLibraryProcAddress is called with const char* argument, but PSTR is char*, casting const char* to char* won't be allowed anymore in C++20