### PR TITLE
PRC117F/PRC152 - Add missing hashes to `getChannelData` event

### DIFF
--- a/addons/sys_prc117f/radio/fnc_getChannelData.sqf
+++ b/addons/sys_prc117f/radio/fnc_getChannelData.sqf
@@ -41,6 +41,13 @@ switch _channelType do {
         HASH_SET(_return, "TEK", HASH_GET(_channel, "tek"));
         HASH_SET(_return, "trafficRate", HASH_GET(_channel, "trafficRate"));
         HASH_SET(_return, "syncLength", HASH_GET(_channel, "phase"));
+        HASH_SET(_return, "optioncode", HASH_GET(_channel, "optioncode"));
+        HASH_SET(_return, "active", HASH_GET(_channel, "active"));
+        HASH_SET(_return, "rxonly", HASH_GET(_channel, "rxonly"));
+        HASH_SET(_return, "squelch", HASH_GET(_channel, "squelch"));
+        HASH_SET(_return, "channelmode", HASH_GET(_channel, "channelmode"));
+        HASH_SET(_return, "deviation", HASH_GET(_channel, "deviation"));
+        HASH_SET(_reutrn, "name", HASH_GET(_channel, "name"));
     };
 };
 _return

--- a/addons/sys_prc152/radio/fnc_getChannelData.sqf
+++ b/addons/sys_prc152/radio/fnc_getChannelData.sqf
@@ -42,6 +42,12 @@ switch _channelType do {
         HASH_SET(_return, "TEK", HASH_GET(_channel, "tek"));
         HASH_SET(_return, "trafficRate", HASH_GET(_channel, "trafficRate"));
         HASH_SET(_return, "syncLength", HASH_GET(_channel, "phase"));
+        HASH_SET(_return, "optioncode", HASH_GET(_channel, "optioncode"));
+        HASH_SET(_return, "rxonly", HASH_GET(_channel, "rxonly"));
+        HASH_SET(_return, "squelch", HASH_GET(_channel, "squelch"));
+        HASH_SET(_return, "channelmode", HASH_GET(_channel, "channelmode"));
+        HASH_SET(_return, "deviation", HASH_GET(_channel, "deviation"));
+        HASH_SET(_return, "description", HASH_GET(_channel, "description"));
     };
 };
 _return


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Need to pull deviation in a mod I'm working on and I'm having to get hash data in a separate way specifically for it. This makes it easier as its just one event call.
