### PR TITLE
API - Optimize `setPTTDelay`

### DIFF
--- a/addons/api/fnc_setPTTDelay.sqf
+++ b/addons/api/fnc_setPTTDelay.sqf
@@ -19,8 +19,6 @@ params [
     ["_delay", 0, [0]]
 ];
 
-if (!( _delay isEqualType 0)) exitWith { false };
-
 if (_delay > 1 || _delay < 0) exitWith { false };
 
 ACRE_PTT_RELEASE_DELAY = _delay;


### PR DESCRIPTION
**When merged this pull request will:**

- Allow us to now reach the statement on line 22, that was previously blocked by 
`if (!( _delay isEqualType 0)) exitWith { false };`.

- Valid `_delay` values will now proceed to line 24, where `ACRE_PTT_RELEASE_DELAY` will be set accordingly.
