### PR TITLE
Gestures - Fix Event Handlers when switching units

### DIFF
--- a/addons/sys_gestures/XEH_postInit.sqf
+++ b/addons/sys_gestures/XEH_postInit.sqf
@@ -10,20 +10,26 @@ if (GVAR(stopADS)) then {
 ["acre_stoppedSpeaking", {call FUNC(stoppedSpeaking)}] call CBA_fnc_addEventHandler;
 
 ["unit", {
-    params ["", "_oldUnit"];
+    params ["_newUnit", "_oldUnit"];
     _oldUnit call FUNC(stopGesture);
-}, true] call CBA_fnc_addPlayerEventHandler;
 
-acre_player addEventHandler ["GetInMan", {
-    params ["_unit"];
+    // Add EHs one time only (won't be re-added on respawn)
+    if (_newUnit getVariable [QGVAR(hasEHS), false]) exitWith {};
+    _newUnit setVariable [QGVAR(hasEHS), true];
 
-    _unit call FUNC(stopGesture);
-}];
+    _newUnit addEventHandler ["GetInMan", {
+        params ["_unit"];
+        TRACE_1("GetInMan",_unit);
 
-acre_player addEventHandler ["WeaponDeployed", {
-    params ["_unit", "_isDeployed"];
-
-    if (_isDeployed) then {
         _unit call FUNC(stopGesture);
-    };
-}];
+    }];
+
+    _newUnit addEventHandler ["WeaponDeployed", {
+        params ["_unit", "_isDeployed"];
+        TRACE_2("WeaponDeployed",_unit,_isDeployed);
+
+        if (_isDeployed) then {
+            _unit call FUNC(stopGesture);
+        };
+    }];
+}, true] call CBA_fnc_addPlayerEventHandler;

--- a/addons/sys_gestures/script_component.hpp
+++ b/addons/sys_gestures/script_component.hpp
@@ -2,6 +2,10 @@
 #define COMPONENT_BEAUTIFIED Gestures
 #include "\idi\acre\addons\main\script_mod.hpp"
 
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
 #ifdef DEBUG_ENABLED_SYS_GESTURES
     #define DEBUG_MODE_FULL
 #endif


### PR DESCRIPTION
This adds the 2 event handlers to any new units the player controls
On traditional arma-respawn, the EH will transfer, but so will the setVar so nothing will change
On zeusRC switch or `selectPlayer` the EH will be added to the new unit