### PR TITLE
TeamSpeak - Move plugin log location to writeable location and fix metadata segfault

### DIFF
--- a/extensions/src/ACRE2Core/Engine.cpp
+++ b/extensions/src/ACRE2Core/Engine.cpp
@@ -29,12 +29,17 @@
 #include "setSelectableVoiceCurve.h"
 #include "setSetting.h"
 #include "setTs3ChannelDetails.h"
-
+#include <shlobj.h>
 
 acre::Result CEngine::initialize(IClient *client, IServer *externalServer, std::string fromPipeName, std::string toPipeName) {
 
     if (!g_Log) {
-        g_Log = (Log *)new Log("acre2.log");
+        std::string acrePluginLog{"acre2_plugin.log"};
+        std::array<char, MAX_PATH> appDataPath{""};
+        if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appDataPath.data()))) {
+            acrePluginLog = std::string(appDataPath.data()) + "\\Arma 3\\" + acrePluginLog;
+        }
+        g_Log = (Log *) new Log(acrePluginLog.c_str());
         LOG("* Logging engine initialized.");
     }
     LOG("Configuration Path: {%s\\acre2.ini}", client->getConfigFilePath().c_str());

--- a/extensions/src/ACRE2Core/Engine.h
+++ b/extensions/src/ACRE2Core/Engine.h
@@ -13,8 +13,6 @@
 #include "Log.h"
 
 
-#define ACRE_LOG_PATH "acre2.log"
-
 class CEngine : public TSingleton<CEngine>, public CLockable {
 public:
     CEngine(void) { g_Log = nullptr; };

--- a/extensions/src/ACRE2TS/TS3Client.cpp
+++ b/extensions/src/ACRE2TS/TS3Client.cpp
@@ -118,22 +118,23 @@ acre::Result CTS3Client::exPersistVersion( void ) {
 }
 
 acre::Result CTS3Client::setClientMetadata(const char *const data) {
-    char* clientInfo;
+    char* clientInfo{nullptr};
     anyID myID;
     ts3Functions.getClientID(ts3Functions.getCurrentServerConnectionHandlerID(), &myID);
-    ts3Functions.getClientVariableAsString(ts3Functions.getCurrentServerConnectionHandlerID(), myID, CLIENT_META_DATA, &clientInfo);
-    std::string to_set;
-    std::string_view sharedMsg = clientInfo;
-    const size_t start_pos = sharedMsg.find(START_DATA);
-    const size_t end_pos = sharedMsg.find(END_DATA);
-    if ((start_pos == std::string::npos) || (end_pos == std::string::npos)) {
-        to_set = to_set + START_DATA + data + END_DATA;
-    } else {
-        const std::string before = (std::string)sharedMsg.substr(0, start_pos);
-        const std::string after = (std::string)sharedMsg.substr(end_pos + strlen(END_DATA), std::string::npos);
-        to_set = before + START_DATA + data + END_DATA + after;
+    if (Ts3ErrorType::ERROR_ok == ts3Functions.getClientVariableAsString(ts3Functions.getCurrentServerConnectionHandlerID(), myID, CLIENT_META_DATA, &clientInfo)) {
+        std::string to_set;
+        std::string_view sharedMsg = clientInfo;
+        const size_t start_pos = sharedMsg.find(START_DATA);
+        const size_t end_pos = sharedMsg.find(END_DATA);
+        if ((start_pos == std::string::npos) || (end_pos == std::string::npos)) {
+            to_set = to_set + START_DATA + data + END_DATA;
+        } else {
+            const std::string before = (std::string)sharedMsg.substr(0, start_pos);
+            const std::string after = (std::string)sharedMsg.substr(end_pos + strlen(END_DATA), std::string::npos);
+            to_set = before + START_DATA + data + END_DATA + after;
+        }
+        ts3Functions.setClientSelfVariableAsString(ts3Functions.getCurrentServerConnectionHandlerID(), CLIENT_META_DATA, to_set.c_str());
     }
-    ts3Functions.setClientSelfVariableAsString(ts3Functions.getCurrentServerConnectionHandlerID(), CLIENT_META_DATA, to_set.c_str());
     ts3Functions.freeMemory(clientInfo);
     ts3Functions.flushClientSelfUpdates(ts3Functions.getCurrentServerConnectionHandlerID(), NULL);
     return acre::Result::ok;


### PR DESCRIPTION
Normal non-elevated programs can't write to Program Files 
(e.g. `C:\Program Files\TeamSpeak 3 Client`) due to UAC

This moves the plugin log location to same as arma3's rpt location 
(e.g. `C:\Users\X\AppData\Local\Arma 3\acre2_plugin.log`) which should be writeable

same issue also exists with the `acre2.ini` but I think that's ok because the settings will be loaded by the game

Fix #1109