### PR TITLE
Attenuate - Add config value for attenuation between people inside and turned out

### DIFF
--- a/addons/sys_attenuate/CfgSoundEffects.hpp
+++ b/addons/sys_attenuate/CfgSoundEffects.hpp
@@ -1,68 +1,68 @@
 /*
  * acreAttenuation: Use this to determine the attenution between people inside and outside vehicles.
- * acreTurnedOutAttenuation: Use this to determine the attenution between people inside (turned in) and turned out in a vehicle (refers to isTurnedOut command).
+ * acreAttenuationTurnedOut: Use this to determine the attenution between people inside (turned in) and turned out in a vehicle (refers to isTurnedOut command).
  */
 
 class CfgSoundEffects {
     class AttenuationsEffects {
         acreDefaultAttenuation = 0;
-        acreDefaultTurnedOutAttenuation = 0;
+        acreDefaultAttenuationTurnedOut = 0;
 
         class CarAttenuation {
             acreAttenuation = 0.5;
-            acreTurnedOutAttenuation = 0.25;
+            acreAttenuationTurnedOut = 0.25;
         };
         class SemiOpenCarAttenuation {
             acreAttenuation = 0;
-            acreTurnedOutAttenuation = 0;
+            acreAttenuationTurnedOut = 0;
         };
         class SemiOpenCarAttenuation2 {
             acreAttenuation = 0;
-            acreTurnedOutAttenuation = 0;
+            acreAttenuationTurnedOut = 0;
         };
         class OpenCarAttenuation {
             acreAttenuation = 0;
-            acreTurnedOutAttenuation = 0;
+            acreAttenuationTurnedOut = 0;
         };
         class TankAttenuation {
             acreAttenuation = 0.6;
-            acreTurnedOutAttenuation = 0.3;
+            acreAttenuationTurnedOut = 0.3;
         };
         class HeliAttenuation {
             acreAttenuation = 0.6;
-            acreTurnedOutAttenuation = 0.3;
+            acreAttenuationTurnedOut = 0.3;
         };
         class OpenHeliAttenuation {
             acreAttenuation = 0.1;
-            acreTurnedOutAttenuation = 0.05;
+            acreAttenuationTurnedOut = 0.05;
         };
         class SemiOpenHeliAttenuation {
             acreAttenuation = 0.4;
-            acreTurnedOutAttenuation = 0.2;
+            acreAttenuationTurnedOut = 0.2;
         };
         class HeliAttenuationGunner {
             acreAttenuation = 0.15;
-            acreTurnedOutAttenuation = 0.075;
+            acreAttenuationTurnedOut = 0.075;
         };
         class HeliAttenuationRamp {
             acreAttenuation = 0.15;
-            acreTurnedOutAttenuation = 0.075;
+            acreAttenuationTurnedOut = 0.075;
         };
         class PlaneAttenuation {
             acreAttenuation = 0.6;
-            acreTurnedOutAttenuation = 0.3;
+            acreAttenuationTurnedOut = 0.3;
         };
         class RHS_CarAttenuation {
             acreAttenuation = 0.5;
-            acreTurnedOutAttenuation = 0.25;
+            acreAttenuationTurnedOut = 0.25;
         };
         class CUP_UAZ_CarAttenuation {
             acreAttenuation = 0;
-            acreTurnedOutAttenuation = 0;
+            acreAttenuationTurnedOut = 0;
         };
         class CUP_Ural_CarAttenuation {
             acreAttenuation = 0;
-            acreTurnedOutAttenuation = 0;
+            acreAttenuationTurnedOut = 0;
         };
     };
 };

--- a/addons/sys_attenuate/CfgSoundEffects.hpp
+++ b/addons/sys_attenuate/CfgSoundEffects.hpp
@@ -1,49 +1,68 @@
-/* Use this to determine the attenution between people inside and outside vehicles. */
+/*
+ * acreAttenuation: Use this to determine the attenution between people inside and outside vehicles.
+ * acreTurnedOutAttenuation: Use this to determine the attenution between people inside (turned in) and turned out in a vehicle (refers to isTurnedOut command).
+ */
 
 class CfgSoundEffects {
     class AttenuationsEffects {
         acreDefaultAttenuation = 0;
+        acreDefaultTurnedOutAttenuation = 0;
+
         class CarAttenuation {
             acreAttenuation = 0.5;
+            acreTurnedOutAttenuation = 0.25;
         };
         class SemiOpenCarAttenuation {
             acreAttenuation = 0;
+            acreTurnedOutAttenuation = 0;
         };
         class SemiOpenCarAttenuation2 {
             acreAttenuation = 0;
+            acreTurnedOutAttenuation = 0;
         };
         class OpenCarAttenuation {
             acreAttenuation = 0;
+            acreTurnedOutAttenuation = 0;
         };
         class TankAttenuation {
             acreAttenuation = 0.6;
+            acreTurnedOutAttenuation = 0.3;
         };
         class HeliAttenuation {
             acreAttenuation = 0.6;
+            acreTurnedOutAttenuation = 0.3;
         };
         class OpenHeliAttenuation {
             acreAttenuation = 0.1;
+            acreTurnedOutAttenuation = 0.05;
         };
         class SemiOpenHeliAttenuation {
             acreAttenuation = 0.4;
+            acreTurnedOutAttenuation = 0.2;
         };
         class HeliAttenuationGunner {
             acreAttenuation = 0.15;
+            acreTurnedOutAttenuation = 0.075;
         };
         class HeliAttenuationRamp {
             acreAttenuation = 0.15;
+            acreTurnedOutAttenuation = 0.075;
         };
         class PlaneAttenuation {
             acreAttenuation = 0.6;
+            acreTurnedOutAttenuation = 0.3;
         };
         class RHS_CarAttenuation {
             acreAttenuation = 0.5;
+            acreTurnedOutAttenuation = 0.25;
         };
         class CUP_UAZ_CarAttenuation {
             acreAttenuation = 0;
+            acreTurnedOutAttenuation = 0;
         };
         class CUP_Ural_CarAttenuation {
             acreAttenuation = 0;
+            acreTurnedOutAttenuation = 0;
         };
     };
 };

--- a/addons/sys_attenuate/XEH_PREP.hpp
+++ b/addons/sys_attenuate/XEH_PREP.hpp
@@ -1,3 +1,5 @@
+PREP(getAttenuationEffectType);
+PREP(getTurnedOutAttenuation);
 PREP(getUnitAttenuate);
 PREP(getVehicleAttenuation);
 PREP(isIntercomAttenuate);

--- a/addons/sys_attenuate/XEH_PREP.hpp
+++ b/addons/sys_attenuate/XEH_PREP.hpp
@@ -1,5 +1,5 @@
 PREP(getAttenuationEffectType);
-PREP(getTurnedOutAttenuation);
+PREP(getAttenuationTurnedOut);
 PREP(getUnitAttenuate);
 PREP(getVehicleAttenuation);
 PREP(isIntercomAttenuate);

--- a/addons/sys_attenuate/XEH_preInit.sqf
+++ b/addons/sys_attenuate/XEH_preInit.sqf
@@ -8,6 +8,7 @@ PREP_RECOMPILE_END;
 
 if (hasInterface) then {
     GVAR(attenuationCache) = HASH_CREATE;
+    GVAR(turnedOutAttenuationCache) = HASH_CREATE;
 };
 
 ADDON = true;

--- a/addons/sys_attenuate/XEH_preInit.sqf
+++ b/addons/sys_attenuate/XEH_preInit.sqf
@@ -8,7 +8,7 @@ PREP_RECOMPILE_END;
 
 if (hasInterface) then {
     GVAR(attenuationCache) = HASH_CREATE;
-    GVAR(turnedOutAttenuationCache) = HASH_CREATE;
+    GVAR(attenuationTurnedOutCache) = HASH_CREATE;
 };
 
 ADDON = true;

--- a/addons/sys_attenuate/fnc_getAttenuationEffectType.sqf
+++ b/addons/sys_attenuate/fnc_getAttenuationEffectType.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team, Timi007
+ * Gets the attenuation effect type for the vehicle of the given unit.
+ *
+ * Arguments:
+ * 0: Unit <Object>
+ *
+ * Return Value:
+ * Attenuation effect type (see CfgSoundEffects >> AttenuationsEffects) or empty string if not available. <STRING>
+ *
+ * Example:
+ * [unit] call acre_sys_attenuate_fnc_getAttenuationEffectType
+ *
+ * Public: No
+ */
+
+params [["_unit", objNull, [objNull]]];
+
+private _vehicle = vehicle _unit;
+if (isNull _vehicle) exitWith {""};
+
+private _effectType = getText (configOf _vehicle >> "attenuationEffectType");
+
+private _turret = _vehicle unitTurret _unit;
+if (_turret in [[], [-1]]) exitWith {_effectType};
+
+private _config = [_vehicle, _turret] call CBA_fnc_getTurret;
+
+if ((getNumber (_config >> "disableSoundAttenuation")) isEqualTo 1) exitWith {""};
+
+if (isText (_config >> "soundAttenuationTurret")) then {
+    _effectType = getText (_config >> "soundAttenuationTurret");
+};
+
+_effectType

--- a/addons/sys_attenuate/fnc_getAttenuationEffectType.sqf
+++ b/addons/sys_attenuate/fnc_getAttenuationEffectType.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: ACRE2Team, Timi007
+ * Author: ACRE2Team
  * Gets the attenuation effect type for the vehicle of the given unit.
  *
  * Arguments:

--- a/addons/sys_attenuate/fnc_getAttenuationTurnedOut.sqf
+++ b/addons/sys_attenuate/fnc_getAttenuationTurnedOut.sqf
@@ -10,30 +10,30 @@
  * Attenuation between players turned out and inside. <NUMBER>
  *
  * Example:
- * [unit] call acre_sys_attenuate_fnc_getTurnedOutAttenuation
+ * [unit] call acre_sys_attenuate_fnc_getAttenuationTurnedOut
  *
  * Public: No
  */
 
 params [["_unit", objNull, [objNull]]];
 
-private _turnedOutAttenuation = 0;
+private _attenuationTurnedOut = 0;
 
 private _effectType = [_unit] call FUNC(getAttenuationEffectType);
-if (_effectType isEqualTo "") exitWith {_turnedOutAttenuation};
+if (_effectType isEqualTo "") exitWith {_attenuationTurnedOut};
 
-private _cachedAttenuation = HASH_GET(GVAR(turnedOutAttenuationCache), _effectType);
+private _cachedAttenuation = HASH_GET(GVAR(attenuationTurnedOutCache), _effectType);
 if (!isNil "_cachedAttenuation") exitWith {_cachedAttenuation};
 
 private _attenuationsEffectsCfg = configFile >> "CfgSoundEffects" >> "AttenuationsEffects";
 
-private _attenuationCfg = _attenuationsEffectsCfg >> _effectType >> "acreTurnedOutAttenuation";
+private _attenuationCfg = _attenuationsEffectsCfg >> _effectType >> "acreAttenuationTurnedOut";
 if (isNumber (_attenuationCfg)) then {
-    _turnedOutAttenuation = getNumber (_attenuationCfg);
+    _attenuationTurnedOut = getNumber (_attenuationCfg);
 } else {
-    _turnedOutAttenuation = getNumber (_attenuationsEffectsCfg >> "acreDefaultTurnedOutAttenuation");
+    _attenuationTurnedOut = getNumber (_attenuationsEffectsCfg >> "acreDefaultAttenuationTurnedOut");
 };
 
-HASH_SET(GVAR(turnedOutAttenuationCache), _effectType, _turnedOutAttenuation);
+HASH_SET(GVAR(attenuationTurnedOutCache), _effectType, _attenuationTurnedOut);
 
-_turnedOutAttenuation
+_attenuationTurnedOut

--- a/addons/sys_attenuate/fnc_getTurnedOutAttenuation.sqf
+++ b/addons/sys_attenuate/fnc_getTurnedOutAttenuation.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: Timi007
+ * Author: ACRE2Team
  * Calculates the attenuation between players turned out and inside.
  *
  * Arguments:

--- a/addons/sys_attenuate/fnc_getTurnedOutAttenuation.sqf
+++ b/addons/sys_attenuate/fnc_getTurnedOutAttenuation.sqf
@@ -1,0 +1,39 @@
+#include "script_component.hpp"
+/*
+ * Author: Timi007
+ * Calculates the attenuation between players turned out and inside.
+ *
+ * Arguments:
+ * 0: Unit <Object>
+ *
+ * Return Value:
+ * Attenuation between players turned out and inside. <NUMBER>
+ *
+ * Example:
+ * [unit] call acre_sys_attenuate_fnc_getTurnedOutAttenuation
+ *
+ * Public: No
+ */
+
+params [["_unit", objNull, [objNull]]];
+
+private _turnedOutAttenuation = 0;
+
+private _effectType = [_unit] call FUNC(getAttenuationEffectType);
+if (_effectType isEqualTo "") exitWith {_turnedOutAttenuation};
+
+private _cachedAttenuation = HASH_GET(GVAR(turnedOutAttenuationCache), _effectType);
+if (!isNil "_cachedAttenuation") exitWith {_cachedAttenuation};
+
+private _attenuationsEffectsCfg = configFile >> "CfgSoundEffects" >> "AttenuationsEffects";
+
+private _attenuationCfg = _attenuationsEffectsCfg >> _effectType >> "acreTurnedOutAttenuation";
+if (isNumber (_attenuationCfg)) then {
+    _turnedOutAttenuation = getNumber (_attenuationCfg);
+} else {
+    _turnedOutAttenuation = getNumber (_attenuationsEffectsCfg >> "acreDefaultTurnedOutAttenuation");
+};
+
+HASH_SET(GVAR(turnedOutAttenuationCache), _effectType, _turnedOutAttenuation);
+
+_turnedOutAttenuation

--- a/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
+++ b/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
@@ -50,7 +50,7 @@ if (_vehListener isEqualTo _vehSpeaker) then {
         };
 
         if (_speakerTurnedOut || _listenerTurnedOut) then {
-            _attenuate = [_listener] call FUNC(getTurnedOutAttenuation);
+            _attenuate = [_listener] call FUNC(getAttenuationTurnedOut);
         };
     };
 } else {

--- a/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
+++ b/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: ACRE2Team, Timi007
+ * Author: ACRE2Team
  * Calculates the attenuation between the local player unit and the inputted unit.
  *
  * Arguments:

--- a/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
+++ b/addons/sys_attenuate/fnc_getUnitAttenuate.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: ACRE2Team
+ * Author: ACRE2Team, Timi007
  * Calculates the attenuation between the local player unit and the inputted unit.
  *
  * Arguments:
@@ -20,6 +20,7 @@
 // returns 0-1
 
 params ["_speaker"];
+
 private _vehSpeaker = vehicle _speaker;
 private _listener = acre_player;
 private _vehListener = vehicle _listener;
@@ -34,35 +35,37 @@ if (ACRE_IS_SPECTATOR && {cameraView == "INTERNAL"} && {!(cameraOn isKindOf "CaM
 
 private _attenuate = 0;
 
-if (_vehListener == _vehSpeaker) then {
+if (_vehListener isEqualTo _vehSpeaker) then {
     if (_spectatingInsideVehicle) exitWith {}; // we won't be able to determine the specific compartment
+
     private _listenerTurnedOut = isTurnedOut _listener;
     private _speakerTurnedOut = isTurnedOut _speaker;
-    if (!(_listenerTurnedOut && _speakerTurnedOut)) then {
 
+    if (!(_listenerTurnedOut && _speakerTurnedOut)) then {
         private _listenerCompartment = [_listener] call EFUNC(sys_core,getCompartment);
         private _speakerCompartment = [_speaker] call EFUNC(sys_core,getCompartment);
+
         if (_speakerCompartment != _listenerCompartment) then {
-            // acre_player sideChat format["1 lc: %1 sc: %2 %3", _listenerCompartment, _speakerCompartment, (getNumber (configFile >> "CfgVehicles" >> (typeOf _vehListener) >> "ACRE" >> "attenuation" >> _speakerCompartment >> _listenerCompartment))];
-            _attenuate = ((getNumber (configOf _vehListener >> "ACRE" >> "attenuation" >> _speakerCompartment >> _listenerCompartment)));
+            _attenuate = getNumber (configOf _vehListener >> "ACRE" >> "attenuation" >> _speakerCompartment >> _listenerCompartment);
         };
+
         if (_speakerTurnedOut || _listenerTurnedOut) then {
-            // acre_player sideChat format["2 lc: %1 sc: %2 %3", _listenerCompartment, _speakerCompartment, (getNumber (configFile >> "CfgVehicles" >> (typeOf _vehListener) >> "ACRE" >> "attenuation" >> _speakerCompartment >> _listenerCompartment))];
-            _attenuate = ([_listener] call FUNC(getVehicleAttenuation))*0.5;
+            _attenuate = [_listener] call FUNC(getTurnedOutAttenuation);
         };
     };
 } else {
-    if (_spectatingInsideVehicle || {_vehListener != _listener}) then {
+    if (_spectatingInsideVehicle || {_vehListener isNotEqualTo _listener}) then {
         private _listenerTurnedOut = isTurnedOut _listener;
+
         if (!_listenerTurnedOut) then {
-            // acre_player sideChat format["1 %1 %2", _attenuate, (1-(getNumber (configFile >> "CfgVehicles" >> (typeOf (vehicle _listener)) >> "insideSoundCoef")))];
             _attenuate = _attenuate + ([_listener] call FUNC(getVehicleAttenuation));
         };
     };
-    if (_vehSpeaker != _speaker) then {
+
+    if (_vehSpeaker isNotEqualTo _speaker) then {
         private _speakerTurnedOut = isTurnedOut _speaker;
+
         if (!_speakerTurnedOut) then {
-            // acre_player sideChat format["2 %1 %2", _attenuate, (1-(getNumber (configFile >> "CfgVehicles" >> (typeOf (vehicle _speaker)) >> "insideSoundCoef")))];
             _attenuate = _attenuate + ([_speaker] call FUNC(getVehicleAttenuation));
         };
     };

--- a/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
+++ b/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
@@ -1,10 +1,10 @@
 #include "script_component.hpp"
 /*
- * Author: ACRE2Team, Timi007
+ * Author: ACRE2Team
  * Calculates the attenuation of a unit being heard externally from the vehicle.
  *
  * Arguments:
- * 0: Unit (or vehicle) <Object>
+ * 0: Unit <Object>
  *
  * Return Value:
  * Attenuation <NUMBER>

--- a/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
+++ b/addons/sys_attenuate/fnc_getVehicleAttenuation.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 /*
- * Author: ACRE2Team
+ * Author: ACRE2Team, Timi007
  * Calculates the attenuation of a unit being heard externally from the vehicle.
  *
  * Arguments:
@@ -15,42 +15,25 @@
  * Public: No
  */
 
-params [["_unit",objNull]];
-private _vehicle = vehicle _unit;
-
-if (isNull _vehicle) exitWith {};
+params [["_unit", objNull, [objNull]]];
 
 private _attenuation = 0;
-private _effectType = getText (configOf _vehicle >> "attenuationEffectType");
 
-private _turret = _vehicle unitTurret _unit;
-if (!(_turret in [[], [-1]])) then {
-    private _config = [_vehicle, _turret] call CBA_fnc_getTurret;
+private _effectType = [_unit] call FUNC(getAttenuationEffectType);
+if (_effectType isEqualTo "") exitWith {_attenuation};
 
-    if ((getNumber (_config >> "disableSoundAttenuation")) == 1) then {
-        _effectType = "";
-    } else {
-        if (isText (_config >> "soundAttenuationTurret")) then {
-            _effectType = getText (_config >> "soundAttenuationTurret");
-        };
-    };
+private _cachedAttenuation = HASH_GET(GVAR(attenuationCache), _effectType);
+if (!isNil "_cachedAttenuation") exitWith {_cachedAttenuation};
+
+private _attenuationsEffectsCfg = configFile >> "CfgSoundEffects" >> "AttenuationsEffects";
+
+private _attenuationCfg = _attenuationsEffectsCfg >> _effectType >> "acreAttenuation";
+if (isNumber (_attenuationCfg)) then {
+    _attenuation = getNumber (_attenuationCfg);
+} else {
+    _attenuation = getNumber (_attenuationsEffectsCfg >> "acreDefaultAttenuation");
 };
 
-if (_effectType != "") then {
-    // CfgSoundEffects >> AttenuationsEffects
-    private _value = HASH_GET(GVAR(attenuationCache), _effectType);
-    if (isNil "_value") then {
-        private _config = configFile >> "CfgSoundEffects" >> "AttenuationsEffects" >> _effectType >> "acreAttenuation";
-        if (isNumber(_config)) then {
-            _attenuation = getNumber (_config);
-            HASH_SET(GVAR(attenuationCache), _effectType, _attenuation);
-        } else {
-            _attenuation = getNumber (configFile >> "CfgSoundEffects" >> "AttenuationsEffects" >> "acreDefaultAttenuation");
-            HASH_SET(GVAR(attenuationCache), _effectType, _attenuation);
-        };
-    } else {
-        _attenuation = _value;
-    };
-};
+HASH_SET(GVAR(attenuationCache), _effectType, _attenuation);
 
-_attenuation;
+_attenuation


### PR DESCRIPTION
**When merged this pull request will:**
- Add config value for attenution between people inside and turned out in the same vehicle
- Replace hardcoded `0.5` value with config value allowing modders to change it at will
- Keep `0.5 * acreAttenuation` as default
- Try to make code more readable

I'm still uncertain if `acreTurnedOutAttenuation` is a good name. If you have a better name, I'm open to change it.
