### PR TITLE
Extension - Fix potential named pipe buffer overflow

### DIFF
--- a/extensions/src/ACRE2Core/NamedPipeServer.cpp
+++ b/extensions/src/ACRE2Core/NamedPipeServer.cpp
@@ -212,7 +212,7 @@ acre::Result CNamedPipeServer::sendLoop() {
 acre::Result CNamedPipeServer::readLoop() {
     DWORD cbRead;
 
-    char *mBuffer = (char *)LocalAlloc(LMEM_FIXED, BUFSIZE);
+    char *mBuffer = (char *)LocalAlloc(LMEM_FIXED, BUFSIZE + 1);
     if (mBuffer == nullptr) {
         LOG("LocalAlloc() failed: %d", GetLastError());
     }


### PR DESCRIPTION
There's no room allocated for a terminating 0-byte at the end of mBuffer. This could lead to an off-by-one buffer overflow on line 268. This is fixed by adding room (+1) for a 0-byte on line 215 when performing the buffer allocation.
