### PR TITLE
WIP: Extensions - Add CVSD codec effect for AN/PRC-343

### DIFF
--- a/addons/sys_core/fnc_processRadioSpeaker.sqf
+++ b/addons/sys_core/fnc_processRadioSpeaker.sqf
@@ -92,7 +92,12 @@ if (_okRadios isNotEqualTo []) then {
             _radioVolume = [_x, _radioVolume] call EFUNC(sys_intercom,modifyRadioVolume);
             _radioVolume = _radioVolume * GVAR(globalVolume);
             // acre_player sideChat format["rv: %1", _radioVolume];
+
+            private _channelData = [_receivingRadioid, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
+            private _modulation = HASH_GET(_channelData, "modulation");
+
             private _isLoudspeaker = [_receivingRadioid, "isExternalAudio"] call EFUNC(sys_data,dataEvent);
+
             private _spatialArray = [0,0,0];
             if (!_isLoudspeaker) then {
                 private _spatial = [_receivingRadioid, "getSpatial"] call EFUNC(sys_data,dataEvent);
@@ -100,7 +105,7 @@ if (_okRadios isNotEqualTo []) then {
             };
             // FULL DUPLEX radios, shouldn't be able to hear themselves.
 
-            _params = [_transmittingRadioId, _receivingRadioid, [_signalQuality, _signalDb], [_radioVolume, _signalQuality, _signalModel, _isLoudspeaker, _spatialArray]];
+            _params = [_transmittingRadioId, _receivingRadioid, [_signalQuality, _signalDb], [_radioVolume, _signalQuality, _signalModel, _isLoudspeaker, _spatialArray, _modulation]];
             _unit setVariable ["ACRE_%1CachedSampleParams"+_x, _params];
         } else {
             _params = _unit getVariable ["ACRE_%1CachedSampleParams"+_x, []];

--- a/addons/sys_prc343/radio/fnc_getChannelData.sqf
+++ b/addons/sys_prc343/radio/fnc_getChannelData.sqf
@@ -31,5 +31,6 @@ private _return = HASH_CREATE;
 HASH_SET(_return, "mode", "singleChannelPRR");
 HASH_SET(_return, "frequencyTX", HASH_GET(_channel, "frequencyTX"));
 HASH_SET(_return, "frequencyRX", HASH_GET(_channel, "frequencyRX"));
+HASH_SET(_return, "modulation", "CVSD");
 HASH_SET(_return, "power", 100);
 _return

--- a/addons/sys_prc343/radio/fnc_getCurrentChannelData.sqf
+++ b/addons/sys_prc343/radio/fnc_getCurrentChannelData.sqf
@@ -33,4 +33,5 @@ HASH_SET(_return, "mode", "singleChannelPRR");
 HASH_SET(_return, "frequencyTX", HASH_GET(_currentChannelData, "frequencyTX"));
 HASH_SET(_return, "frequencyRX", HASH_GET(_currentChannelData, "frequencyRX"));
 HASH_SET(_return, "power", 100);
+HASH_SET(_return, "modulation", "CVSD");
 _return

--- a/addons/sys_sem52sl/radio/fnc_getChannelData.sqf
+++ b/addons/sys_sem52sl/radio/fnc_getChannelData.sqf
@@ -48,19 +48,6 @@ private _channelNumber = _eventData;
 private _channels = HASH_GET(_radioData, "channels");
 private _channel = HASHLIST_SELECT(_channels, _channelNumber);
 
-/*
- *  All needed data from the channel hash can be extracted and
- *  consequently written to the _return hash.
- *
- *  Optional:
- *  Here we have the opportunity to add static data to the
- *  channel data hash. This can be useful if the radio has
- *  only one power setting. While this data can be stored in
- *  the _radioData -- channels hash it would only add unneccessary
- *  data as the value can't be changed ingame.
- *  For our example, we also got the "mode" parameter set to
- *  "singleChannel" for all channels.
-*/
 private _return = HASH_CREATE;
 HASH_SET(_return, "mode", GVAR(channelMode));
 HASH_SET(_return, "frequencyTX", HASH_GET(_channel, "frequencyTX"));

--- a/addons/sys_sem52sl/radio/fnc_getCurrentChannelData.sqf
+++ b/addons/sys_sem52sl/radio/fnc_getCurrentChannelData.sqf
@@ -49,19 +49,6 @@ ISNILS(_channelNumber,0);
 private _channels = HASH_GET(_radioData, "channels");
 private _channel = HASHLIST_SELECT(_channels, _channelNumber);
 
-/*
- *  All needed data from the channel hash can be extracted and
- *  consequently written to the _return hash.
- *
- *  Optional:
- *  Here we have the opportunity to add static data to the
- *  channel data hash. This can be useful if the radio has
- *  only one power setting. While this data can be stored in
- *  the _radioData -- channels hash it would only add unneccessary
- *  data as the value can't be changed ingame.
- *  For our example, we also got the "mode" parameter set to
- *  "singleChannel" for all channels.
-*/
 private _return = HASH_CREATE;
 HASH_SET(_return, "mode", GVAR(channelMode));
 HASH_SET(_return, "frequencyTX", HASH_GET(_channel, "frequencyTX"));

--- a/addons/sys_sem70/radio/fnc_getChannelData.sqf
+++ b/addons/sys_sem70/radio/fnc_getChannelData.sqf
@@ -48,19 +48,6 @@ private _channelNumber = _eventData;
 private _channels = HASH_GET(_radioData, "channels");
 private _channel = HASHLIST_SELECT(_channels, _channelNumber);
 private _manualChannel = HASH_GET(_radioData, "manualChannelSelection");
-/*
- *  All needed data from the channel hash can be extracted and
- *  consequently written to the _return hash.
- *
- *  Optional:
- *  Here we have the opportunity to add static data to the
- *  channel data hash. This can be useful if the radio has
- *  only one power setting. While this data can be stored in
- *  the _radioData -- channels hash it would only add unneccessary
- *  data as the value can't be changed ingame.
- *  For our example, we also got the "mode" parameter set to
- *  "singleChannel" for all channels.
-*/
 
 private _return = HASH_CREATE;
 
@@ -85,6 +72,11 @@ if (_manualChannel isEqualTo 1) then {
     HASH_SET(_return, "frequencies", HASH_GET(_channel, "frequencies"));
     HASH_SET(_return, "frequencyTX", HASH_GET(_channel, "frequencyTX"));
     HASH_SET(_return, "frequencyRX", HASH_GET(_channel, "frequencyRX"));
+    HASH_SET(_return, "CTCSSTx", HASH_GET(_radioData, "CTCSS"));
+    HASH_SET(_return, "CTCSSRx", HASH_GET(_radioData, "CTCSS"));
+    HASH_SET(_return, "modulation", HASH_GET(_radioData, "modulation"));
+    HASH_SET(_return, "encryption", HASH_GET(_radioData, "encryption"));
+    HASH_SET(_return, "squelch", HASH_GET(_radioData, "squelch"));
     if (HASH_GET(_radioData, "powerSource") == "VAU") then {
         HASH_SET(_return, "power", (HASH_GET(_radioData, "power") * SEM90_RACK_POWER_MULTIPLIER));
     } else {

--- a/addons/sys_sem70/radio/fnc_getCurrentChannelData.sqf
+++ b/addons/sys_sem70/radio/fnc_getCurrentChannelData.sqf
@@ -49,19 +49,6 @@ ISNILS(_channelNumber,0);
 private _channels = HASH_GET(_radioData, "channels");
 private _channel = HASHLIST_SELECT(_channels, _channelNumber);
 private _manualChannel = HASH_GET(_radioData, "manualChannelSelection");
-/*
- *  All needed data from the channel hash can be extracted and
- *  consequently written to the _return hash.
- *
- *  Optional:
- *  Here we have the opportunity to add static data to the
- *  channel data hash. This can be useful if the radio has
- *  only one power setting. While this data can be stored in
- *  the _radioData -- channels hash it would only add unneccessary
- *  data as the value can't be changed ingame.
- *  For our example, we also got the "mode" parameter set to
- *  "singleChannel" for all channels.
-*/
 
 private _return = HASH_CREATE;
 
@@ -82,11 +69,11 @@ if (_manualChannel isEqualTo 1) then {
     HASH_SET(_return, "frequencies", HASH_GET(_channel, "frequencies"));
     HASH_SET(_return, "frequencyTX", HASH_GET(_channel, "frequencyTX"));
     HASH_SET(_return, "frequencyRX", HASH_GET(_channel, "frequencyRX"));
-    //HASH_SET(_return, "CTCSSTx", HASH_GET(_radioData, "CTCSS"));
-    //HASH_SET(_return, "CTCSSRx", HASH_GET(_radioData, "CTCSS"));
-    //HASH_SET(_return, "modulation", HASH_GET(_radioData, "modulation"));
-    //HASH_SET(_return, "encryption", HASH_GET(_radioData, "encryption"));
+    HASH_SET(_return, "CTCSSTx", HASH_GET(_radioData, "CTCSS"));
+    HASH_SET(_return, "CTCSSRx", HASH_GET(_radioData, "CTCSS"));
+    HASH_SET(_return, "modulation", HASH_GET(_radioData, "modulation"));
+    HASH_SET(_return, "encryption", HASH_GET(_radioData, "encryption"));
     HASH_SET(_return, "power", HASH_GET(_radioData, "power"));
-    //HASH_SET(_return, "squelch", HASH_GET(_radioData, "squelch"));
+    HASH_SET(_return, "squelch", HASH_GET(_radioData, "squelch"));
 };
 _return

--- a/extensions/src/ACRE2Core/FilterPosition.cpp
+++ b/extensions/src/ACRE2Core/FilterPosition.cpp
@@ -57,22 +57,22 @@ acre::Result CFilterPosition::process(short* samples, int sampleCount, int chann
     DSPSettings.DstChannelCount = channels;
     DSPSettings.pMatrixCoefficients = Matrix;
 
-    speaker_position.x = params->getParam("speakerPosX");
-    speaker_position.y = params->getParam("speakerPosY");
-    speaker_position.z = params->getParam("speakerPosZ");
+    speaker_position.x = params->getParam<float>("speakerPosX");
+    speaker_position.y = params->getParam<float>("speakerPosY");
+    speaker_position.z = params->getParam<float>("speakerPosZ");
 
     Emitter.Position = speaker_position;
 
-    vector_speakerDirection.x = params->getParam("headVectorX");
-    vector_speakerDirection.y = params->getParam("headVectorY");
-    vector_speakerDirection.z = params->getParam("headVectorZ");
+    vector_speakerDirection.x = params->getParam<float>("headVectorX");
+    vector_speakerDirection.y = params->getParam<float>("headVectorY");
+    vector_speakerDirection.z = params->getParam<float>("headVectorZ");
 
     Emitter.OrientFront = vector_speakerDirection;
     Emitter.OrientTop = this->getUpVector(vector_speakerDirection);
     Emitter.Velocity = X3DAUDIO_VECTOR( 0, 0, 0 );
     Emitter.ChannelCount = 1;
 
-    if (params->getParam("isWorld") == POSITIONAL_EFFECT_ISWORLD) {
+    if (params->getParam<bool>("isWorld")) {
         listener_position.x = CEngine::getInstance()->getSelf()->getWorldPosition().x;
         listener_position.y = CEngine::getInstance()->getSelf()->getWorldPosition().y;
         listener_position.z = CEngine::getInstance()->getSelf()->getWorldPosition().z;
@@ -82,16 +82,16 @@ acre::Result CFilterPosition::process(short* samples, int sampleCount, int chann
         vector_listenerDirection.y = CEngine::getInstance()->getSelf()->getHeadVector().y;
         vector_listenerDirection.z = CEngine::getInstance()->getSelf()->getHeadVector().z;
 
-        if (params->getParam("speakingType") == static_cast<float32_t>(acre::Speaking::direct)) {
+        if (params->getParam<acre::Speaking>("speakingType") == acre::Speaking::direct) {
             /*if(CEngine::getInstance()->getSoundEngine()->getCurveModel() == acre::CurveModel::amplitude) {
                 Emitter.CurveDistanceScaler = (player->getAmplitudeCoef())*(CEngine::getInstance()->getSoundEngine()->getCurveScale());
                 Emitter.pVolumeCurve = NULL;
             } else */
             if (CEngine::getInstance()->getSoundEngine()->getCurveModel() == acre::CurveModel::selectableA) {
-                Emitter.CurveDistanceScaler = 1.0f*(params->getParam("curveScale"));
+                Emitter.CurveDistanceScaler = 1.0f * params->getParam<float>("curveScale");
                 Emitter.pVolumeCurve = NULL;
             } else if (CEngine::getInstance()->getSoundEngine()->getCurveModel() == acre::CurveModel::selectableB) {
-                Emitter.CurveDistanceScaler = 1.0f*(params->getParam("curveScale"));
+                Emitter.CurveDistanceScaler = 1.0f * params->getParam<float>("curveScale");
                 Emitter.pVolumeCurve = (X3DAUDIO_DISTANCE_CURVE *)&distanceCurve;
             } else {
                 Emitter.CurveDistanceScaler = 1.0f;

--- a/extensions/src/ACRE2Core/Player.cpp
+++ b/extensions/src/ACRE2Core/Player.cpp
@@ -26,7 +26,7 @@ void CPlayer::clearSoundChannels() {
     CEngine::getInstance()->getSoundEngine()->getSoundMixer()->lock();
     for (size_t i = 0; i < channels.size(); ++i) {
         if (channels[i]) {
-            CEngine::getInstance()->getSoundEngine()->getSoundMixer()->releaseChannel(channels[i]);
+            CEngine::getInstance()->getSoundEngine()->getSoundMixer()->releaseChannel(&channels[i]);
         }
     }
     CEngine::getInstance()->getSoundEngine()->getSoundMixer()->unlock();

--- a/extensions/src/ACRE2Core/Player.h
+++ b/extensions/src/ACRE2Core/Player.h
@@ -33,7 +33,7 @@ public:
     DECLARE_MEMBER(acre::volume_t, PreviousVolume);
     DECLARE_MEMBER(acre::volume_t, SignalQuality);
     DECLARE_MEMBER(char *, SignalModel);
-    DECLARE_MEMBER(BOOL, IsLoudSpeaker);
+    DECLARE_MEMBER(bool, IsLoudSpeaker);
 
     DECLARE_MEMBER(std::string, CurrentRadioId);
 

--- a/extensions/src/ACRE2Core/PositionalMixdownEffect.h
+++ b/extensions/src/ACRE2Core/PositionalMixdownEffect.h
@@ -5,16 +5,13 @@
 #include "SoundMixdownEffect.h"
 #include "FilterPosition.h"
 
-#define POSITIONAL_EFFECT_ISLOCAL    0x00000000
-#define POSITIONAL_EFFECT_ISWORLD    0x00000001
-
 class CPositionalMixdownEffect : public CSoundMixdownEffect {
 private:
     static CFilterPosition positionFilter;
 public:
     CPositionalMixdownEffect() {
-        this->setParam("isWorld", POSITIONAL_EFFECT_ISWORLD);
-        this->setParam("isLoudSpeaker", 0.0f);
+        this->setParam("isWorld", true);
+        this->setParam("isLoudSpeaker", false);
         this->setParam("speakerPosX", 0.0f);
         this->setParam("speakerPosY", 0.0f);
         this->setParam("speakerPosZ", 0.0f);
@@ -22,7 +19,7 @@ public:
         this->setParam("headVectorY", 1.0f);
         this->setParam("headVectorZ", 0.0f);
         this->setParam("curveScale", 1.0f);
-        this->setParam("speakingType", static_cast<float32_t>(acre::Speaking::direct));
+        this->setParam("speakingType", acre::Speaking::direct);
     };
     void process(short* samples, int sampleCount, int channels, const unsigned int speakerMask) {
         this->positionFilter.process(samples, sampleCount, channels, speakerMask, this);

--- a/extensions/src/ACRE2Core/RadioEffect.cpp
+++ b/extensions/src/ACRE2Core/RadioEffect.cpp
@@ -9,10 +9,15 @@ CRadioEffect::~CRadioEffect() {
     delete radioFilter;
 }
 void CRadioEffect::process(short *samples, int sampleCount) {
-    
     bool noise = true;
-    if (this->getParam("disableNoise"))
+    if (this->getParam<bool>("disableNoise")) {
         noise = false;
+    }
 
-    this->radioFilter->process(samples, sampleCount, 1, static_cast<acre::volume_t>(this->getParam("signalQuality")), noise);
+    this->radioFilter->process(
+        samples,
+        sampleCount,
+        1,
+        this->getParam<acre::volume_t>("signalQuality"),
+        noise);
 };

--- a/extensions/src/ACRE2Core/RadioEffectAnalogue.cpp
+++ b/extensions/src/ACRE2Core/RadioEffectAnalogue.cpp
@@ -1,14 +1,14 @@
-#include "RadioEffect.h"
+#include "RadioEffectAnalogue.h"
 
 
-CRadioEffect::CRadioEffect() {
+CRadioEffectAnalogue::CRadioEffectAnalogue() {
     radioFilter = new CFilterRadio();
     this->setParam("signalQuality", 0.0f);
 };
-CRadioEffect::~CRadioEffect() {
+CRadioEffectAnalogue::~CRadioEffectAnalogue() {
     delete radioFilter;
 }
-void CRadioEffect::process(short *samples, int sampleCount) {
+void CRadioEffectAnalogue::process(short *samples, int sampleCount) {
     bool noise = true;
     if (this->getParam<bool>("disableNoise")) {
         noise = false;

--- a/extensions/src/ACRE2Core/RadioEffectAnalogue.h
+++ b/extensions/src/ACRE2Core/RadioEffectAnalogue.h
@@ -6,11 +6,11 @@
 #include "SoundMonoEffect.h"
 #include "FilterRadio.h"
 
-class CRadioEffect : public CSoundMonoEffect {
+class CRadioEffectAnalogue : public CSoundMonoEffect {
 private:
     CFilterRadio *radioFilter;
 public:
-    CRadioEffect();
-    ~CRadioEffect();
+    CRadioEffectAnalogue();
+    ~CRadioEffectAnalogue();
     void process(short *samples, int sampleCount);
 };

--- a/extensions/src/ACRE2Core/RadioEffectCVSD.cpp
+++ b/extensions/src/ACRE2Core/RadioEffectCVSD.cpp
@@ -1,0 +1,100 @@
+#include <climits>
+
+#include "RadioEffectCVSD.h"
+
+CRadioEffectCVSD::CVSDDecoder::CVSDDecoder() {
+    lookback_register.reserve(lookback);
+}
+
+short CRadioEffectCVSD::CVSDDecoder::decode(bool sample) {
+    // shift the new sample into the lookback shift register
+    if (lookback_register.size() < lookback) {
+        lookback_register.emplace_back();
+    }
+    std::copy(
+        std::next(lookback_register.rbegin()),
+        lookback_register.rend(),
+        lookback_register.rbegin());
+    if (!lookback_register.empty()) {
+        lookback_register[0] = sample;
+    }
+
+    if (lookback_register.size() >= lookback) {
+        // adjust delta
+        bool positive_run = true;
+        bool negative_run = true;
+        for (bool val: lookback_register) {
+            positive_run &= val;
+            negative_run &= !val;
+        }
+        if (positive_run || negative_run) {
+            delta = std::min(delta *= delta_coef, delta_max);
+        } else {
+            delta = std::max(delta /= delta_coef, delta_min);
+        }
+    }
+
+    // adjust reference
+    const short previous_reference = reference;
+    if (sample) {
+        reference += delta;
+        if (reference < previous_reference) {
+            reference = SHRT_MAX;
+        }
+    } else {
+        reference -= delta;
+        if (reference > previous_reference) {
+            reference = SHRT_MIN;
+        }
+    }
+    reference *= decay;
+
+    return reference;
+}
+
+bool CRadioEffectCVSD::CVSDEncoder::encode(short sample) {
+    const bool ret = sample > reference;
+    reference = decoder.decode(ret);
+    return ret;
+}
+
+CRadioEffectCVSD::CRadioEffectCVSD() {
+    filter.setup(4, TS_SAMPLE_RATE, CVSD_RATE / 2, 1);
+}
+
+// this is a somewhat arbitrary function derived empirically to match the intelligibility
+// of the existing signalQuality metric at a variety of distances.
+float CRadioEffectCVSD::quality_to_ber(float signalQuality) {
+    return pow(0.4 * (signalQuality - 1), 2);
+}
+
+void CRadioEffectCVSD::process(short *samples, int sampleCount) {
+    // anti-aliasing LPF prior to downsampling
+    filter.process(sampleCount, &samples);
+
+    for (std::size_t i = 0; i < sampleCount; i += TS_SAMPLE_RATE / CVSD_RATE) {
+        bool coded = encoder.encode(samples[i]);
+
+        // introduce bit errors
+        const float bit_error_rate = quality_to_ber(getParam<float>("signalQuality"));
+        if ((float) rand() / RAND_MAX < bit_error_rate) {
+            coded ^= 1;
+        }
+
+        samples[i] = decoder.decode(coded);
+
+        // boost the volume
+        if (samples[i] < SHRT_MAX / VOL_BOOST) {
+            samples[i] *= VOL_BOOST;
+        } else {
+            samples[i] = SHRT_MAX;
+        }
+
+        // upsample back to 48kHz
+        for (std::size_t j = 1; j < TS_SAMPLE_RATE / CVSD_RATE; j++) {
+            samples[i + j] = samples[i];
+        }
+    }
+
+    filter.process(sampleCount, &samples);
+}

--- a/extensions/src/ACRE2Core/RadioEffectCVSD.h
+++ b/extensions/src/ACRE2Core/RadioEffectCVSD.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <climits>
 
 #include "compat.h"
 
@@ -20,10 +21,11 @@ private:
     private:
         std::vector<bool> lookback_register;
         const std::size_t lookback = 3;
-        const short delta_min = 32;
-        const short delta_max = delta_min * 16;
-        const short delta_coef = 2;
-        const float decay = 0.95;
+        const short delta_min = 256;
+        const short delta_max = 16 * delta_min;
+        const short delta_step = delta_min;
+        const float delta_coef = std::exp(-1.0f / (5e-3 * CVSD_RATE));
+        const float decay = std::exp(-1.0f / (1e-3 * CVSD_RATE));
         
         short reference = 0;
         short delta = delta_min;
@@ -46,12 +48,12 @@ private:
 
     CVSDEncoder encoder;
     CVSDDecoder decoder;
-    Dsp::SimpleFilter<Dsp::ChebyshevII::LowPass<4>, 1> filter;
+    Dsp::SimpleFilter<Dsp::ChebyshevI::LowPass<8>, 1> input_filter;
+    Dsp::SimpleFilter<Dsp::ChebyshevI::LowPass<8>, 1> output_filter;
 
 public:
     CRadioEffectCVSD();
 
     static float quality_to_ber(float signalQuality);
-
     void process(short* samples, int sampleCount);
 };

--- a/extensions/src/ACRE2Core/RadioEffectCVSD.h
+++ b/extensions/src/ACRE2Core/RadioEffectCVSD.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <vector>
+
+#include "compat.h"
+
+#include "SoundMonoEffect.h"
+#include "AcreDsp.h"
+
+// the CVSD rate must be a factor of the sample rate
+#define TS_SAMPLE_RATE 48000
+#define CVSD_RATE 16000
+
+// this is chosen to match the volume of other radio effects
+#define VOL_BOOST 3
+
+class CRadioEffectCVSD : public CSoundMonoEffect {
+private:
+    class CVSDDecoder {
+    private:
+        std::vector<bool> lookback_register;
+        const std::size_t lookback = 3;
+        const short delta_min = 32;
+        const short delta_max = delta_min * 16;
+        const short delta_coef = 2;
+        const float decay = 0.95;
+        
+        short reference = 0;
+        short delta = delta_min;
+        
+    public:
+        CVSDDecoder();
+        
+        short decode(bool sample);
+    };
+
+    class CVSDEncoder {
+    private:
+        CVSDDecoder decoder;
+
+        short reference = 0;
+
+    public:
+        bool encode(short sample);
+    };
+
+    CVSDEncoder encoder;
+    CVSDDecoder decoder;
+    Dsp::SimpleFilter<Dsp::ChebyshevII::LowPass<4>, 1> filter;
+
+public:
+    CRadioEffectCVSD();
+
+    static float quality_to_ber(float signalQuality);
+
+    void process(short* samples, int sampleCount);
+};

--- a/extensions/src/ACRE2Core/SoundMixdownEffect.h
+++ b/extensions/src/ACRE2Core/SoundMixdownEffect.h
@@ -4,15 +4,17 @@
 #include "Lockable.h"
 #include <string>
 #include <map>
+#include <any>
 #include <concurrent_unordered_map.h>
 
 class CSoundMixdownEffect : public CLockable {
 private:
-    concurrency::concurrent_unordered_map<std::string, float> paramMap;
+    concurrency::concurrent_unordered_map<std::string, std::any> paramMap;
 public:
     CSoundMixdownEffect() { };
     ~CSoundMixdownEffect()  { };
     virtual void process(short* samples, int sampleCount, int channels, const unsigned int speakerMask) = 0;
-    void setParam(std::string paramName, float value) { paramMap[paramName] = value; };
-    float getParam(std::string paramName) { return paramMap[paramName]; };
+    void setParam(std::string paramName, std::any value) { paramMap[paramName] = value; };
+    template <typename T>
+    T getParam(std::string paramName) { return std::any_cast<T>(paramMap[paramName]); };
 };

--- a/extensions/src/ACRE2Core/SoundMixer.cpp
+++ b/extensions/src/ACRE2Core/SoundMixer.cpp
@@ -87,7 +87,7 @@ void CSoundMixer::mixDown(short* samples, int sampleCount, int channels, const u
     }
     if (cleanUp.size() > 0) {
         for (auto it = cleanUp.begin(); it != cleanUp.end(); ++it) {
-            this->releaseChannel((CSoundChannelMono *)*it);
+            this->releaseChannel((CSoundChannelMono **)*it);
         }
     }
     delete monoSamples;
@@ -95,13 +95,13 @@ void CSoundMixer::mixDown(short* samples, int sampleCount, int channels, const u
     this->unlock();
 }
 
-bool CSoundMixer::releaseChannel(CSoundChannelMono *releaseChannel) { 
+bool CSoundMixer::releaseChannel(CSoundChannelMono **releaseChannel) { 
     this->lock();
-    if (this->channelList.find(releaseChannel) != this->channelList.end()) {
-        this->channelList.unsafe_erase(releaseChannel); 
-        if (releaseChannel)
-            delete releaseChannel;
-        releaseChannel = NULL;
+    if (this->channelList.find(*releaseChannel) != this->channelList.end()) {
+        this->channelList.unsafe_erase(*releaseChannel); 
+        if (*releaseChannel)
+            delete *releaseChannel;
+        *releaseChannel = NULL;
     }
     this->unlock();
     return true; 

--- a/extensions/src/ACRE2Core/SoundMixer.h
+++ b/extensions/src/ACRE2Core/SoundMixer.h
@@ -18,7 +18,7 @@ public:
     bool acquireChannel(CSoundChannelMono **returnChannel, int bufferSize);
     bool acquireChannel(CSoundChannelMono **returnChannel, int bufferSize, bool singleShot);
 
-    bool releaseChannel(CSoundChannelMono *releaseChannel);
+    bool releaseChannel(CSoundChannelMono **releaseChannel);
     void mixDown(short* samples, int sampleCount, int channels, const unsigned int speakerMask);
 
 };

--- a/extensions/src/ACRE2Core/SoundMonoChannel.cpp
+++ b/extensions/src/ACRE2Core/SoundMonoChannel.cpp
@@ -1,6 +1,7 @@
 #include "SoundMonoChannel.h"
 
-#include "RadioEffect.h"
+#include "RadioEffectAnalogue.h"
+#include "RadioEffectCVSD.h"
 #include "VolumeEffect.h"
 #include "BabbelEffect.h"
 #include "PositionalMixdownEffect.h"
@@ -77,8 +78,11 @@ CSoundMonoEffect * CSoundChannelMono::setEffectInsert(int index, std::string typ
     if (type == "acre_volume") {
         this->effects[index] = new CVolumeEffect();
         return this->effects[index];
-    } else if (type == "acre_radio") {
-        this->effects[index] = new CRadioEffect();
+    } else if (type == "acre_radio_analogue") {
+        this->effects[index] = new CRadioEffectAnalogue();
+        return this->effects[index];
+    } else if (type == "acre_radio_cvsd") {
+        this->effects[index] = new CRadioEffectCVSD();
         return this->effects[index];
     } else if (type == "acre_babbel") {
         this->effects[index] = new CBabbelEffect();

--- a/extensions/src/ACRE2Core/SoundMonoChannel.cpp
+++ b/extensions/src/ACRE2Core/SoundMonoChannel.cpp
@@ -7,8 +7,10 @@
 #include "Log.h"
 
 void CSoundChannelMono::init( int length, bool singleShot ) {
-    for (int i = 0; i < 8; ++i) {
+    for (int i = 0; i < effects.size(); ++i) {
         this->effects[i] = NULL;
+    }
+    for (int i = 0; i < mixdownEffects.size(); ++i) {
         this->mixdownEffects[i] = NULL;
     }
     this->bufferMaxSize = length;
@@ -36,7 +38,7 @@ CSoundChannelMono::~CSoundChannelMono() {
         delete this->buffer;
         this->buffer = NULL;
     }
-    for (int i = 0; i < 8; ++i) {
+    for (int i = 0; i < effects.size(); ++i) {
         if (effects[i])
             delete effects[i];
         if (mixdownEffects[i])
@@ -68,7 +70,7 @@ int CSoundChannelMono::Out(short *samples, int sampleCount) {
 }
 
 CSoundMonoEffect * CSoundChannelMono::setEffectInsert(int index, std::string type) {
-    if (index > 7)
+    if (index >= effects.size())
         return NULL;
     if (this->effects[index])
         delete this->effects[index];
@@ -85,20 +87,24 @@ CSoundMonoEffect * CSoundChannelMono::setEffectInsert(int index, std::string typ
 }
 
 CSoundMonoEffect * CSoundChannelMono::getEffectInsert(int index) {
-    if (index > 7)
+    if (index >= effects.size())
         return NULL;
     return this->effects[index];
 }
 
 void CSoundChannelMono::clearEffectInsert(int index) {
-    if (index > 7)
+    if (index >= effects.size())
         return;
     if (this->effects[index])
         delete this->effects[index];
 }
 
+std::size_t CSoundChannelMono::maxEffectInserts() {
+    return this->effects.size();
+}
+
 CSoundMixdownEffect * CSoundChannelMono::setMixdownEffectInsert(int index, std::string type) {
-    if (index > 7)
+    if (index >= mixdownEffects.size())
         return NULL;
     if (this->mixdownEffects[index])
         delete this->mixdownEffects[index];
@@ -110,7 +116,18 @@ CSoundMixdownEffect * CSoundChannelMono::setMixdownEffectInsert(int index, std::
 }
 
 CSoundMixdownEffect * CSoundChannelMono::getMixdownEffectInsert(int index) {
-    if (index > 7)
+    if (index >= mixdownEffects.size())
         return NULL;
     return this->mixdownEffects[index];
+}
+
+void CSoundChannelMono::clearMixdownEffectInsert(int index) {
+    if (index >= mixdownEffects.size())
+        return;
+    if (this->mixdownEffects[index])
+        delete this->mixdownEffects[index];
+}
+
+std::size_t CSoundChannelMono::maxMixdownEffectInserts() {
+    return this->mixdownEffects.size();
 }

--- a/extensions/src/ACRE2Core/SoundMonoChannel.h
+++ b/extensions/src/ACRE2Core/SoundMonoChannel.h
@@ -31,9 +31,14 @@ public:
     int Out(short *samples, int sampleCount);
     int GetCurrentBufferSize() { return this->bufferLength-this->bufferPos; };
     bool IsOneShot() { return this->oneShot; };
+
     CSoundMonoEffect * setEffectInsert(int index, std::string type);
     CSoundMonoEffect * getEffectInsert(int index);
+    void clearEffectInsert(int index);
+    std::size_t maxEffectInserts();
+
     CSoundMixdownEffect * setMixdownEffectInsert(int index, std::string type);
     CSoundMixdownEffect * getMixdownEffectInsert(int index);
-    void clearEffectInsert(int index);
+    void clearMixdownEffectInsert(int index);
+    std::size_t maxMixdownEffectInserts();
 };

--- a/extensions/src/ACRE2Core/SoundMonoEffect.h
+++ b/extensions/src/ACRE2Core/SoundMonoEffect.h
@@ -4,21 +4,23 @@
 #include "Lockable.h"
 #include <string>
 #include <map>
+#include <any>
 #include <concurrent_unordered_map.h>
 
 class CSoundMonoEffect : public CLockable {
 private:
-    concurrency::concurrent_unordered_map<std::string, float> paramMap;
+    concurrency::concurrent_unordered_map<std::string, std::any> paramMap;
 public:
     CSoundMonoEffect() { };
     ~CSoundMonoEffect() { };
     virtual void process(short *samples, int sampleCount) = 0;
-    void setParam(std::string paramName, float value) { paramMap[paramName] = value; };
-    float getParam(std::string paramName) {
+    void setParam(std::string paramName, std::any value) { paramMap[paramName] = value; };
+    template <typename T>
+    T getParam(std::string paramName) {
         if (paramMap.find(paramName) != paramMap.end()) {
-            return paramMap[paramName];
+            return std::any_cast<T>(paramMap[paramName]);
         } else {
-            return 0.0f;
+            return T();
         }
     };
 };

--- a/extensions/src/ACRE2Core/SoundPlayback.cpp
+++ b/extensions/src/ACRE2Core/SoundPlayback.cpp
@@ -72,10 +72,10 @@ acre::Result CSoundPlayback::playSound(std::string id, acre::vec3_fp32_t positio
         tempChannel->getMixdownEffectInsert(0)->setParam("headVectorZ", direction.z);
 
         if (isWorld) {
-            tempChannel->getMixdownEffectInsert(0)->setParam("isWorld", 0x00000001);
-            tempChannel->getMixdownEffectInsert(0)->setParam("speakingType", static_cast<float32_t>(acre::Speaking::radio));
+            tempChannel->getMixdownEffectInsert(0)->setParam("isWorld", true);
+            tempChannel->getMixdownEffectInsert(0)->setParam("speakingType", acre::Speaking::radio);
         } else {
-            tempChannel->getMixdownEffectInsert(0)->setParam("isWorld", 0x00000000);
+            tempChannel->getMixdownEffectInsert(0)->setParam("isWorld", false);
         }
 
         tempChannel->In((short *)waveFile.GetData(), waveFile.GetSize()/sizeof(short));

--- a/extensions/src/ACRE2Core/VolumeEffect.h
+++ b/extensions/src/ACRE2Core/VolumeEffect.h
@@ -15,7 +15,13 @@ public:
     };
 
     void process(short *samples, int sampleCount) {
-        this->volumeFilter.process(samples, sampleCount, 1, static_cast<acre::volume_t>(this->getParam("volume")), static_cast<acre::volume_t>(this->getParam("previousVolume")));
-        this->setParam("previousVolume", this->getParam("volume"));
+        this->volumeFilter.process(
+            samples,
+            sampleCount,
+            1,
+            this->getParam<acre::volume_t>("volume"),
+            this->getParam<acre::volume_t>("previousVolume"));
+
+        this->setParam("previousVolume", this->getParam<acre::volume_t>("volume"));
     };
 };

--- a/extensions/src/ACRE2Core/updateSpeakingData.h
+++ b/extensions/src/ACRE2Core/updateSpeakingData.h
@@ -49,7 +49,7 @@ RPC_FUNCTION(updateSpeakingData) {
 
                 acre::Speaking speakingTypeEnum;
                 if (speakingType == "i") {
-                    channel->setEffectInsert(2, "acre_radio");
+                    channel->setEffectInsert(2, "acre_radio_analogue");
                     channel->getEffectInsert(2)->setParam("disableNoise", true);
                     channel->getEffectInsert(2)->setParam("signalQuality", 1.0f);
                     speakingTypeEnum = acre::Speaking::intercom;
@@ -99,9 +99,14 @@ RPC_FUNCTION(updateSpeakingData) {
                     channel->setEffectInsert(channel->maxEffectInserts() - 1, "acre_volume");
                     channel->getEffectInsert(channel->maxEffectInserts() - 1)->setParam("volume", volume);
 
-                    channel->setEffectInsert(2, "acre_radio");
-                    channel->getEffectInsert(2)->setParam("disableNoise", false);
-                    channel->getEffectInsert(2)->setParam("signalQuality", signalQuality);
+                    const std::string modulation = (char*) vMessage->getParameter(11 + i*8);
+                    if (modulation == "FM" || modulation == "AM" || modulation == "NB") {
+                        channel->setEffectInsert(2, "acre_radio_analogue");
+                        channel->getEffectInsert(2)->setParam("disableNoise", false);
+                        channel->getEffectInsert(2)->setParam("signalQuality", signalQuality);
+                    } else if (modulation == "CVSD") {
+                        channel->setEffectInsert(2, "acre_radio_cvsd");
+                    }
 
                     channel->setMixdownEffectInsert(0, "acre_positional");
                     channel->getMixdownEffectInsert(0)->setParam("speakingType", acre::Speaking::radio);
@@ -110,10 +115,14 @@ RPC_FUNCTION(updateSpeakingData) {
                 if (channel) {
                     channel->getEffectInsert(channel->maxEffectInserts() - 1)->setParam("volume", vMessage->getParameterAsFloat(4 + (i * 8)));
 
-                    channel->getEffectInsert(2)->setParam("disableNoise", false);
-                    channel->getEffectInsert(2)->setParam("signalQuality", vMessage->getParameterAsFloat(5 + (i * 8)));
-                    channel->getEffectInsert(2)->setParam("signalModel", vMessage->getParameterAsFloat(6 + (i * 8)));
-                    channel->getEffectInsert(2)->setParam("modulation", vMessage->getParameter(11 + (i * 8)));
+                    const std::string modulation = (char*) vMessage->getParameter(11 + i*8);
+                    if (modulation == "FM" || modulation == "AM" || modulation == "NB") {
+                        channel->getEffectInsert(2)->setParam("disableNoise", false);
+                        channel->getEffectInsert(2)->setParam("signalQuality", vMessage->getParameterAsFloat(5 + (i * 8)));
+                        channel->getEffectInsert(2)->setParam("signalModel", vMessage->getParameterAsFloat(6 + (i * 8)));
+                    } else if (modulation == "CVSD") {
+                        channel->getEffectInsert(2)->setParam("signalQuality", vMessage->getParameterAsFloat(5 + (i * 8)));
+                    }
 
                     const bool isLoudSpeaker = vMessage->getParameterAsInt(7 + (i * 8));
                     channel->getMixdownEffectInsert(0)->setParam("isLoudSpeaker", isLoudSpeaker);


### PR DESCRIPTION
**When merged this pull request will:**
- Add a new radio effect for the AN/PRC-343. This radio effect implements [Continuously Variable Slope Delta Modulation](https://en.wikipedia.org/wiki/Continuously_variable_slope_delta_modulation), as the radio does in real life (the sources for this online are scarce, but I'm fairly certain of this). Signal degradation is also simulated by flipping bits in the encoded bit stream. [Here is a demo of the effect](https://youtu.be/9bRBxkWccH0)*.
- Make various changes to the TS plugin to enable different radios to use different effects.

Given I've done the work to enable it, I may make more changes to the effects so the other radios are more distinct. I think the analogue radios could do with some tweaking to make their effects a bit more realistic. The AN/PRC-154 uses the SRW which I believe uses [MELPe](https://youtu.be/UM9RY9Evw48?t=173), however this algorithm is much more complex than CVSD so I'm not sure I'll have the time.

Feedback is welcome, I'm aware the new effect is much worse quality than the current one, but I think it's much more realistic.

\* The effect has changed since this demo was posted. See the comments for more up-to-date demos.