### PR TITLE
SEM70 - Fix frequency setting on dedicated server

### DIFF
--- a/addons/sys_sem70/functions/fnc_onMHzKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onMHzKnobTurn.sqf
@@ -50,7 +50,7 @@ if (_knobPosition != _newKnobPosition) then {
     if (_newKnobPosition < 0) then {
         _newKnobPosition = 49;
     };
-    ["setState", ["MHzKnobPosition",_newKnobPosition]] call GUI_DATA_EVENT;
+    ["setStateCritical", ["MHzKnobPosition",_newKnobPosition]] call GUI_DATA_EVENT;
 
     // We parse a 0 here, because we are in manual mode
     ["setCurrentChannel", GVAR(manualChannel)] call GUI_DATA_EVENT;

--- a/addons/sys_sem70/functions/fnc_onkHzKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onkHzKnobTurn.sqf
@@ -61,7 +61,7 @@ if (_knobPosition != _newKnobPosition) then {
             _newKnobPosition = 39;
         };
     };
-    ["setState", ["kHzKnobPosition",_newKnobPosition]] call GUI_DATA_EVENT;
+    ["setStateCritical", ["kHzKnobPosition",_newKnobPosition]] call GUI_DATA_EVENT;
 
     // We parse a 0 here, because we are in manual mode
     ["setCurrentChannel", GVAR(manualChannel)] call GUI_DATA_EVENT;

--- a/addons/sys_sem70/radio/fnc_setCurrentChannel.sqf
+++ b/addons/sys_sem70/radio/fnc_setCurrentChannel.sqf
@@ -38,11 +38,10 @@
 */
 
 params ["_radioId", "", "_eventData", "_radioData"];
+TRACE_2("setCurrentChannel",_radioID,_eventData);
 
 private _manualChannel = HASH_GET(_radioData, "manualChannelSelection");
-
 TRACE_1("ManualChannel",_manualChannel);
-TRACE_1("NewChannel",_eventData);
 
 if (_manualChannel isEqualTo 1) then {
     private _currentMHzFrequency = HASH_GET(_radioData, "MHzKnobPosition");
@@ -56,6 +55,7 @@ if (_manualChannel isEqualTo 1) then {
 
     HASH_SET(_channel, "frequencyTX", _newFreq);
     HASH_SET(_channel, "frequencyRX", _newFreq);
+    TRACE_3("",_currentMHzFrequency,_currentkHzFrequency,_newFreq);
 
     [_radioID,"setChannelData", [GVAR(manualChannel), _channel]] call EFUNC(sys_data,dataEvent);
 


### PR DESCRIPTION
Fix #645

https://github.com/IDI-Systems/acre2/blob/master/addons/sys_sem70/functions/fnc_onMHzKnobTurn.sqf
calls these in order
```
    ["setState", ["MHzKnobPosition",_newKnobPosition]] call GUI_DATA_EVENT;
    ["setCurrentChannel", GVAR(manualChannel)] call GUI_DATA_EVENT;
```
https://github.com/IDI-Systems/acre2/blob/master/addons/sys_sem70/radio/fnc_setCurrentChannel.sqf
uses `MHzKnobPosition` to set frequencyTX

but setState has a lower data priority, so the events would arrive out of order and frequency wouldn't be updated correctly
setStateCritical should have same priority, so they should arrive in order, but this could use testing