### PR TITLE
Core - Fix radio, intercom and sound effects not affected by global volume

### DIFF
--- a/addons/sys_core/CfgSounds.hpp
+++ b/addons/sys_core/CfgSounds.hpp
@@ -1,7 +1,7 @@
 class CfgSounds  {
     class acre_lip_sound {
         name = "";
-        sound[] = {QPATHTOF(sounds\mouth.wss), db-40, 1.0};
+        sound[] = {QPATHTOF(sounds\mouth.wss), "db-40", 1.0};
         titles[] = {};
     };
 };

--- a/addons/sys_core/fnc_processDirectSpeaker.sqf
+++ b/addons/sys_core/fnc_processDirectSpeaker.sqf
@@ -82,7 +82,7 @@ private _underwater = (ACRE_LISTENER_DIVE == 1) || {_emitterHeight < -0.2};
 
 if (_isIntercomAttenuate) then {
     _speakingType = "i";
-    _directVolume = _directVolume * [_unit] call EFUNC(sys_intercom,getVolumeIntercomUnit);
+    _directVolume = _directVolume * ([_unit] call EFUNC(sys_intercom,getVolumeIntercomUnit));
     _underwater = false;
 };
 

--- a/addons/sys_core/fnc_processDirectSpeaker.sqf
+++ b/addons/sys_core/fnc_processDirectSpeaker.sqf
@@ -22,14 +22,14 @@ private _id = GET_TS3ID(_unit);
 
 private _bothSpectating = false;
 private _isIntercomAttenuate = false;
-private _directVolume = GVAR(globalVolume);
+private _directVolume = 1;
 private _speakingType = "d";
 
 if (_id in ACRE_SPECTATORS_LIST && {ACRE_IS_SPECTATOR}) then {
     _bothSpectating = true;
 } else {
     private _attenuate = [_unit] call EFUNC(sys_attenuate,getUnitAttenuate);
-    _directVolume = GVAR(globalVolume) * (1 - _attenuate);
+    _directVolume = 1 - _attenuate;
     _isIntercomAttenuate = [_unit] call EFUNC(sys_attenuate,isIntercomAttenuate);
 };
 
@@ -82,7 +82,7 @@ private _underwater = (ACRE_LISTENER_DIVE == 1) || {_emitterHeight < -0.2};
 
 if (_isIntercomAttenuate) then {
     _speakingType = "i";
-    _directVolume = _directVolume * ([_unit] call EFUNC(sys_intercom,getVolumeIntercomUnit));
+    _directVolume = [_unit] call EFUNC(sys_intercom,getVolumeIntercomUnit);
     _underwater = false;
 };
 
@@ -91,6 +91,6 @@ if (GVAR(isDeaf) || {_unit getVariable [QGVAR(isDisabled), false]} || {_underwat
 };
 
 private _canUnderstand = [_unit] call FUNC(canUnderstand);
-private _params = [_speakingType, _id, !_canUnderstand, _directVolume^3, _emitterPos, _emitterDir];
+private _params = [_speakingType, _id, !_canUnderstand, (_directVolume * GVAR(globalVolume))^3, _emitterPos, _emitterDir];
 TRACE_1("SPEAKING UPDATE", _params);
 _params

--- a/addons/sys_core/fnc_processDirectSpeaker.sqf
+++ b/addons/sys_core/fnc_processDirectSpeaker.sqf
@@ -82,7 +82,7 @@ private _underwater = (ACRE_LISTENER_DIVE == 1) || {_emitterHeight < -0.2};
 
 if (_isIntercomAttenuate) then {
     _speakingType = "i";
-    _directVolume = [_unit] call EFUNC(sys_intercom,getVolumeIntercomUnit);
+    _directVolume = _directVolume * [_unit] call EFUNC(sys_intercom,getVolumeIntercomUnit);
     _underwater = false;
 };
 

--- a/addons/sys_core/fnc_processRadioSpeaker.sqf
+++ b/addons/sys_core/fnc_processRadioSpeaker.sqf
@@ -90,8 +90,7 @@ if (_okRadios isNotEqualTo []) then {
 
             private _radioVolume = [_receivingRadioid, "getVolume"] call EFUNC(sys_data,dataEvent);
             _radioVolume = [_x, _radioVolume] call EFUNC(sys_intercom,modifyRadioVolume);
-            _radioVolume = _radioVolume * GVAR(globalVolume);
-            // acre_player sideChat format["rv: %1", _radioVolume];
+
             private _isLoudspeaker = [_receivingRadioid, "isExternalAudio"] call EFUNC(sys_data,dataEvent);
             private _spatialArray = [0,0,0];
             if (!_isLoudspeaker) then {

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -142,14 +142,15 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
 
                 private _radioPos = [0,0,0];
                 private _attenuate = 1;
+                private _occlusion = 1;
                 if ([_recRadio, "isExternalAudio"] call EFUNC(sys_data,dataEvent)) then {
                     _radioPos = [_recRadio, "getExternalAudioPosition"] call EFUNC(sys_data,physicalEvent);
                     // there needs to be handling of vehicle attenuation too
                     private _recRadioObject = [_recRadio] call EFUNC(sys_radio,getRadioObject);
                     _attenuate = [_recRadioObject] call EFUNC(sys_attenuate,getUnitAttenuate);
                     _attenuate = (1 - _attenuate)^3;
-                    _volumeModifier = [_radioPos, ACRE_LISTENER_POS, _recRadioObject] call FUNC(findOcclusion);
-                    _volumeModifier = _volumeModifier^3;
+                    _occlusion = [_radioPos, ACRE_LISTENER_POS, _recRadioObject] call FUNC(findOcclusion);
+                    _occlusion = _occlusion^3;
                 };
 
                 #ifdef ENABLE_PERFORMANCE_COUNTERS
@@ -165,12 +166,13 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
                             HASH_SET(_compiledParams, netId _unit, []);
                         };
                         private _speakingRadios = HASH_GET(_compiledParams, netId _unit);
-                        if (_params select 3) then {
+                        if (_params select 3) then { // speaker / loudspeaker
                             // Possible sound fix: Always double the distance of the radio for hearing purposes
                             // on external speaker to make it 'distant' like a speaker.
                             // This should be moved to plugin probably.
                             _params set [4, _radioPos];
-                            _params set [0, _radioVolume*_volumeModifier*_attenuate];
+                            _params set [0, _radioVolume * _volumeModifier * _attenuate * _occlusion];
+                            TRACE_4("volume (loudspeaker)",_params select 0,_radioVolume,_volumeModifier,_attenuate,_occlusion);
                         } else {
                             private _ear = [_recRadio, "getState", "ACRE_INTERNAL_RADIOSPATIALIZATION"] call EFUNC(sys_data,dataEvent);
                             if (isNil "_ear") then {
@@ -183,7 +185,8 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
                             if (GVAR(lowered)) then {
                                 _radioVolume = _radioVolume * 0.15;
                             };
-                            _params set [0, _radioVolume*_volumeModifier];
+                            _params set [0, _radioVolume * _volumeModifier];
+                            TRACE_3("volume (normal)",_params select 0,_radioVolume,_volumeModifier);
                         };
                         _params set [1, _signalData select 0];
                         _speakingRadios pushBack _params;

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -183,7 +183,7 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
                             if (GVAR(lowered)) then {
                                 _radioVolume = _radioVolume * 0.15;
                             };
-                            _params set [0, _radioVolume];
+                            _params set [0, _radioVolume*_volumeModifier];
                         };
                         _params set [1, _signalData select 0];
                         _speakingRadios pushBack _params;

--- a/addons/sys_godmode/XEH_postInit.sqf
+++ b/addons/sys_godmode/XEH_postInit.sqf
@@ -17,7 +17,7 @@ LOAD_SOUND(Acre_GodPingOff);
 
     GVAR(speakingGods) pushBackUnique _speakingId;
 
-    ["Acre_GodPingOn", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false] call EFUNC(sys_sounds,playSound);
+    ["Acre_GodPingOn", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false, false] call EFUNC(sys_sounds,playSound);
 
     if (GVAR(rxNotification)) then {
         _channel = localize _channel;
@@ -44,7 +44,7 @@ LOAD_SOUND(Acre_GodPingOff);
 
     GVAR(speakingGods) deleteAt (GVAR(speakingGods) find _speakingId);
 
-    ["Acre_GodPingOff", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false] call EFUNC(sys_sounds,playSound);
+    ["Acre_GodPingOff", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false, false] call EFUNC(sys_sounds,playSound);
 
     [format [QGVAR(%1), _speakingId]] call EFUNC(sys_list,hideHint);
 }] call CBA_fnc_addEventHandler;

--- a/addons/sys_godmode/fnc_handlePttKeyPress.sqf
+++ b/addons/sys_godmode/fnc_handlePttKeyPress.sqf
@@ -85,7 +85,7 @@ GVAR(targetUnits) = GVAR(targetUnits) apply {
 GVAR(speaking) = true;
 
 #ifndef TEST_SELF_RX
-["Acre_GodBeep", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false] call EFUNC(sys_sounds,playSound);
+["Acre_GodBeep", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false, false] call EFUNC(sys_sounds,playSound);
 #endif
 
 if (GVAR(txNotification)) then {

--- a/addons/sys_godmode/fnc_handlePttKeyPressUp.sqf
+++ b/addons/sys_godmode/fnc_handlePttKeyPressUp.sqf
@@ -28,7 +28,7 @@ GVAR(speaking) = false;
 #ifndef ALLOW_EMPTY_TARGETS
 if (GVAR(targetUnits) isNotEqualTo []) then {
     #ifndef TEST_SELF_RX
-    ["Acre_GodPingOff", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false] call EFUNC(sys_sounds,playSound);
+    ["Acre_GodPingOff", [0,0,0], [0,0,0], EGVAR(sys_core,godVolume), false, false] call EFUNC(sys_sounds,playSound);
     #endif
 };
 #endif

--- a/addons/sys_prc117f/menus/fnc_onButtonPress.sqf
+++ b/addons/sys_prc117f/menus/fnc_onButtonPress.sqf
@@ -17,12 +17,12 @@
  */
 
 
-//["Acre_GenericClick", [0,0,0], [0,0,0], 0.2, false] call EFUNC(sys_sounds,playSound);
+//["Acre_GenericClick", [0,0,0], [0,0,0], 0.6, false] call EFUNC(sys_sounds,playSound);
 private _control = ctrlIDC (_this select 1);
 if (_control != (99902 + 222)) then {
 [_this select 0] call FUNC(toggleButtonPressDown);
 } else {
-    ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], 0.2, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], 0.6, false] call EFUNC(sys_sounds,playSound);
 };
 
 

--- a/addons/sys_prc148/menus/fnc_onChannelKnobPress.sqf
+++ b/addons/sys_prc148/menus/fnc_onChannelKnobPress.sqf
@@ -37,7 +37,7 @@ if (_channelPosition < 0) then {
     _channelPosition = 0;
 };
 if (_channelPositionOld != _channelPosition) then {
-    ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], 0.6, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], 0.8, false] call EFUNC(sys_sounds,playSound);
     SET_STATE_CRIT("channelKnobPosition", _channelPosition);
 
 

--- a/addons/sys_prc148/menus/fnc_onVolumeKnobPress.sqf
+++ b/addons/sys_prc148/menus/fnc_onVolumeKnobPress.sqf
@@ -38,7 +38,7 @@ if (_newVolume > 1) then {
 // acre_player sideChat format["NEW VOL: %1", _newVolume];
 if (_currentVolume != _newVolume) then {
     if (_newVolume >= 0.2) then {
-        ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], _newVolume^3, false] call EFUNC(sys_sounds,playSound);
+        ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], _newVolume, false] call EFUNC(sys_sounds,playSound);
         ["setVolume", _newVolume] call GUI_DATA_EVENT;
         RADIO_CTRL(12010+201) ctrlSetTooltip format ["Current Volume: %1%2", round (_newVolume*100), "%"];
     };

--- a/addons/sys_prc152/menus/fnc_onButtonPress.sqf
+++ b/addons/sys_prc152/menus/fnc_onButtonPress.sqf
@@ -18,7 +18,7 @@
 
 TRACE_1("enter", _this);
 
-//["Acre_GenericClick", [0,0,0], [0,0,0], 0.2, false] call EFUNC(sys_sounds,playSound);
+//["Acre_GenericClick", [0,0,0], [0,0,0], 0.6, false] call EFUNC(sys_sounds,playSound);
 
 #ifdef ENABLE_PERFORMANCE_COUNTERS
     BEGIN_COUNTER(buttonPress);
@@ -29,7 +29,7 @@ private _control = ctrlIDC (_this select 1);
 if (_control != 222 && {_control != (99902 + 116)} && {_control != (99902 + 117)}) then {
     [_this select 0] call FUNC(toggleButtonPressDown);
 } else {
-    ["Acre_GenericClick", [0,0,0], [0,0,0], 0.2, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_GenericClick", [0,0,0], [0,0,0], 0.6, false] call EFUNC(sys_sounds,playSound);
 };
 
 

--- a/addons/sys_prc343/functions/fnc_onVolumeKnobPress.sqf
+++ b/addons/sys_prc343/functions/fnc_onVolumeKnobPress.sqf
@@ -32,7 +32,7 @@ private _currentVolume = GET_STATE("volume"); //["getState", "volume"] call GUI_
 private _newVolume = ((_currentVolume + _currentDirection) max 0) min 1;
 
 if (_currentVolume != _newVolume) then {
-    ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], _newVolume^3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_GenericClick", [0, 0, 0], [0, 0, 0], _newVolume, false] call EFUNC(sys_sounds,playSound);
     ["setVolume", _newVolume] call GUI_DATA_EVENT;
 
 

--- a/addons/sys_sem52sl/functions/fnc_onChannelKnobPress.sqf
+++ b/addons/sys_sem52sl/functions/fnc_onChannelKnobPress.sqf
@@ -182,6 +182,6 @@ if (_knobPosition != _newKnobPosition) then {
         };
     };
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
     [MAIN_DISPLAY] call FUNC(render);
 };

--- a/addons/sys_sem52sl/functions/fnc_onVolumeKnobPress.sqf
+++ b/addons/sys_sem52sl/functions/fnc_onVolumeKnobPress.sqf
@@ -43,7 +43,7 @@ if (_channelKnobPosition == 15) then { // programming (used to help program).
         GVAR(selectionDir) = 0;
     };
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
 } else { // Channel selected do Volume control
     private _newKnobPosition = ((_knobPosition + _currentDirection) max 0) min 16;
 
@@ -55,7 +55,7 @@ if (_channelKnobPosition == 15) then { // programming (used to help program).
         private _newVolume = abs ((_newKnobPosition - 8)/8);
         ["setVolume", _newVolume] call GUI_DATA_EVENT;
 
-        ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+        ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
     };
 };
 [MAIN_DISPLAY] call FUNC(render);

--- a/addons/sys_sem70/functions/fnc_onChannelStepKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onChannelStepKnobTurn.sqf
@@ -15,7 +15,7 @@
  *
  * Public: No
  */
- 
+
  params ["","_key"];
 
   private _currentDirection = -1;
@@ -56,6 +56,6 @@
          };
      };
 
-     ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+     ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
      [MAIN_DISPLAY] call FUNC(render);
  };

--- a/addons/sys_sem70/functions/fnc_onFunctionKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onFunctionKnobTurn.sqf
@@ -64,6 +64,6 @@ if (_knobPosition != _newKnobPosition) then {
         };
     };
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
     [MAIN_DISPLAY] call FUNC(render);
 };

--- a/addons/sys_sem70/functions/fnc_onMHzKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onMHzKnobTurn.sqf
@@ -55,6 +55,6 @@ if (_knobPosition != _newKnobPosition) then {
     // We parse a 0 here, because we are in manual mode
     ["setCurrentChannel", GVAR(manualChannel)] call GUI_DATA_EVENT;
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
     [MAIN_DISPLAY] call FUNC(render);
 };

--- a/addons/sys_sem70/functions/fnc_onMainKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onMainKnobTurn.sqf
@@ -56,6 +56,6 @@ if (_knobPosition != _newKnobPosition) then {
         };
     };
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
     [MAIN_DISPLAY] call FUNC(render);
 };

--- a/addons/sys_sem70/functions/fnc_onMemorySlotKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onMemorySlotKnobTurn.sqf
@@ -49,6 +49,6 @@ if (_knobPosition != _newKnobPosition) then {
 
     ["setCurrentChannel", _newKnobPosition] call GUI_DATA_EVENT;
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
     [MAIN_DISPLAY] call FUNC(render);
 };

--- a/addons/sys_sem70/functions/fnc_onNetworkKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onNetworkKnobTurn.sqf
@@ -86,5 +86,5 @@ switch (_ctrlIDC) do {
 
 [] call FUNC(setNetworkID);
 
-["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
 [MAIN_DISPLAY] call FUNC(render);

--- a/addons/sys_sem70/functions/fnc_onVolumeKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onVolumeKnobTurn.sqf
@@ -37,7 +37,7 @@ if (_knobPosition != _newKnobPosition) then {
     private _newVolume = abs ((_newKnobPosition)/5);
     ["setVolume", _newVolume] call GUI_DATA_EVENT;
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
 };
 
 [MAIN_DISPLAY] call FUNC(render);

--- a/addons/sys_sem70/functions/fnc_onkHzKnobTurn.sqf
+++ b/addons/sys_sem70/functions/fnc_onkHzKnobTurn.sqf
@@ -66,6 +66,6 @@ if (_knobPosition != _newKnobPosition) then {
     // We parse a 0 here, because we are in manual mode
     ["setCurrentChannel", GVAR(manualChannel)] call GUI_DATA_EVENT;
 
-    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.3, false] call EFUNC(sys_sounds,playSound);
+    ["Acre_SEMKnob", [0,0,0], [0,0,0], 0.7, false] call EFUNC(sys_sounds,playSound);
     [MAIN_DISPLAY] call FUNC(render);
 };

--- a/addons/sys_sounds/fnc_playSound.sqf
+++ b/addons/sys_sounds/fnc_playSound.sqf
@@ -21,5 +21,5 @@
 
 params ["_className", "_position", "_direction", "_volume", "_isWorld"];
 
-_volume = (_volume max 0) min 1;
+_volume = ((_volume max 0) min 1) * EGVAR(sys_core,globalVolume);
 ["playLoadedSound", [_className, _position, _direction, _volume, _isWorld]] call EFUNC(sys_rpc,callRemoteProcedure);

--- a/addons/sys_sounds/fnc_playSound.sqf
+++ b/addons/sys_sounds/fnc_playSound.sqf
@@ -22,4 +22,4 @@
 params ["_className", "_position", "_direction", "_volume", "_isWorld"];
 
 _volume = ((_volume max 0) min 1) * EGVAR(sys_core,globalVolume);
-["playLoadedSound", [_className, _position, _direction, _volume, _isWorld]] call EFUNC(sys_rpc,callRemoteProcedure);
+["playLoadedSound", [_className, _position, _direction, _volume^3, _isWorld]] call EFUNC(sys_rpc,callRemoteProcedure);

--- a/addons/sys_sounds/fnc_playSound.sqf
+++ b/addons/sys_sounds/fnc_playSound.sqf
@@ -9,17 +9,24 @@
  * 2: Direction of sound <ARRAY>
  * 3: Volume <NUMBER>
  * 4: World <BOOL>
+ * 5: Scale with Global Volume <BOOL> (default: true)
  *
  * Return Value:
  * None
  *
  * Example:
  * ["Acre_GenericClick", [0,0,0], [0,0,0], 1, false] call acre_sys_sounds_fnc_playSound
+ * ["Acre_GodPingOn", [0,0,0], [0,0,0], 1, false, false] call acre_sys_sounds_fnc_playSound
  *
  * Public: No
  */
 
-params ["_className", "_position", "_direction", "_volume", "_isWorld"];
+params ["_className", "_position", "_direction", "_volume", "_isWorld", ["_scaleGlobalVolume", true]];
 
-_volume = ((_volume max 0) min 1) * EGVAR(sys_core,globalVolume);
+_volume = (_volume max 0) min 1;
+
+if (_scaleGlobalVolume) then {
+    _volume = _volume * EGVAR(sys_core,globalVolume);
+};
+
 ["playLoadedSound", [_className, _position, _direction, _volume^3, _isWorld]] call EFUNC(sys_rpc,callRemoteProcedure);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix #1080 
  - Remove use of `GVAR(globalVolume)` from `fnc_processRadioSpeaker` to avoid double-setting (don't think `_radioVolume` parameter in this function is even used, as for radios the radio volume property is used)
  - Fix https://github.com/acemod/ACE3/issues/6392 properly for radios and all other ACRE2 sounds as well
  - Fix radio speakers not affected by global volume
  - Fix intercom and infantry phone not affected by global volume
- Fix an unstringified config entry
- Fix sound effects not affected by global volume
- Fix sound effects not following dB dropoff
  - Streamline radio sounds to dB scale, ignoring God Mode

Could use another set of ears to make sure levels are about the same and not completely off. Radio speakers should also be a bit more manageable now and not 3x louder (more like 2x as intended).

_Was testing without ACE, then added ACE and completely forgot ACE calls this function every frame, thought I broke something as it kept resetting in front of my eyes..._