### PR TITLE
Extensions - Add effect for internal radio speakers

### DIFF
--- a/extensions/src/ACRE2Core/FilterRadio.cpp
+++ b/extensions/src/ACRE2Core/FilterRadio.cpp
@@ -8,7 +8,7 @@
 
 #define BASE_DISTORTION_LEVEL 0.43f
 
-acre::Result CFilterRadio::process(short* samples, int sampleCount, int channels, acre::volume_t value, bool noise) {
+acre::Result CFilterRadio::process(short* samples, int sampleCount, int channels, acre::volume_t value, bool noise, const bool isLoudSpeaker) {
     float buffer[4096], *floatPointer[1];
     short *shortPointer[1];
 
@@ -43,6 +43,11 @@ acre::Result CFilterRadio::process(short* samples, int sampleCount, int channels
         // shelf it
         this->m_LowPass.process(sampleCount*channels, floatPointer);
         this->m_HighPass.process(sampleCount*channels, floatPointer);
+
+        // Drop low-end if on speakerphone
+        if (isLoudSpeaker) { 
+            this->m_lowShelf.process(sampleCount * channels, floatPointer);
+        }
 
         // Convert it back to shorts
         for (int i = 0; i < sampleCount; ++i) {
@@ -89,6 +94,7 @@ CFilterRadio::CFilterRadio(void)
     srand((unsigned int)time(0));
     this->m_HighPass.setup (TS_SAMPLE_RATE, 750, 0.97);
     this->m_LowPass.setup (TS_SAMPLE_RATE, 4000, 2.0);
+    this->m_lowShelf.setup(TS_SAMPLE_RATE, 1000, -20, 1);
     this->m_PinkNoise.clear();
 }
 

--- a/extensions/src/ACRE2Core/FilterRadio.cpp
+++ b/extensions/src/ACRE2Core/FilterRadio.cpp
@@ -94,7 +94,7 @@ CFilterRadio::CFilterRadio(void)
     srand((unsigned int)time(0));
     this->m_HighPass.setup (TS_SAMPLE_RATE, 750, 0.97);
     this->m_LowPass.setup (TS_SAMPLE_RATE, 4000, 2.0);
-    this->m_lowShelf.setup(TS_SAMPLE_RATE, 1000, -20, 1);
+    this->m_lowShelf.setup(TS_SAMPLE_RATE, 1000, -10, 1);
     this->m_PinkNoise.clear();
 }
 

--- a/extensions/src/ACRE2Core/FilterRadio.h
+++ b/extensions/src/ACRE2Core/FilterRadio.h
@@ -14,10 +14,11 @@ public:
     CFilterRadio(void);
     ~CFilterRadio(void);
 
-    acre::Result process(short* samples, int sampleCount, int channels, acre::volume_t value, bool noise);
+    acre::Result process(short* samples, int sampleCount, int channels, acre::volume_t value, bool noise, const bool isLoudSpeaker);
 
     Dsp::SimpleFilter<Dsp::RBJ::HighPass, 1> m_HighPass;
     Dsp::SimpleFilter<Dsp::RBJ::LowPass, 1> m_LowPass;
+    Dsp::SimpleFilter<Dsp::RBJ::LowShelf, 1> m_lowShelf;
     Dsp::PinkNoise m_PinkNoise;
     Dsp::RingModulate m_RingModulate;
 protected:

--- a/extensions/src/ACRE2Core/RadioEffect.cpp
+++ b/extensions/src/ACRE2Core/RadioEffect.cpp
@@ -4,6 +4,7 @@
 CRadioEffect::CRadioEffect() {
     radioFilter = new CFilterRadio();
     this->setParam("signalQuality", 0.0f);
+    this->setParam("isLoudSpeaker", 0.0f);
 };
 CRadioEffect::~CRadioEffect() {
     delete radioFilter;
@@ -13,6 +14,7 @@ void CRadioEffect::process(short *samples, int sampleCount) {
     bool noise = true;
     if (this->getParam("disableNoise"))
         noise = false;
+    const bool isLoudSpeaker = getParam("isLoudSpeaker") > 0.0f;
 
-    this->radioFilter->process(samples, sampleCount, 1, static_cast<acre::volume_t>(this->getParam("signalQuality")), noise);
+    this->radioFilter->process(samples, sampleCount, 1, static_cast<acre::volume_t>(this->getParam("signalQuality")), noise, isLoudSpeaker);
 };

--- a/extensions/src/ACRE2Core/updateSpeakingData.h
+++ b/extensions/src/ACRE2Core/updateSpeakingData.h
@@ -91,6 +91,7 @@ RPC_FUNCTION(updateSpeakingData) {
                     speaker->channels[channelId]->setEffectInsert(2, "acre_radio");
                     speaker->channels[channelId]->getEffectInsert(2)->setParam("disableNoise", false);
                     speaker->channels[channelId]->getEffectInsert(2)->setParam("signalQuality", vMessage->getParameterAsFloat(5));
+                    speaker->channels[channelId]->getEffectInsert(2)->setParam("isLoudSpeaker", vMessage->getParameterAsFloat(7));
 
                     speaker->channels[channelId]->setMixdownEffectInsert(0, "acre_positional");
                 }


### PR DESCRIPTION
Close #1173

Small speakers generally struggle with lower frequencies. e.g. frequency response of some phones:
![Pixel3-comp_575px](https://user-images.githubusercontent.com/9376747/148289174-4c7a110d-450b-4287-8644-9c2b7ee0810b.png)

This attempts to emulate that, and should make it more apparent to players that they are listening to a radio's speaker

