### PR TITLE
API - Add Audio Source Control

### DIFF
--- a/addons/api/CfgFunctions.hpp
+++ b/addons/api/CfgFunctions.hpp
@@ -52,6 +52,9 @@ class CfgFunctions {
 
             PATHTO_FNC(setCurrentRadioChannelNumber);
             PATHTO_FNC(getCurrentRadioChannelNumber);
+
+            PATHTO_FNC(setRadioAudioSource);
+            PATHTO_FNC(getRadioAudioSource);
         };
 
         class Racks {

--- a/addons/api/CfgFunctions.hpp
+++ b/addons/api/CfgFunctions.hpp
@@ -55,6 +55,8 @@ class CfgFunctions {
 
             PATHTO_FNC(setRadioAudioSource);
             PATHTO_FNC(getRadioAudioSource);
+            PATHTO_FNC(setRadioSpeaker);
+            PATHTO_FNC(isRadioSpeaker);
         };
 
         class Racks {

--- a/addons/api/fnc_getRadioAudioSource.sqf
+++ b/addons/api/fnc_getRadioAudioSource.sqf
@@ -10,7 +10,7 @@
  * Audio Source <STRING>
  *
  * Example:
- * _audioSource = ["ACRE_PRC148_ID_123"] call acre_api_fnc_getRadioAudioSource;
+ * _audioSource = ["ACRE_PRC148_ID_123"] call acre_api_fnc_getRadioAudioSource
  *
  * Public: Yes
  */
@@ -19,6 +19,4 @@ params [
     ["_radioId", "", [""]]
 ];
 
-private _audioSource = [_radioId, "getState", "audioPath"] call EFUNC(sys_data,dataEvent);
-
-_audioSource
+[_radioId, "getState", "audioPath"] call EFUNC(sys_data,dataEvent)

--- a/addons/api/fnc_getRadioAudioSource.sqf
+++ b/addons/api/fnc_getRadioAudioSource.sqf
@@ -19,8 +19,6 @@ params [
     ["_radioId", "", [""]]
 ];
 
-if ( !(_radioId isEqualType "")) exitWith { -1 };
-
 private _audioSource = [_radioId, "getState", "audioPath"] call EFUNC(sys_data,dataEvent);
 
 _audioSource

--- a/addons/api/fnc_getRadioAudioSource.sqf
+++ b/addons/api/fnc_getRadioAudioSource.sqf
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Gets the audio source currently selected on the provided radio ID.
+ *
+ * Arguments:
+ * 0: Radio ID <STRING>
+ *
+ * Return Value:
+ * Audio Source <STRING>
+ *
+ * Example:
+ * _audioSource = ["ACRE_PRC148_ID_123"] call acre_api_fnc_getRadioAudioSource;
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_radioId", "", [""]]
+];
+
+if ( !(_radioId isEqualType "")) exitWith { -1 };
+
+private _audioSource = [_radioId, "getState", "audioPath"] call EFUNC(sys_data,dataEvent);
+
+_audioSource

--- a/addons/api/fnc_isRadioSpeaker.sqf
+++ b/addons/api/fnc_isRadioSpeaker.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Returns true or false whether the provided radio ID has audio source set to speaker or not.
+ *
+ * Arguments:
+ * 0: Radio ID <STRING>
+ *
+ * Return Value:
+ * Is Audio Source Speaker <BOOL>
+ *
+ * Example:
+ * _isSpeaker = ["ACRE_PRC148_ID_123"] call acre_api_fnc_isRadioSpeaker
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_radioId", "", [""]]
+];
+
+private _radioType = [_radioId] call FUNC(getBaseRadio);
+private _audioSource = [_radioId] call FUNC(getRadioAudioSource);
+
+if (_radioType in ["ACRE_PRC148", "ACRE_PRC152"] && {_audioSource == "INTAUDIO"}) exitWith {
+    true
+};
+if (_radioType in ["ACRE_SEM70", "ACRE_SEM52SL"] && {_audioSource == "INTSPEAKER"}) exitWith {
+    true
+};
+
+false

--- a/addons/api/fnc_setRadioAudioSource.sqf
+++ b/addons/api/fnc_setRadioAudioSource.sqf
@@ -25,10 +25,7 @@ params [
     ["_audioSource", "", [""]]
 ];
 
-if ( !(_radioId isEqualType "")) exitWith { -1 };
-
 private _radioType = [_radioId] call acre_api_fnc_getBaseRadio;
-
 private _success = false;
 
 if (_radioType isEqualTo "ACRE_PRC148" && {_audioSource in ["INTAUDIO", "TOPAUDIO", "TOPSIDETON", "SIDEAUDIO", "SIDESIDETON"]}) then {

--- a/addons/api/fnc_setRadioAudioSource.sqf
+++ b/addons/api/fnc_setRadioAudioSource.sqf
@@ -15,7 +15,7 @@
  * Success <BOOLEAN>
  *
  * Example:
- * _success = ["ACRE_PRC148_ID_123", "INTAUDIO"] call acre_api_fnc_setRadioAudioSource;
+ * _success = ["ACRE_PRC148_ID_123", "INTAUDIO"] call acre_api_fnc_setRadioAudioSource
  *
  * Public: Yes
  */
@@ -25,23 +25,22 @@ params [
     ["_audioSource", "", [""]]
 ];
 
-private _radioType = [_radioId] call acre_api_fnc_getBaseRadio;
-private _success = false;
+private _radioType = [_radioId] call FUNC(getBaseRadio);
 
-if (_radioType isEqualTo "ACRE_PRC148" && {_audioSource in ["INTAUDIO", "TOPAUDIO", "TOPSIDETON", "SIDEAUDIO", "SIDESIDETON"]}) then {
-    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+if (_radioType isEqualTo "ACRE_PRC148" && {_audioSource in ["INTAUDIO", "TOPAUDIO", "TOPSIDETON", "SIDEAUDIO", "SIDESIDETON"]}) exitWith {
+    [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent)
 };
 
-if (_radioType isEqualTo "ACRE_PRC152" && {_audioSource in ["INTAUDIO", "TOPAUDIO"]}) then {
-    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+if (_radioType isEqualTo "ACRE_PRC152" && {_audioSource in ["INTAUDIO", "TOPAUDIO"]}) exitWith {
+    [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent)
 };
 
-if (_radioType isEqualTo "ACRE_SEM52SL" && {_audioSource in ["INTSPEAKER", "HEADSET"]}) then {
-    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+if (_radioType isEqualTo "ACRE_SEM52SL" && {_audioSource in ["INTSPEAKER", "HEADSET"]}) exitWith {
+    [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent)
 };
 
-if (_radioType isEqualTo "ACRE_SEM70" && {_audioSource in ["INTSPEAKER", "HEADSET"]}) then {
-    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+if (_radioType isEqualTo "ACRE_SEM70" && {_audioSource in ["INTSPEAKER", "HEADSET"]}) exitWith {
+    [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent)
 };
 
-_success
+false

--- a/addons/api/fnc_setRadioAudioSource.sqf
+++ b/addons/api/fnc_setRadioAudioSource.sqf
@@ -1,0 +1,50 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Sets the audio source on the provided radio ID.
+ * Possible Values for ACRE_PRC148: ["INTAUDIO", "TOPAUDIO", "TOPSIDETON", "SIDEAUDIO", "SIDESIDETON"]
+ * Possible Values for ACRE_PRC152: ["INTAUDIO", "TOPAUDIO"]
+ * Possible Values for ACRE_SEM52SL: ["INTSPEAKER", "HEADSET"]
+ * Possible Values for ACRE_SEM70: ["INTSPEAKER", "HEADSET"]
+ *
+ * Arguments:
+ * 0: Radio ID <STRING>
+ * 1: Audio Source <STRING>
+ *
+ * Return Value:
+ * Success <BOOLEAN>
+ *
+ * Example:
+ * _success = ["ACRE_PRC148_ID_123", "INTAUDIO"] call acre_api_fnc_setRadioAudioSource;
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_radioId", "", [""]],
+    ["_audioSource", "", [""]]
+];
+
+if ( !(_radioId isEqualType "")) exitWith { -1 };
+
+private _radioType = [_radioId] call acre_api_fnc_getBaseRadio;
+
+private _success = false;
+
+if (_radioType isEqualTo "ACRE_PRC148" && {_audioSource in ["INTAUDIO", "TOPAUDIO", "TOPSIDETON", "SIDEAUDIO", "SIDESIDETON"]}) then {
+    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+};
+
+if (_radioType isEqualTo "ACRE_PRC152" && {_audioSource in ["INTAUDIO", "TOPAUDIO"]}) then {
+    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+};
+
+if (_radioType isEqualTo "ACRE_SEM52SL" && {_audioSource in ["INTSPEAKER", "HEADSET"]}) then {
+    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+};
+
+if (_radioType isEqualTo "ACRE_SEM70" && {_audioSource in ["INTSPEAKER", "HEADSET"]}) then {
+    _success = [_radioId, "setState", ["audioPath", _audioSource]] call EFUNC(sys_data,dataEvent);
+};
+
+_success

--- a/addons/api/fnc_setRadioSpeaker.sqf
+++ b/addons/api/fnc_setRadioSpeaker.sqf
@@ -1,0 +1,37 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Sets the audio source to speaker or back to default on the provided radio ID.
+ *
+ * Arguments:
+ * 0: Radio ID <STRING>
+ * 1: Speaker <BOOL>
+ *
+ * Return Value:
+ * Success <BOOLEAN>
+ *
+ * Example:
+ * _success = ["ACRE_PRC148_ID_123", true] call acre_api_fnc_setRadioSpeaker
+ * _success = ["ACRE_PRC148_ID_123", false] call acre_api_fnc_setRadioSpeaker
+ *
+ * Public: Yes
+ */
+
+params [
+    ["_radioId", "", [""]],
+    ["_speaker", true, [true]]
+];
+
+private _radioType = [_radioId] call FUNC(getBaseRadio);
+
+if (_radioType in ["ACRE_PRC148", "ACRE_PRC152"]) exitWith {
+    private _audioSpeaker = ["TOPAUDIO", "INTAUDIO"] select _speaker;
+    [_radioId, "setState", ["audioPath", _audioSpeaker]] call EFUNC(sys_data,dataEvent)
+};
+
+if (_radioType in ["ACRE_SEM70", "ACRE_SEM52SL"]) exitWith {
+    private _audioSpeaker = ["HEADSET", "INTSPEAKER"] select _speaker;
+    [_radioId, "setState", ["audioPath", _audioSpeaker]] call EFUNC(sys_data,dataEvent)
+};
+
+false


### PR DESCRIPTION
**When merged this pull request will:**
- Add two API Functions for controling the Radio Audio Source for available Radios

**Currently four Radios have the possibility to switch the audio source:**
 * Possible Values for ACRE_PRC148: ["INTAUDIO", "TOPAUDIO", "TOPSIDETON", "SIDEAUDIO", "SIDESIDETON"]
 * Possible Values for ACRE_PRC152: ["INTAUDIO", "TOPAUDIO"]
 * Possible Values for ACRE_SEM52SL: ["INTSPEAKER", "HEADSET"]
 * Possible Values for ACRE_SEM70: ["INTSPEAKER", "HEADSET"]