### PR TITLE
Documentation - Update Chat URLs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,7 +34,7 @@ template: |
 
   DESCRIPTION HERE
 
-  If you're looking to chat with us, be sure to join us on [Slack](http://slackin.idi-systems.com) (`#acre2` channel)! 
+  If you're looking to chat with us, be sure to join us on [Discord](https://acemod.org/discord) (`#acre2` channel)!
 
   ## Change Log Summary
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
     <a href="http://acre2.idi-systems.com">
         <img src="https://img.shields.io/badge/Documentation-Home-lightgrey.svg?style=flat-square" alt="ACRE2 Wiki">
     </a>
-    <a href="http://slackin.idi-systems.com">
-        <img src="https://img.shields.io/badge/Slack-Join%20%23acre2-darkviolet.svg?style=flat-square" alt="ACRE2 Slack">
+    <a href="https://acemod.org/discord">
+        <img src="https://img.shields.io/badge/Discord-Join%20%23acre2-darkviolet.svg?style=flat-square" alt="ACE Discord">
     </a>
     <a href="https://travis-ci.org/IDI-Systems/acre2">
         <img src="https://img.shields.io/travis/IDI-Systems/acre2.svg?style=flat-square&label=Build" alt="ACRE2 Build Status">

--- a/docs/_data/topnav.yml
+++ b/docs/_data/topnav.yml
@@ -21,8 +21,8 @@ topnav_dropdowns:
     - title: Contact
       folderitems:
 
-        - title: Slack (#acre2 channel)
-          external_url: http://slackin.idi-systems.com
+        - title: ACE Discord
+          external_url: https://acemod.org/discord
 
         - title: BI Forums
           external_url: https://forums.bistudio.com/topic/193813-acre2-v22-stable-steam-workshop-release


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- Use direct acemod.org URL instead of redirect from slackin.