### PR TITLE
General - Remove `CALL_RPC` macro and use function

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -1,8 +1,6 @@
 #define DEBUG_SYNCHRONOUS
 #include "\x\cba\addons\main\script_macros_common.hpp"
 
-#define CALL_RPC(proc,params) [proc, params] call EFUNC(sys_rpc,callRemoteProcedure);
-
 #define RGB_GREEN 0, 0.5, 0, 1
 #define RGB_BLUE 0, 0, 1, 1
 #define RGB_ORANGE 0.5, 0.5, 0, 1

--- a/addons/sys_core/fnc_handleGetHeadVector.sqf
+++ b/addons/sys_core/fnc_handleGetHeadVector.sqf
@@ -18,6 +18,6 @@
 // return the head vector of the current acre_player, or 0,0,0 if no vector
 private _vector = [] call FUNC(getHeadVector);
 private _vectorStr = format ["%1,%2,%3,", _vector select 0, _vector select 1, _vector select 2];
-CALL_RPC("setHeadVector", _vectorStr);
+["setHeadVector", _vectorStr] call EFUNC(sys_rpc,callRemoteProcedure);
 
 true

--- a/addons/sys_core/fnc_localStartSpeaking.sqf
+++ b/addons/sys_core/fnc_localStartSpeaking.sqf
@@ -48,8 +48,7 @@ if (!GVAR(fullDuplex) && {ACRE_BROADCASTING_RADIOID != ""}) then {
                 private _unit = _x select 0;
                 if (!isNull _unit && {_unit != acre_player}) then {
                     private _canUnderstand = [_unit] call FUNC(canUnderstand);
-                    private _paramArray = ["r", GET_TS3ID(_unit), !_canUnderstand,1,0,1,0,false,[0,0,0]];
-                    CALL_RPC("updateSpeakingData", _paramArray);
+                    ["updateSpeakingData", ["r", GET_TS3ID(_unit), !_canUnderstand, 1, 0, 1, 0, false, [0, 0, 0]]] call EFUNC(sys_rpc,callRemoteProcedure);
                 };
             } forEach (_sources select _forEachIndex);
         };

--- a/addons/sys_core/fnc_muting.sqf
+++ b/addons/sys_core/fnc_muting.sqf
@@ -117,7 +117,7 @@ DFUNC(mutingPFHLoop) = {
         GVAR(fullListTime) = false;
     };
     if (_mutingParams != "") then {
-        CALL_RPC("setMuted",_mutingParams);
+        ["setMuted", _mutingParams] call EFUNC(sys_rpc,callRemoteProcedure);
     };
     true
 };

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -219,10 +219,8 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
             private _params = HASH_GET(_compiledParams, _x);
             private _canUnderstand = [_unit] call FUNC(canUnderstand);
             private _paramArray = ["r", GET_TS3ID(_unit), !_canUnderstand, count _params];
-            {
-                _paramArray append _x;
-            } forEach _params;
-            CALL_RPC("updateSpeakingData", _paramArray);
+            _paramArray append (flatten _params);
+            ["updateSpeakingData", _paramArray] call EFUNC(sys_rpc,callRemoteProcedure);
         };
     } forEach HASH_KEYS(_compiledParams);
 
@@ -244,17 +242,15 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
             if (_unit call FUNC(inRange)) then {
                 TRACE_1("Calling processDirectSpeaker", _unit);
                 private _params = [_unit] call FUNC(processDirectSpeaker);
-                CALL_RPC("updateSpeakingData", _params);
+                ["updateSpeakingData", _params] call EFUNC(sys_rpc,callRemoteProcedure);
             } else {
                 if !(_unit in _sentMicRadios) then {
-                    private _params = ['m', GET_TS3ID(_unit), 0];
-                    CALL_RPC("updateSpeakingData", _params);
+                    ["updateSpeakingData", ["m", GET_TS3ID(_unit), 0]] call EFUNC(sys_rpc,callRemoteProcedure);
                 };
             };
         } else {
             if (_unit != acre_player) then {
-                private _params = ['m', GET_TS3ID(_unit), 0];
-                CALL_RPC("updateSpeakingData", _params);
+                ["updateSpeakingData", ['m', GET_TS3ID(_unit), 0]] call EFUNC(sys_rpc,callRemoteProcedure);
             };
         };
     };
@@ -265,8 +261,7 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
 
     // Check speaking gods to only allow hearing by the god's target group
     if ((EGVAR(sys_godmode,speakingGods) find _speakingId) != -1) then {
-        private _params = ["g", _speakingId, 0, GVAR(godVolume)];
-        CALL_RPC("updateSpeakingData", _params);
+        ["updateSpeakingData", ["g", _speakingId, 0, GVAR(godVolume)]] call EFUNC(sys_rpc,callRemoteProcedure);
     };
 } forEach GVAR(godSpeakers);
 
@@ -278,7 +273,7 @@ if (ACRE_IS_SPECTATOR) then {
             _volume = 0;
         };
         private _params = ["s", _speakingId, 0, _volume];
-        CALL_RPC("updateSpeakingData", _params);
+        ["updateSpeakingData", ["s", _speakingId, 0, _volume]] call EFUNC(sys_rpc,callRemoteProcedure);
     } forEach GVAR(spectatorSpeakers);
 };
 

--- a/addons/sys_core/fnc_updateSelf.sqf
+++ b/addons/sys_core/fnc_updateSelf.sqf
@@ -43,4 +43,4 @@ _updateSelf append ACRE_LISTENER_POS;
 _updateSelf append ACRE_LISTENER_DIR;
 _updateSelf append _additionalValues;
 
-CALL_RPC("updateSelf", _updateSelf);
+["updateSelf", _updateSelf] call EFUNC(sys_rpc,callRemoteProcedure);

--- a/addons/sys_io/fnc_ts3ChannelMove.sqf
+++ b/addons/sys_io/fnc_ts3ChannelMove.sqf
@@ -17,4 +17,4 @@
 
 private _ts3ChannelDetails = format ["%1,%2,%3", EGVAR(sys_core,ts3ChannelName), EGVAR(sys_core,ts3ChannelPassword), serverName];
 TRACE_1("Moving TS3 Channel",_ts3ChannelDetails);
-CALL_RPC("setTs3ChannelDetails",_ts3ChannelDetails);
+["setTs3ChannelDetails",_ts3ChannelDetails] call EFUNC(sys_rpc,callRemoteProcedure);


### PR DESCRIPTION
**When merged this pull request will:**
- Remove `CALL_RPC` macro as a lot of RPCs have array parameters which have to be worked around with `ARR_n` family of macros. It is just easier to use the function everywhere.