### PR TITLE
Intercom - Remove intercom PFH when ejecting from aircraft

### DIFF
--- a/addons/sys_intercom/fnc_enterVehicle.sqf
+++ b/addons/sys_intercom/fnc_enterVehicle.sqf
@@ -17,6 +17,24 @@
  */
 
 params ["_vehicle", "_unit"];
+TRACE_2("enterVehicle",typeOf _vehicle,typeOf _unit);
+
+if ((_unit == _vehicle) || {GVAR(intercomPFH) > -1}) then {
+    [GVAR(intercomPFH)] call CBA_fnc_removePerFrameHandler;
+    TRACE_1("del intercom PFH",GVAR(intercomPFH));
+    GVAR(intercomPFH) = -1;
+
+    private _oldVehicle = _unit getVariable [QGVAR(intercomVehicle), objNull];
+
+    // Handle the case of broadcasting or using a seat that uses limited connections
+    [_oldVehicle, _unit] call FUNC(seatSwitched);
+
+    // Reset variables
+    _unit setVariable [QGVAR(intercomVehicle), objNull];
+    _unit setVariable [QGVAR(role), ""];
+    ACRE_PLAYER_INTERCOM = [];
+    GVAR(intercomUse) = [];
+};
 
 if (_unit != _vehicle) then {
     // Save current seat variable
@@ -29,19 +47,5 @@ if (_unit != _vehicle) then {
 
     // Start PFH
     GVAR(intercomPFH) = [DFUNC(intercomPFH), 1, [_unit, _vehicle]] call CBA_fnc_addPerFrameHandler;
-    TRACE_1("intercom PFH",GVAR(intercomPFH));
-} else {
-    [GVAR(intercomPFH)] call CBA_fnc_removePerFrameHandler;
-    TRACE_1("del intercom PFH",GVAR(intercomPFH));
-
-    _vehicle = _unit getVariable [QGVAR(intercomVehicle), objNull];
-
-    // Handle the case of broadcasting or using a seat that uses limited connections
-    [_vehicle, _unit] call FUNC(seatSwitched);
-
-    // Reset variables
-    _unit setVariable [QGVAR(intercomVehicle), objNull];
-    _unit setVariable [QGVAR(role), ""];
-    ACRE_PLAYER_INTERCOM = [];
-    GVAR(intercomUse) = [];
+    TRACE_1("add intercom PFH",GVAR(intercomPFH));
 };


### PR DESCRIPTION
When using ejection seat it goes directly from plane to ejection seat to parachute.
Additional PFEH were added and old ones never cleaned up.

This changes the function to always cleanup the existing PFEH if it exists, before adding a new one.


also yay for auto callstacks on script errors
```
   Error Zero divisor
 File \x\cba\addons\hashes\fnc_hashGet.sqf [CBA_fnc_hashGet]..., line 1853
  âž¥ Context: 	[] L1 ()
	[] L21 ()
	[] L17 ()
	[] L19 ()
	[] L98 (idi\acre\addons\sys_intercom\fnc_intercomPFH.sqf)
	[] L99 (idi\acre\addons\sys_intercom\fnc_intercomPFH.sqf)
	[] L60 (idi\acre\addons\sys_intercom\fnc_seatSwitched.sqf)
	[] L37 (idi\acre\addons\sys_intercom\fnc_seatSwitched.sqf)
	[] L38 (idi\acre\addons\sys_intercom\fnc_seatSwitched.sqf)
	[] L31 (idi\acre\addons\sys_intercom\fnc_getStationConfiguration.sqf)
	[] L1855 (\x\cba\addons\hashes\fnc_hashGet.sqf [CBA_fnc_hashGet])
```