### PR TITLE
S.O.G. Prairie Fire - Remove hard requirement

### DIFF
--- a/optionals/sys_sog/config.cpp
+++ b/optionals/sys_sog/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"acre_main", "acre_api", "data_f_vietnam"};
+        requiredAddons[] = {"acre_main", "acre_api"};
         author = ECSTRING(main,Author);
         authors[] = {"Savage Game Design", "veteran29"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION
**When merged this pull request will:**
- Remove the `data_f_vietnam` requiredAddon so the optional can run without SOG being loaded and throwing an error. No classes from SOG are modified so should be safe to not have said requirement. This bring it in-line with how the GM optional is written.