### PR TITLE
Attenuation - Improve handling of 1st person spectating

### DIFF
--- a/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
+++ b/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
@@ -19,18 +19,23 @@
 // e.g. what the local acre_player attenuation scale value is.
 // returns 0-1
 
-private _listener = acre_player;
 params ["_speaker"];
+private _vehSpeaker = vehicle _speaker;
+private _listener = acre_player;
+private _vehListener = vehicle _listener;
 
-// If we are spectating and in first person on the speaker's vehicle (from ANY crew member's point of view) then assume no attenuation
-if (ACRE_IS_SPECTATOR && {cameraView == "INTERNAL"} && {(vehicle cameraOn) == (vehicle _speaker)}) exitWith { 0 };
+private _spectatingInsideVehicle = false;
+// If we are spectating and in first person view then use the spectating-target's vehicle for attenuation calcs
+if (ACRE_IS_SPECTATOR && {cameraView == "INTERNAL"} && {!(cameraOn isKindOf "CaManBase")}) then {
+    _listener = cameraOn; // note: cameraOn only provides the vehicle, not the specific unit
+    _vehListener = _listener;
+    _spectatingInsideVehicle = true;
+};
 
 private _attenuate = 0;
 
-private _vehListener = vehicle _listener;
-private _vehSpeaker = vehicle _speaker;
-
 if (_vehListener == _vehSpeaker) then {
+    if (_spectatingInsideVehicle) exitWith {}; // we won't be able to determine the specific compartment
     private _listenerTurnedOut = isTurnedOut _listener;
     private _speakerTurnedOut = isTurnedOut _speaker;
     if (!(_listenerTurnedOut && _speakerTurnedOut)) then {
@@ -47,7 +52,7 @@ if (_vehListener == _vehSpeaker) then {
         };
     };
 } else {
-    if (_vehListener != _listener) then {
+    if (_spectatingInsideVehicle || {_vehListener != _listener}) then {
         private _listenerTurnedOut = isTurnedOut _listener;
         if (!_listenerTurnedOut) then {
             // acre_player sideChat format["1 %1 %2", _attenuate, (1-(getNumber (configFile >> "CfgVehicles" >> (typeOf (vehicle _listener)) >> "insideSoundCoef")))];

--- a/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
+++ b/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
@@ -21,6 +21,10 @@
 
 private _listener = acre_player;
 params ["_speaker"];
+
+// If we are spectating and in first person on the speaker's vehicle (from ANY crew member's point of view) then assume no attenuation
+if (ACRE_IS_SPECTATOR && {cameraView == "INTERNAL"} && {(vehicle cameraOn) == (vehicle _speaker)}) exitWith { 0 };
+
 private _attenuate = 0;
 
 private _vehListener = vehicle _listener;

--- a/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
+++ b/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
@@ -4,7 +4,7 @@
  * Calculates the attenuation of a unit being heard externally from the vehicle.
  *
  * Arguments:
- * 0: Unit <Object>
+ * 0: Unit (or vehicle) <Object>
  *
  * Return Value:
  * Attenuation <NUMBER>
@@ -21,24 +21,22 @@ private _vehicle = vehicle _unit;
 if (isNull _vehicle) exitWith {};
 
 private _attenuation = 0;
-if (_unit != _vehicle) then {
-    private _effectType = getText (configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "attenuationEffectType");
+private _effectType = getText (configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "attenuationEffectType");
 
-    {
-        if (_unit == (_vehicle turretUnit _x)) exitWith {
-            private _config = [_vehicle, _x] call CBA_fnc_getTurret;
+private _turret = _vehicle unitTurret _unit;
+if (!(_turret in [[], [-1]])) then {
+    private _config = [_vehicle, _turret] call CBA_fnc_getTurret;
 
-            if ((getNumber (_config >> "disableSoundAttenuation")) == 1) then {
-                _effectType = "";
-            } else {
-                if (isText (_config >> "soundAttenuationTurret")) then {
-                    _effectType = getText (_config >> "soundAttenuationTurret");
-                };
-            };
+    if ((getNumber (_config >> "disableSoundAttenuation")) == 1) then {
+        _effectType = "";
+    } else {
+        if (isText (_config >> "soundAttenuationTurret")) then {
+            _effectType = getText (_config >> "soundAttenuationTurret");
         };
-    } forEach allTurrets [_vehicle, true];
+    };
+};
 
-    if (_effectType == "") exitWith {};
+if (_effectType != "") then {
     // CfgSoundEffects >> AttenuationsEffects
     private _value = HASH_GET(GVAR(attenuationCache), _effectType);
     if (isNil "_value") then {
@@ -53,7 +51,6 @@ if (_unit != _vehicle) then {
     } else {
         _attenuation = _value;
     };
-
 };
 
 _attenuation;

--- a/addons/sys_core/fnc_findOcclusion.sqf
+++ b/addons/sys_core/fnc_findOcclusion.sqf
@@ -24,6 +24,11 @@ if (_distance > 150) exitWith { 0; };
 if (!lineIntersects [_startPos, _endPos]) exitWith { 1; };
 private _vehicleUnit = vehicle _unit;
 private _vehiclePlayer = vehicle acre_player;
+// If spectating, use the spectating-target's vehicle for lineIntersects commands
+if (ACRE_IS_SPECTATOR) then {
+    _vehiclePlayer = vehicle cameraOn;
+};
+
 if (_vehicleUnit isEqualTo _vehiclePlayer) exitWith { 1; };
 
 private _cachedData = (_unit getVariable [QGVAR(occlusionCache), [nil,nil,-1]]);

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -148,7 +148,7 @@ if !(GVAR(keyedMicRadios) isEqualTo []) then {
                     private _recRadioObject = [_recRadio] call EFUNC(sys_radio,getRadioObject);
                     _attenuate = [_recRadioObject] call EFUNC(sys_attenuate,getUnitAttenuate);
                     _attenuate = (1 - _attenuate)^3;
-                    _volumeModifier = [_radioPos, ACRE_LISTENER_POS, acre_player] call FUNC(findOcclusion);
+                    _volumeModifier = [_radioPos, ACRE_LISTENER_POS, _recRadioObject] call FUNC(findOcclusion);
                     _volumeModifier = _volumeModifier^3;
                 };
 


### PR DESCRIPTION
Fix #1048
Fix occlusion calc on ExternalAudio radios (_vehicleUnit was always equal to _vehiclePlayer)
Trivial performance improvements with `unitTurret`!!!!

Tested with scripted ace_spectator
- [ ] Test with vanilla spectator