### PR TITLE
Tools - Use hemtt in build.py if installed

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -9,6 +9,18 @@ MAINPREFIX = "idi"
 PREFIX = "acre_"
 ##########################
 
+def tryHemttBuild(projectpath):
+    hemttExe = os.path.join(projectpath, "hemtt.exe")
+    if os.path.isfile(hemttExe):
+        os.chdir(projectpath)
+        ret = subprocess.call([hemttExe, "pack"], stderr=subprocess.STDOUT)
+        print("Using hemtt: {}".format(ret));
+        return True
+    else:
+        print("hemtt not installed");
+    return False
+
+
 def mod_time(path):
     if not os.path.isdir(path):
         return os.path.getmtime(path)
@@ -39,6 +51,8 @@ def main():
     scriptpath = os.path.realpath(__file__)
     projectpath = os.path.dirname(os.path.dirname(scriptpath))
     addonspath = os.path.join(projectpath, "addons")
+
+    if (tryHemttBuild(projectpath)): return
 
     os.chdir(addonspath)
 


### PR DESCRIPTION
new version of makepbo can't build pbos with non-binerized p3ds