### PR TITLE
Extensions - Fix crash if unable to load wrp (fallback to arcade model)

### DIFF
--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -116,7 +116,7 @@ if ([findDisplay 0] isNotEqualTo allDisplays) then {
                 if (_result == -1) then {
                     WARNING_1("Map Load [%1] (WRP) parsing error - ACRE will now assume the terrain is flat and all at elevation 0m.",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
                 } else {
-                    ERROR_MSG_1("ACRE was unable to parse the map [%1]. Please file a ticket on our tracker http://github.com/idi-systems/acre2 ",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
+                    ERROR_MSG_2("ACRE was unable to parse the map [%1] - ACRE will now use Arcade signal propagation model. Please file a ticket on our tracker: %2",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"),LELSTRING(Main,URL));
                 };
             } else {
                 INFO_2("Map Load Complete: %1 with radio signal code %2",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"),[worldName] call EFUNC(sys_signal,getRadioClimateCode));

--- a/addons/sys_core/XEH_postInit.sqf
+++ b/addons/sys_core/XEH_postInit.sqf
@@ -116,7 +116,7 @@ if ([findDisplay 0] isNotEqualTo allDisplays) then {
                 if (_result == -1) then {
                     WARNING_1("Map Load [%1] (WRP) parsing error - ACRE will now assume the terrain is flat and all at elevation 0m.",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"));
                 } else {
-                    ERROR_MSG_2("ACRE was unable to parse the map [%1] - ACRE will now use Arcade signal propagation model. Please file a ticket on our tracker: %2",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"),LELSTRING(Main,URL));
+                    ERROR_MSG_2("ACRE was unable to parse the map [%1]\nACRE will now use Arcade signal propagation model.\nPlease file a ticket on our tracker: %2",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"),LELSTRING(Main,URL));
                 };
             } else {
                 INFO_2("Map Load Complete: %1 with radio signal code %2",getText (configFile >> "CfgWorlds" >> worldName >> "worldName"),[worldName] call EFUNC(sys_signal,getRadioClimateCode));

--- a/extensions/src/ACRE2Arma/signal/map/map.hpp
+++ b/extensions/src/ACRE2Arma/signal/map/map.hpp
@@ -46,6 +46,8 @@ namespace acre {
                     return landscape.get()->failure;
                 }
 
+                _current_map = "";
+                result_      = nullptr;
                 LOG(ERROR) << "WRP unable to find wrp file: " << wrp_path_;
                 return acre::wrp::LandscapeResult::Failure;
             };

--- a/extensions/src/ACRE2Arma/signal/signal.hpp
+++ b/extensions/src/ACRE2Arma/signal/signal.hpp
@@ -218,11 +218,11 @@ namespace acre {
                         _signalProcessor_multipath.process(&signal_result, tx_pos, tx_dir, rx_pos, rx_dir, tx_antenna, rx_antenna, frequency_MHz, power_mW, scale, omnidirectional);
                     }
                 }
-                
+
                 // Sanatize numbers as arma will not be able to parse bad values (can remove if no more errors are reported)
                 if (!isfinite(signal_result.result_dbm) || !isfinite(signal_result.result_v)) {
                     if (logging >= 1) { LOG(ERROR) << "Signal was NaN/infinite: " << args_.to_string() << ": " << signal_result.result_dbm << "," << signal_result.result_v; }
-                    signal_result.result_dbm = 9000.0f; 
+                    signal_result.result_dbm = 9000.0f;
                     signal_result.result_v = 9000.0f; // ouch - don't touch the antenna
                 }
 

--- a/extensions/src/ACRE2Arma/signal/signal.hpp
+++ b/extensions/src/ACRE2Arma/signal/signal.hpp
@@ -151,7 +151,7 @@ namespace acre {
                     return true;
                 }
 
-                const PropagationModel model = static_cast<PropagationModel>(args_.as_int(acre_signalArgument_signalPropagationModel));
+                const PropagationModel model = (_map) ? static_cast<PropagationModel>(args_.as_int(acre_signalArgument_signalPropagationModel)) : PropagationModel::arcade;
 
                 const int32_t logging = args_.as_int(acre_signalArgument_debugEnabled);
                 const bool omnidirectional = args_.as_int(acre_signalArgument_omnidirectionalRadios);


### PR DESCRIPTION
Fix signal models attempting to use map that may not exist.
If `get_map` failed, it would leave `result_` untouched, which means it was just the last map loaded
- so different clients would have different map loaded depending on what they played last
- if no map was ever loaded it would lead to null pointer dereference

Specific crash reproduction steps:
- Launch with `-nosplash -world=empty -skipIntro -noPause` so no map is loaded on main menu
- Change https://github.com/IDI-Systems/acre2/blob/master/addons/sys_core/XEH_postInit.sqf#L110 
to `["doNotExist.wrp", _radioSignalCode],` to simulate a epbo on any map
- Run any signal calc `[2400, 5000, "ACRE_PRC343_ID_1", "ACRE_PRC343_ID_2"] call acre_sys_signal_fnc_getSignal;`

![a0y2hxI](https://user-images.githubusercontent.com/9376747/136667569-fd70df70-8c93-4fce-8e59-26bb383fe607.png)
