### PR TITLE
PRC148 - Fix invalid knob position after call to setRadioChannel API

### DIFF
--- a/addons/sys_prc148/radio/fnc_setCurrentChannel.sqf
+++ b/addons/sys_prc148/radio/fnc_setCurrentChannel.sqf
@@ -20,22 +20,19 @@ params ["_radioId", "", "_eventData", "_radioData"];
 
 TRACE_1("SETTING CURRENT CHANNEL",_this);
 private _groups = HASH_GET(_radioData, "groups");
-private _group = _groups select HASH_GET(_radioData, "currentGroup");
 
-if !(_eventData in (_group select 1)) then {
-    {
-        _x params ["","_channelNums"];
-        private _groupIndex = _forEachIndex;
-        if (_eventData in _channelNums) exitWith {
-            {
-                if (_x == _eventData) then {
-                    HASH_SET(_radioData, "currentGroup", _groupIndex);
-                    HASH_SET(_radioData, "channelKnobPosition", _forEachIndex);
-                };
-            } forEach _channelNums;
-        };
-    } forEach _groups;
-};
+{
+    _x params ["","_channelNums"];
+    private _groupIndex = _forEachIndex;
+    if (_eventData in _channelNums) exitWith {
+        {
+            if (_x == _eventData) then {
+                HASH_SET(_radioData, "currentGroup", _groupIndex);
+                HASH_SET(_radioData, "channelKnobPosition", _forEachIndex);
+            };
+        } forEach _channelNums;
+    };
+} forEach _groups;
 
 private _channelsCount = count ([_radioId, "getState", "channels"] call EFUNC(sys_data,dataEvent)) - 1;
 _eventData = (0 max _eventData) min _channelsCount;


### PR DESCRIPTION
Issue this addresses:
Exec `["ACRE_PRC148_ID_1", 5] call acre_api_fnc_setRadioChannel`
It will show channel 5 in display, but clicking the channel knob would set you on channel 2

`[] call acre_api_fnc_getCurrentRadioChannelNumber;` was 5
but  `["ACRE_PRC148_ID_1", "getState", "channelKnobPosition"] call acre_sys_data_fnc_dataEvent` was still 0

With this PR, `currentGroup` and `channelKnobPosition` are always updated
