### PR TITLE
Core - Fix compartment detection for non-local units

### DIFF
--- a/addons/sys_core/fnc_getCompartment.sqf
+++ b/addons/sys_core/fnc_getCompartment.sqf
@@ -24,16 +24,15 @@ private _defaultCompartment = "";
 if (_vehicle != _unit) then {
     private _defaultCompartment = "Compartment1";
     private _cfg = configOf _vehicle;
-    private _assignedRole = assignedVehicleRole _unit;
-    private _roleType = _assignedRole select 0;
-    if (_roleType == "Driver") then {
+    private _roleType = [_unit] call CBA_fnc_vehicleRole;
+    if (_roleType == "driver") then {
         _compartment = getText (_cfg >> "driverCompartments");
         if (_compartment == "") then {
             _compartment = _defaultCompartment;
         };
     } else {
-        if (_roleType == "Turret") then {
-            private _turretPath = _assignedRole select 1;
+        if (_roleType in ["gunner", "commander", "turret"]) then {
+            private _turretPath = _vehicle unitTurret _unit;
             private _turret = [_vehicle, _turretPath] call CBA_fnc_getTurret;
             _compartment = getText (_turret >> "gunnerCompartments");
             if (_compartment == "") then {
@@ -43,7 +42,7 @@ if (_vehicle != _unit) then {
                 };
             };
         } else {
-            if (_roleType == "Cargo") then {
+            if (_roleType == "cargo") then {
                 private _cargoCompartments = getArray (_cfg >> "cargoCompartments");
                 if (_cargoCompartments isNotEqualTo []) then {
                     private _index = _vehicle getCargoIndex _unit;


### PR DESCRIPTION
`assignedVehicleRole`
>On a client the command will return empty arrays for every unit that is not local.

e.g. Top is player (server) in littlebird copilot, bottom is other client on cargo (skid seats)
![image](https://user-images.githubusercontent.com/9376747/134817671-b0b7d7e4-a574-4662-ac40-0390778d43ca.png)

This PR changes it to use https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_vehicleRole.sqf (uses `fullCrew`)