### PR TITLE
Signal - Split core signal getter

### DIFF
--- a/addons/sys_signal/XEH_PREP.hpp
+++ b/addons/sys_signal/XEH_PREP.hpp
@@ -1,4 +1,5 @@
 PREP(getRadioClimateCode);
 PREP(getSignal);
+PREP(getSignalCore);
 PREP(handleEndTransmission);
 PREP(handleSignalReturn);

--- a/addons/sys_signal/fnc_getSignal.sqf
+++ b/addons/sys_signal/fnc_getSignal.sqf
@@ -2,12 +2,13 @@
 /*
  * Author: ACRE2Team
  * Wrapper function for calling the signal calculation (extension).
+ * Calls custom signal function if defined, core (default) signal function otherwise.
  *
  * Arguments:
- * 0: Frequency <NUMBER>
- * 1: Power <NUMBER>
- * 2: Receiving Radio ID <STRING>
- * 3: Transmitting Radio ID <STRING>
+ * 0: Frequency <NUMBER> (passed-through)
+ * 1: Power <NUMBER> (passed-through)
+ * 2: Receiving Radio ID <STRING> (passed-through)
+ * 3: Transmitting Radio ID <STRING> (passed-through)
  *
  * Return Value:
  * Tuple of power and maximum signal strength <ARRAY>
@@ -18,63 +19,8 @@
  * Public: No
  */
 
-if (!isNil QGVAR(customSignalFunc)) exitWith { _this call GVAR(customSignalFunc); };
-
-params ["_f", "_mW", "_receiverClass", "_transmitterClass"];
-
-private _count = (missionNamespace getVariable [_transmitterClass + "_running_count", 0]) max 0;
-if (_count == 0) then {
-    private _rxAntennas = [_receiverClass] call EFUNC(sys_components,findAntenna);
-    private _txAntennas = [_transmitterClass] call EFUNC(sys_components,findAntenna);
-
-    {
-        private _txAntenna = _x;
-        {
-            private _rxAntenna = _x;
-            private _model = GVAR(signalModel); // TODO: Change models on the fly if compatible (underwater, better frequency matching)
-
-            // Make sure ITWOM is not used for the moment
-            if (_model > SIGNAL_MODEL_ITWOM || {_model < SIGNAL_MODEL_CASUAL}) then {
-                _model = SIGNAL_MODEL_LOS_MULTIPATH;  // Default to LOS Multipath if the model is out of range
-                GVAR(signalModel) = _model;           // And make sure we do not use an invalid mode next time
-            };
-
-            _count = _count + 1;
-            private _id = format ["%1_%2_%3_%4", _transmitterClass, (_txAntenna select 0), _receiverClass, (_rxAntenna select 0)];
-            [
-                "process_signal",
-                [
-                    _model,
-                    _id,
-                    (_txAntenna select 2),
-                    (_txAntenna select 3),
-                    (_txAntenna select 0),
-                    (_rxAntenna select 2),
-                    (_rxAntenna select 3),
-                    (_rxAntenna select 0),
-                    _f,
-                    _mW,
-                    GVAR(terrainScaling),
-                    diag_tickTime,
-                    ACRE_SIGNAL_DEBUGGING,
-                    GVAR(omnidirectionalRadios)
-                ],
-                2,
-                FUNC(handleSignalReturn),
-                [_transmitterClass, _receiverClass]
-            ] call EFUNC(sys_core,callExt);
-        } forEach _rxAntennas;
-    } forEach _txAntennas;
-    missionNamespace setVariable [_transmitterClass + "_running_count", _count];
-};
-private _maxSignal = missionNamespace getVariable [_transmitterClass + "_best_signal", -992];
-private _Px = missionNamespace getVariable [_transmitterClass + "_best_px", 0];
-
-if (ACRE_SIGNAL_DEBUGGING > 0) then {
-    private _signalTrace = missionNamespace getVariable [_transmitterClass + "_signal_trace", []];
-    _signalTrace pushBack _maxSignal;
-    missionNamespace setVariable [_transmitterClass + "_signal_trace", _signalTrace];
+if (!isNil QGVAR(customSignalFunc)) exitWith {
+    _this call GVAR(customSignalFunc);
 };
 
-
-[_Px, _maxSignal];
+_this call FUNC(getSignalCore)

--- a/addons/sys_signal/fnc_getSignalCore.sqf
+++ b/addons/sys_signal/fnc_getSignalCore.sqf
@@ -1,0 +1,78 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Core function for calling the signal calculation (extension) with support for multiple signal models.
+ *
+ * Arguments:
+ * 0: Frequency <NUMBER>
+ * 1: Power <NUMBER>
+ * 2: Receiving Radio ID <STRING>
+ * 3: Transmitting Radio ID <STRING>
+ *
+ * Return Value:
+ * Tuple of power and maximum signal strength <ARRAY>
+ *
+ * Example:
+ * [30, 5000, "ACRE_PRC343_ID_1", "ACRE_PRC343_ID_2"] call acre_sys_signal_fnc_getSignalCore
+ *
+ * Public: No
+ */
+
+params ["_f", "_mW", "_receiverClass", "_transmitterClass"];
+
+private _count = (missionNamespace getVariable [_transmitterClass + "_running_count", 0]) max 0;
+if (_count == 0) then {
+    private _rxAntennas = [_receiverClass] call EFUNC(sys_components,findAntenna);
+    private _txAntennas = [_transmitterClass] call EFUNC(sys_components,findAntenna);
+
+    {
+        private _txAntenna = _x;
+        {
+            private _rxAntenna = _x;
+            private _model = GVAR(signalModel); // TODO: Change models on the fly if compatible (underwater, better frequency matching)
+
+            // Make sure ITWOM is not used for the moment
+            if (_model > SIGNAL_MODEL_ITWOM || {_model < SIGNAL_MODEL_CASUAL}) then {
+                _model = SIGNAL_MODEL_LOS_MULTIPATH;  // Default to LOS Multipath if the model is out of range
+                GVAR(signalModel) = _model;           // And make sure we do not use an invalid mode next time
+            };
+
+            _count = _count + 1;
+            private _id = format ["%1_%2_%3_%4", _transmitterClass, (_txAntenna select 0), _receiverClass, (_rxAntenna select 0)];
+            [
+                "process_signal",
+                [
+                    _model,
+                    _id,
+                    (_txAntenna select 2),
+                    (_txAntenna select 3),
+                    (_txAntenna select 0),
+                    (_rxAntenna select 2),
+                    (_rxAntenna select 3),
+                    (_rxAntenna select 0),
+                    _f,
+                    _mW,
+                    GVAR(terrainScaling),
+                    diag_tickTime,
+                    ACRE_SIGNAL_DEBUGGING,
+                    GVAR(omnidirectionalRadios)
+                ],
+                2,
+                FUNC(handleSignalReturn),
+                [_transmitterClass, _receiverClass]
+            ] call EFUNC(sys_core,callExt);
+        } forEach _rxAntennas;
+    } forEach _txAntennas;
+    missionNamespace setVariable [_transmitterClass + "_running_count", _count];
+};
+private _maxSignal = missionNamespace getVariable [_transmitterClass + "_best_signal", -992];
+private _Px = missionNamespace getVariable [_transmitterClass + "_best_px", 0];
+
+if (ACRE_SIGNAL_DEBUGGING > 0) then {
+    private _signalTrace = missionNamespace getVariable [_transmitterClass + "_signal_trace", []];
+    _signalTrace pushBack _maxSignal;
+    missionNamespace setVariable [_transmitterClass + "_signal_trace", _signalTrace];
+};
+
+
+[_Px, _maxSignal]

--- a/addons/sys_signal/fnc_getSignalCore.sqf
+++ b/addons/sys_signal/fnc_getSignalCore.sqf
@@ -74,5 +74,4 @@ if (ACRE_SIGNAL_DEBUGGING > 0) then {
     missionNamespace setVariable [_transmitterClass + "_signal_trace", _signalTrace];
 };
 
-
 [_Px, _maxSignal]


### PR DESCRIPTION
**When merged this pull request will:**
- Split core signal getter so it can be used in a custom signal function for development, debugging and testing uses (technically also other uses, but not "public" API).
  - Can make it into a proper API function if wanted.
  - Example use-case: Custom signal function that manipulates result of default signal calculation (eg. jamming).