### PR TITLE
Antenna - Make 1.23M VHF TNC compatible with AN/PRC-152

### DIFF
--- a/addons/sys_antenna/CfgAcreComponents.hpp
+++ b/addons/sys_antenna/CfgAcreComponents.hpp
@@ -86,7 +86,7 @@ class CfgAcreComponents {
         connector = ACRE_CONNECTOR_TNC;
         height = 1.23;
         binaryGainFile = QPATHTOF(binary\Harris_123cm_Whip_gain.aba);
-        compatibleRadios[] = {"ACRE_PRC117F"};
+        compatibleRadios[] = {"ACRE_PRC152", "ACRE_PRC117F"};
     };
 
     class ACRE_270CM_VEH_BNC: ACRE_BaseAntenna {


### PR DESCRIPTION
**When merged this pull request will:**
- Make 1.23M VHF TNC compatible with AN/PRC-152

[`Harris_123cm_Whip.nec`](https://github.com/IDI-Systems/acre2/blob/29e20ea74051eb1274735c8d28a04fa55eaf2ba7/extras/antennas/Harris_123cm_Whip.nec#L1) states this antenna is for both 152 and 117F, so I believe this was an oversight (likely because this system isn't actually exposed to the user). This was found while @Drofseh was making videos for #1117.