### PR TITLE
Extensions - Add Tracy support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extensions/src/ACRE2Profiling/tracy"]
+	path = extensions/src/ACRE2Profiling/tracy
+	url = https://github.com/wolfpld/tracy.git

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -58,6 +58,9 @@ if(MSVC)
     set(GLOBAL_SOURCES ${GLOBAL_RC})
 endif()
 
+
+add_subdirectory(src/ACRE2Profiling)
+
 include_directories(src/ACRE2Shared)
 include_directories(src/ACRE2Core)
 
@@ -67,8 +70,6 @@ add_subdirectory(src/ACRE2Core)
 
 add_subdirectory(src/ACRE2Arma)
 add_subdirectory(src/ACRE2Steam)
-
-add_subdirectory(src/ACRE2Profiling)
 
 add_subdirectory(src/ACRE2TS)
 add_subdirectory(src/ACRE2Mumble)

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -6,6 +6,7 @@ include(${PROJECT_SOURCE_DIR}/CMakeModules/cxx_compiler_functions.cmake)
 
 option(USE_64BIT_BUILD "USE_64BIT_BUILD" OFF)
 option(USE_STATIC_LINKING "USE_STATIC_LINKING" ON)
+option(ENABLE_TRACING "ENABLE_TRACING" OFF)
 
 set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 
@@ -58,6 +59,10 @@ if(MSVC)
     set(GLOBAL_SOURCES ${GLOBAL_RC})
 endif()
 
+if(ENABLE_TRACING)
+    message(STATUS "Enabling tracing (beware of excessively verbose log output)")
+    add_compile_definitions(_TRACE=1)
+endif()
 
 add_subdirectory(src/ACRE2Profiling)
 

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -68,6 +68,8 @@ add_subdirectory(src/ACRE2Core)
 add_subdirectory(src/ACRE2Arma)
 add_subdirectory(src/ACRE2Steam)
 
+add_subdirectory(src/ACRE2Profiling)
+
 add_subdirectory(src/ACRE2TS)
 add_subdirectory(src/ACRE2Mumble)
 

--- a/extensions/src/ACRE2Core/CMakeLists.txt
+++ b/extensions/src/ACRE2Core/CMakeLists.txt
@@ -8,5 +8,5 @@ file(GLOB SOURCES *.h *.hpp *.c *.cpp)
 file(GLOB DSP_SOURCES DspFilters/*.h DspFilters/*.hpp DspFilters/*.c DspFilters/*.cpp)
 
 add_library( ${ACRE_NAME} STATIC ${SOURCES} ${GLOBAL_SOURCES} ${DSP_SOURCES})
-target_link_libraries( ${ACRE_NAME} ACRE2Shared)
+target_link_libraries( ${ACRE_NAME} ACRE2Shared ACRE2Profiling)
 set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2)

--- a/extensions/src/ACRE2Core/Engine.cpp
+++ b/extensions/src/ACRE2Core/Engine.cpp
@@ -31,7 +31,10 @@
 #include "setChannelDetails.h"
 #include <shlobj.h>
 
+#include <Tracy.hpp>
+
 acre::Result CEngine::initialize(IClient *client, IServer *externalServer, std::string fromPipeName, std::string toPipeName) {
+    ZoneScoped;
 
     if (!g_Log) {
         std::string acrePluginLog{"acre2_plugin.log"};
@@ -92,6 +95,7 @@ acre::Result CEngine::initialize(IClient *client, IServer *externalServer, std::
 }
 
 acre::Result CEngine::initialize(IClient *client, IServer *externalServer, std::string fromPipeName, std::string toPipeName, std::string loggingPath) {
+    ZoneScoped;
 
     g_Log = (Log *)new Log(const_cast<char *>(loggingPath.c_str()));
     LOG("* Logging engine initialized.");
@@ -100,6 +104,8 @@ acre::Result CEngine::initialize(IClient *client, IServer *externalServer, std::
 }
 
 acre::Result CEngine::start(const acre::id_t id) {
+    ZoneScoped;
+
     if (this->getExternalServer()) {
         this->getExternalServer()->initialize();
     } else {
@@ -124,6 +130,8 @@ acre::Result CEngine::start(const acre::id_t id) {
 }
 
 acre::Result CEngine::stop() {
+    ZoneScoped;
+
     LOG("Engine Shutting Down");
     this->setState(acre::State::stopping);
 
@@ -152,11 +160,15 @@ acre::Result CEngine::stop() {
 }
 
 acre::Result CEngine::localStartSpeaking(const acre::Speaking speakingType) {
+    ZoneScoped;
+
     this->localStartSpeaking(speakingType, "");
     return acre::Result::ok;
 }
 
 acre::Result CEngine::localStartSpeaking(const acre::Speaking speakingType, const std::string radioId) {
+    ZoneScoped;
+
     // send a start speaking event to everyone
     TRACE("Local START speaking: %d, %s", speakingType, radioId.c_str());
     this->getSelf()->lock();
@@ -192,6 +204,8 @@ acre::Result CEngine::localStartSpeaking(const acre::Speaking speakingType, cons
 }
 
 acre::Result CEngine::localStopSpeaking( void ) {
+    ZoneScoped;
+
     this->getSelf()->setSpeaking(false);
     CEngine::getInstance()->getExternalServer()->sendMessage(
         CTextMessage::formatNewMessage("ext_remoteStopSpeaking",
@@ -213,6 +227,8 @@ acre::Result CEngine::localStopSpeaking( void ) {
 }
 
 acre::Result CEngine::remoteStartSpeaking(const acre::id_t remoteId, const int32_t languageId, const std::string netId, const acre::Speaking speakingType, const std::string radioId, const acre::volume_t curveScale) {
+    ZoneScoped;
+
     TRACE("Remote Start Speaking Enter: %d, %d", remoteId, speakingType);
     auto it = this->speakingList.find(remoteId);
     if (it != this->speakingList.end()) {
@@ -241,6 +257,8 @@ acre::Result CEngine::remoteStartSpeaking(const acre::id_t remoteId, const int32
 }
 
 acre::Result CEngine::remoteStopSpeaking(const acre::id_t remoteId) {
+    ZoneScoped;
+
     TRACE("Remote STOP Speaking Enter: %d", remoteId);
     auto it = this->speakingList.find(remoteId);
     if (it != this->speakingList.end()) {

--- a/extensions/src/ACRE2Core/NamedPipeServer.cpp
+++ b/extensions/src/ACRE2Core/NamedPipeServer.cpp
@@ -4,6 +4,7 @@
 #include "Log.h"
 #include "Engine.h"
 
+#include <Tracy.hpp>
 
     
 
@@ -24,6 +25,8 @@ CNamedPipeServer::~CNamedPipeServer( void ) {
 }
 
 acre::Result CNamedPipeServer::initialize() {
+    ZoneScoped;
+
     HANDLE writeHandle, readHandle;
 
     SECURITY_DESCRIPTOR sd;
@@ -105,6 +108,8 @@ acre::Result CNamedPipeServer::initialize() {
 }
 
 acre::Result CNamedPipeServer::shutdown(void) {
+    ZoneScoped;
+
     HANDLE hPipe;
 
     this->setShuttingDown(true);

--- a/extensions/src/ACRE2Core/RpcEngine.cpp
+++ b/extensions/src/ACRE2Core/RpcEngine.cpp
@@ -12,10 +12,14 @@
 #include "Log.h"
 #include <list>
 
+#include <Tracy.hpp>
+
 //
 // Entrant worker, weee
 //
 acre::Result CRpcEngine::exProcessItem(ACRE_RPCDATA *data) {
+    ZoneScoped;
+
     if (data->function != nullptr) {
         data->function->call(data->server, data->message);
     }
@@ -29,6 +33,8 @@ acre::Result CRpcEngine::exProcessItem(ACRE_RPCDATA *data) {
 // Proc functions
 // 
 acre::Result CRpcEngine::addProcedure(IRpcFunction *const cmd) {
+    ZoneScoped;
+
     LOCK(this);
     this->m_FunctionList.insert(std::pair<std::string, IRpcFunction *>(std::string(cmd->getName()), cmd));
     UNLOCK(this);
@@ -36,6 +42,8 @@ acre::Result CRpcEngine::addProcedure(IRpcFunction *const cmd) {
     return acre::Result::ok;
 }
 acre::Result CRpcEngine::removeProcedure(IRpcFunction *const cmd) {
+    ZoneScoped;
+
     LOCK(this);
     this->m_FunctionList.erase(cmd->getName());
     UNLOCK(this);
@@ -43,6 +51,8 @@ acre::Result CRpcEngine::removeProcedure(IRpcFunction *const cmd) {
     return acre::Result::ok;
 }
 acre::Result CRpcEngine::removeProcedure(char *const cmd) {
+    ZoneScoped;
+
     LOCK(this);
     this->m_FunctionList.erase(cmd);
     UNLOCK(this);
@@ -50,6 +60,8 @@ acre::Result CRpcEngine::removeProcedure(char *const cmd) {
     return acre::Result::ok;
 }
 IRpcFunction *CRpcEngine::findProcedure(char *const cmd) {
+    ZoneScoped;
+
     
     if (this->getShuttingDown()) {
         return nullptr;
@@ -62,11 +74,15 @@ IRpcFunction *CRpcEngine::findProcedure(char *const cmd) {
 
     return nullptr;
 }
+
 acre::Result CRpcEngine::runProcedure(IServer *const serverInstance, IMessage *msg) {
+    ZoneScoped;
+
     return this->runProcedure(serverInstance, msg, TRUE);
 }
 
 acre::Result CRpcEngine::runProcedure(IServer *const serverInstance, IMessage *msg, const bool entrant) {
+    ZoneScoped;
     
     if (msg == nullptr) {
         return acre::Result::error;

--- a/extensions/src/ACRE2Core/RpcEngine.cpp
+++ b/extensions/src/ACRE2Core/RpcEngine.cpp
@@ -19,6 +19,7 @@
 //
 acre::Result CRpcEngine::exProcessItem(ACRE_RPCDATA *data) {
     ZoneScoped;
+    tracy::SetThreadName("RPCEngine");
 
     if (data->function != nullptr) {
         data->function->call(data->server, data->message);

--- a/extensions/src/ACRE2Core/RpcEngine.cpp
+++ b/extensions/src/ACRE2Core/RpcEngine.cpp
@@ -14,18 +14,21 @@
 
 #include <Tracy.hpp>
 
-//
+const char *frameName = "RPCEngine";
+  //
 // Entrant worker, weee
 //
 acre::Result CRpcEngine::exProcessItem(ACRE_RPCDATA *data) {
-    ZoneScoped;
     tracy::SetThreadName("RPCEngine");
+    FrameMarkStart(frameName);
 
     if (data->function != nullptr) {
         data->function->call(data->server, data->message);
     }
     delete data->message;
     free(data);
+
+    FrameMarkEnd(frameName);
 
     return acre::Result::ok;
 }

--- a/extensions/src/ACRE2Core/ext_handleGetClientID.h
+++ b/extensions/src/ACRE2Core/ext_handleGetClientID.h
@@ -11,7 +11,11 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(ext_handleGetClientID) {
+    ZoneScoped;
+
     CEngine::getInstance()->getGameServer()->sendMessage(
         CTextMessage::formatNewMessage("handleGetClientID",
             "%d,%s,",

--- a/extensions/src/ACRE2Core/ext_handleGetClientID.h
+++ b/extensions/src/ACRE2Core/ext_handleGetClientID.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(ext_handleGetClientID) {
-    ZoneScoped;
+    ZoneScopedN("RPC - ext_handleGetClientID");
 
     CEngine::getInstance()->getGameServer()->sendMessage(
         CTextMessage::formatNewMessage("handleGetClientID",

--- a/extensions/src/ACRE2Core/ext_remoteStartSpeaking.h
+++ b/extensions/src/ACRE2Core/ext_remoteStartSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(ext_remoteStartSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - ext_remoteStartSpeaking");
 
     /*CTextMessage::formatNewMessage("ext_remoteStartSpeaking",
             "%d,%d,%s,%f,",

--- a/extensions/src/ACRE2Core/ext_remoteStartSpeaking.h
+++ b/extensions/src/ACRE2Core/ext_remoteStartSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(ext_remoteStartSpeaking) {
+    ZoneScoped;
 
     /*CTextMessage::formatNewMessage("ext_remoteStartSpeaking",
             "%d,%d,%s,%f,",

--- a/extensions/src/ACRE2Core/ext_remoteStopSpeaking.h
+++ b/extensions/src/ACRE2Core/ext_remoteStopSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(ext_remoteStopSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - ext_remoteStopSpeaking");
 
     /*CTextMessage::formatNewMessage("ext_remoteStartSpeaking",
             "%d,%d,%s,%f,",

--- a/extensions/src/ACRE2Core/ext_remoteStopSpeaking.h
+++ b/extensions/src/ACRE2Core/ext_remoteStopSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(ext_remoteStopSpeaking) {
+    ZoneScoped;
 
     /*CTextMessage::formatNewMessage("ext_remoteStartSpeaking",
             "%d,%d,%s,%f,",

--- a/extensions/src/ACRE2Core/ext_reset.h
+++ b/extensions/src/ACRE2Core/ext_reset.h
@@ -8,7 +8,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(ext_reset) {
-    ZoneScoped;
+    ZoneScopedN("RPC - ext_reset");
 
     const acre::id_t id = vMessage->getParameterAsInt(0);
 

--- a/extensions/src/ACRE2Core/ext_reset.h
+++ b/extensions/src/ACRE2Core/ext_reset.h
@@ -5,7 +5,11 @@
 #include "Types.h"
 #include "Engine.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(ext_reset) {
+    ZoneScoped;
+
     const acre::id_t id = vMessage->getParameterAsInt(0);
 
     //

--- a/extensions/src/ACRE2Core/getClientID.h
+++ b/extensions/src/ACRE2Core/getClientID.h
@@ -12,7 +12,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(getClientID) {
+    ZoneScoped;
 
     TRACE("enter");
 

--- a/extensions/src/ACRE2Core/getClientID.h
+++ b/extensions/src/ACRE2Core/getClientID.h
@@ -15,7 +15,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(getClientID) {
-    ZoneScoped;
+    ZoneScopedN("RPC - getClientID");
 
     TRACE("enter");
 

--- a/extensions/src/ACRE2Core/getPluginVersion.h
+++ b/extensions/src/ACRE2Core/getPluginVersion.h
@@ -6,7 +6,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(getPluginVersion) {
-    ZoneScoped;
+    ZoneScopedN("RPC - getPluginVersion");
 
     vServer->sendMessage(CTextMessage::formatNewMessage("handleGetPluginVersion", "%s", ACRE_VERSION));
 

--- a/extensions/src/ACRE2Core/getPluginVersion.h
+++ b/extensions/src/ACRE2Core/getPluginVersion.h
@@ -3,7 +3,10 @@
 #include "IServer.h"
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(getPluginVersion) {
+    ZoneScoped;
 
     vServer->sendMessage(CTextMessage::formatNewMessage("handleGetPluginVersion", "%s", ACRE_VERSION));
 

--- a/extensions/src/ACRE2Core/loadSound.h
+++ b/extensions/src/ACRE2Core/loadSound.h
@@ -11,7 +11,11 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(loadSound) {
+    ZoneScoped;
+
     const std::string id = std::string((char *)vMessage->getParameter(0));
     const int32_t currentCount = vMessage->getParameterAsInt(1);
     const int32_t totalCount = vMessage->getParameterAsInt(2);

--- a/extensions/src/ACRE2Core/loadSound.h
+++ b/extensions/src/ACRE2Core/loadSound.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(loadSound) {
-    ZoneScoped;
+    ZoneScopedN("RPC - loadSound");
 
     const std::string id = std::string((char *)vMessage->getParameter(0));
     const int32_t currentCount = vMessage->getParameterAsInt(1);

--- a/extensions/src/ACRE2Core/localMute.h
+++ b/extensions/src/ACRE2Core/localMute.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(localMute) {
-    ZoneScoped;
+    ZoneScopedN("RPC - localMute");
 
     const bool status = vMessage->getParameterAsInt(0) == 1;
 

--- a/extensions/src/ACRE2Core/localMute.h
+++ b/extensions/src/ACRE2Core/localMute.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(localMute) {
+    ZoneScoped;
 
     const bool status = vMessage->getParameterAsInt(0) == 1;
 

--- a/extensions/src/ACRE2Core/ping.h
+++ b/extensions/src/ACRE2Core/ping.h
@@ -12,7 +12,7 @@
 volatile DWORD g_pingTime;
 
 RPC_FUNCTION(ping) {
-    ZoneScoped;
+    ZoneScopedN("RPC - ping");
 
     g_pingTime = clock() / CLOCKS_PER_SEC;
     vServer->sendMessage(CTextMessage::formatNewMessage("pong", "%f,", g_pingTime));

--- a/extensions/src/ACRE2Core/ping.h
+++ b/extensions/src/ACRE2Core/ping.h
@@ -7,9 +7,13 @@
 #include "Engine.h"
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 volatile DWORD g_pingTime;
 
 RPC_FUNCTION(ping) {
+    ZoneScoped;
+
     g_pingTime = clock() / CLOCKS_PER_SEC;
     vServer->sendMessage(CTextMessage::formatNewMessage("pong", "%f,", g_pingTime));
     return acre::Result::ok;

--- a/extensions/src/ACRE2Core/playSound.h
+++ b/extensions/src/ACRE2Core/playSound.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(playLoadedSound) {
-    ZoneScoped;
+    ZoneScopedN("RPC - playLoadedSound");
 
     const std::string id = std::string((char *)vMessage->getParameter(0));
     const acre::vec3_fp32_t position(vMessage->getParameterAsFloat(1), vMessage->getParameterAsFloat(3), vMessage->getParameterAsFloat(2));

--- a/extensions/src/ACRE2Core/playSound.h
+++ b/extensions/src/ACRE2Core/playSound.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(playLoadedSound) {
+    ZoneScoped;
 
     const std::string id = std::string((char *)vMessage->getParameter(0));
     const acre::vec3_fp32_t position(vMessage->getParameterAsFloat(1), vMessage->getParameterAsFloat(3), vMessage->getParameterAsFloat(2));

--- a/extensions/src/ACRE2Core/setChannelDetails.h
+++ b/extensions/src/ACRE2Core/setChannelDetails.h
@@ -7,7 +7,11 @@
 
 #include <sstream>
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(setChannelDetails) {
+    ZoneScoped;
+
     const  std::vector<std::string> details = {
         std::string((char *)vMessage->getParameter(0)),
         std::string((char *)vMessage->getParameter(1)),

--- a/extensions/src/ACRE2Core/setChannelDetails.h
+++ b/extensions/src/ACRE2Core/setChannelDetails.h
@@ -10,7 +10,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(setChannelDetails) {
-    ZoneScoped;
+    ZoneScopedN("RPC - setChannelDetails");
 
     const  std::vector<std::string> details = {
         std::string((char *)vMessage->getParameter(0)),

--- a/extensions/src/ACRE2Core/setMuted.h
+++ b/extensions/src/ACRE2Core/setMuted.h
@@ -12,7 +12,7 @@
 
 
 RPC_FUNCTION(setMuted) {
-    ZoneScoped;
+    ZoneScopedN("RPC - setMuted");
 
     for (DWORD index = 0; index < vMessage->getParameterCount(); -1) {
         if (vMessage->getParameter(index) == nullptr) {

--- a/extensions/src/ACRE2Core/setMuted.h
+++ b/extensions/src/ACRE2Core/setMuted.h
@@ -8,9 +8,12 @@
 #include "Engine.h"
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
 
 
 RPC_FUNCTION(setMuted) {
+    ZoneScoped;
+
     for (DWORD index = 0; index < vMessage->getParameterCount(); -1) {
         if (vMessage->getParameter(index) == nullptr) {
             break;

--- a/extensions/src/ACRE2Core/setPTTKeys.h
+++ b/extensions/src/ACRE2Core/setPTTKeys.h
@@ -4,7 +4,11 @@
 #include "TextMessage.h"
 #include "Log.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(setPTTKeys) {
+    ZoneScoped;
+
     /*
     CEngine::getInstance()->getKeyHandlerEngine()->setKeyBind(
         std::string((char *)vMessage->getParameter(0)),

--- a/extensions/src/ACRE2Core/setPTTKeys.h
+++ b/extensions/src/ACRE2Core/setPTTKeys.h
@@ -7,7 +7,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(setPTTKeys) {
-    ZoneScoped;
+    ZoneScopedN("RPC - setPTTKeys");
 
     /*
     CEngine::getInstance()->getKeyHandlerEngine()->setKeyBind(

--- a/extensions/src/ACRE2Core/setSelectableVoiceCurve.h
+++ b/extensions/src/ACRE2Core/setSelectableVoiceCurve.h
@@ -4,7 +4,11 @@
 #include "TextMessage.h"
 #include "Log.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(setSelectableVoiceCurve) {
+    ZoneScoped;
+
     const float32_t voiceCurveScale = vMessage->getParameterAsFloat(0);
     //LOG("VOICE MODEL: %d VOICE CURVE: %f", voiceModel, voiceCurveScale);
     if (!CEngine::getInstance()->getGameServer()->getConnected()) {

--- a/extensions/src/ACRE2Core/setSelectableVoiceCurve.h
+++ b/extensions/src/ACRE2Core/setSelectableVoiceCurve.h
@@ -7,7 +7,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(setSelectableVoiceCurve) {
-    ZoneScoped;
+    ZoneScopedN("RPC - setSelectableVoiceCurve");
 
     const float32_t voiceCurveScale = vMessage->getParameterAsFloat(0);
     //LOG("VOICE MODEL: %d VOICE CURVE: %f", voiceModel, voiceCurveScale);

--- a/extensions/src/ACRE2Core/setSetting.h
+++ b/extensions/src/ACRE2Core/setSetting.h
@@ -7,7 +7,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(setSetting) {
-    ZoneScoped;
+    ZoneScopedN("RPC - setSetting");
 
     const std::string name = std::string((char *)vMessage->getParameter(0));
     float32_t value = vMessage->getParameterAsFloat(1);

--- a/extensions/src/ACRE2Core/setSetting.h
+++ b/extensions/src/ACRE2Core/setSetting.h
@@ -4,7 +4,11 @@
 #include "Log.h"
 #include "AcreSettings.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(setSetting) {
+    ZoneScoped;
+
     const std::string name = std::string((char *)vMessage->getParameter(0));
     float32_t value = vMessage->getParameterAsFloat(1);
     value = round(value * 100.0f) / 100.0f;

--- a/extensions/src/ACRE2Core/setSoundSystemMasterOverride.h
+++ b/extensions/src/ACRE2Core/setSoundSystemMasterOverride.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(setSoundSystemMasterOverride) {
+    ZoneScoped;
 
     const bool status = vMessage->getParameterAsInt(0) == 1;
 

--- a/extensions/src/ACRE2Core/setSoundSystemMasterOverride.h
+++ b/extensions/src/ACRE2Core/setSoundSystemMasterOverride.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(setSoundSystemMasterOverride) {
-    ZoneScoped;
+    ZoneScopedN("RPC - setSoundSystemMasterOverride");
 
     const bool status = vMessage->getParameterAsInt(0) == 1;
 

--- a/extensions/src/ACRE2Core/setVoiceCurveModel.h
+++ b/extensions/src/ACRE2Core/setVoiceCurveModel.h
@@ -4,7 +4,11 @@
 #include "TextMessage.h"
 #include "Log.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(setVoiceCurveModel) {
+    ZoneScoped;
+
     const acre::CurveModel voiceModel = static_cast<acre::CurveModel>(vMessage->getParameterAsInt(0));
     const float32_t voiceCurveScale = vMessage->getParameterAsFloat(1);
 

--- a/extensions/src/ACRE2Core/setVoiceCurveModel.h
+++ b/extensions/src/ACRE2Core/setVoiceCurveModel.h
@@ -7,7 +7,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(setVoiceCurveModel) {
-    ZoneScoped;
+    ZoneScopedN("RPC - setVoiceCurveModel");
 
     const acre::CurveModel voiceModel = static_cast<acre::CurveModel>(vMessage->getParameterAsInt(0));
     const float32_t voiceCurveScale = vMessage->getParameterAsFloat(1);

--- a/extensions/src/ACRE2Core/startGodModeSpeaking.h
+++ b/extensions/src/ACRE2Core/startGodModeSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(startGodModeSpeaking) {
+    ZoneScoped;
 
     CEngine::getInstance()->getClient()->localStartSpeaking(acre::Speaking::god);
 

--- a/extensions/src/ACRE2Core/startGodModeSpeaking.h
+++ b/extensions/src/ACRE2Core/startGodModeSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(startGodModeSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - startGodModeSpeaking");
 
     CEngine::getInstance()->getClient()->localStartSpeaking(acre::Speaking::god);
 

--- a/extensions/src/ACRE2Core/startIntercomSpeaking.h
+++ b/extensions/src/ACRE2Core/startIntercomSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(startIntercomSpeaking) {
+    ZoneScoped;
 
     CEngine::getInstance()->getClient()->localStartSpeaking(acre::Speaking::intercom);
 

--- a/extensions/src/ACRE2Core/startIntercomSpeaking.h
+++ b/extensions/src/ACRE2Core/startIntercomSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(startIntercomSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - startIntercomSpeaking");
 
     CEngine::getInstance()->getClient()->localStartSpeaking(acre::Speaking::intercom);
 

--- a/extensions/src/ACRE2Core/startRadioSpeaking.h
+++ b/extensions/src/ACRE2Core/startRadioSpeaking.h
@@ -16,7 +16,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(startRadioSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - startRadioSpeaking");
 
     const std::string radioId = std::string((char *)vMessage->getParameter(0));
 

--- a/extensions/src/ACRE2Core/startRadioSpeaking.h
+++ b/extensions/src/ACRE2Core/startRadioSpeaking.h
@@ -13,7 +13,10 @@
 
 #include <string>
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(startRadioSpeaking) {
+    ZoneScoped;
 
     const std::string radioId = std::string((char *)vMessage->getParameter(0));
 

--- a/extensions/src/ACRE2Core/startZeusSpeaking.h
+++ b/extensions/src/ACRE2Core/startZeusSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(startZeusSpeaking) {
+    ZoneScoped;
 
     CEngine::getInstance()->getClient()->localStartSpeaking(acre::Speaking::zeus);
 

--- a/extensions/src/ACRE2Core/startZeusSpeaking.h
+++ b/extensions/src/ACRE2Core/startZeusSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(startZeusSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - startZeusSpeaking");
 
     CEngine::getInstance()->getClient()->localStartSpeaking(acre::Speaking::zeus);
 

--- a/extensions/src/ACRE2Core/stopGodModeSpeaking.h
+++ b/extensions/src/ACRE2Core/stopGodModeSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(stopGodModeSpeaking) {
+    ZoneScoped;
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::god);
 

--- a/extensions/src/ACRE2Core/stopGodModeSpeaking.h
+++ b/extensions/src/ACRE2Core/stopGodModeSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(stopGodModeSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - stopGodModeSpeaking");
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::god);
 

--- a/extensions/src/ACRE2Core/stopIntercomSpeaking.h
+++ b/extensions/src/ACRE2Core/stopIntercomSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(stopIntercomSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - stopIntercomSpeaking");
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::intercom);
 

--- a/extensions/src/ACRE2Core/stopIntercomSpeaking.h
+++ b/extensions/src/ACRE2Core/stopIntercomSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(stopIntercomSpeaking) {
+    ZoneScoped;
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::intercom);
 

--- a/extensions/src/ACRE2Core/stopRadioSpeaking.h
+++ b/extensions/src/ACRE2Core/stopRadioSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(stopRadioSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - stopRadioSpeaking");
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::radio);
 

--- a/extensions/src/ACRE2Core/stopRadioSpeaking.h
+++ b/extensions/src/ACRE2Core/stopRadioSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(stopRadioSpeaking) {
+    ZoneScoped;
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::radio);
 

--- a/extensions/src/ACRE2Core/stopZeusSpeaking.h
+++ b/extensions/src/ACRE2Core/stopZeusSpeaking.h
@@ -11,7 +11,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(stopZeusSpeaking) {
+    ZoneScoped;
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::zeus);
 

--- a/extensions/src/ACRE2Core/stopZeusSpeaking.h
+++ b/extensions/src/ACRE2Core/stopZeusSpeaking.h
@@ -14,7 +14,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(stopZeusSpeaking) {
-    ZoneScoped;
+    ZoneScopedN("RPC - stopZeuSpeaking");
 
     CEngine::getInstance()->getClient()->localStopSpeaking(acre::Speaking::zeus);
 

--- a/extensions/src/ACRE2Core/updateSelf.h
+++ b/extensions/src/ACRE2Core/updateSelf.h
@@ -15,7 +15,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(updateSelf) {
-    ZoneScoped;
+    ZoneScopedN("RPC - updateSelf");
 
     LOCK(CEngine::getInstance()->getSelf());
 

--- a/extensions/src/ACRE2Core/updateSelf.h
+++ b/extensions/src/ACRE2Core/updateSelf.h
@@ -12,7 +12,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(updateSelf) {
+    ZoneScoped;
 
     LOCK(CEngine::getInstance()->getSelf());
 

--- a/extensions/src/ACRE2Core/updateSpeakingData.h
+++ b/extensions/src/ACRE2Core/updateSpeakingData.h
@@ -12,7 +12,10 @@
 
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 RPC_FUNCTION(updateSpeakingData) {
+    ZoneScoped;
 
     CPlayer *speaker = nullptr;
 

--- a/extensions/src/ACRE2Core/updateSpeakingData.h
+++ b/extensions/src/ACRE2Core/updateSpeakingData.h
@@ -15,7 +15,7 @@
 #include <Tracy.hpp>
 
 RPC_FUNCTION(updateSpeakingData) {
-    ZoneScoped;
+    ZoneScopedN("RPC - updateSpeakingData");
 
     CPlayer *speaker = nullptr;
 

--- a/extensions/src/ACRE2Mumble/CMakeLists.txt
+++ b/extensions/src/ACRE2Mumble/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB_RECURSE SOURCES *.h *.hpp *.c *.cpp *.asm mumble_includes/*)
 include_directories(mumble_includes)
 
 add_library( ${ACRE_NAME} MODULE ${SOURCES} ${GLOBAL_SOURCES})
-target_link_libraries(${ACRE_NAME} ACRE2Core ACRE2Shared x3daudio)
+target_link_libraries(${ACRE_NAME} ACRE2Core ACRE2Shared ACRE2Profiling x3daudio)
 set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2 LINK_FLAGS -SAFESEH:NO)
 target_compile_features(${ACRE_NAME} PRIVATE cxx_std_17)
 

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_channelEvents.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_channelEvents.cpp
@@ -5,11 +5,15 @@
 #include "Types.h"
 #include "compat.h"
 
+#include <Tracy.hpp>
+
 extern MumbleAPI_v_1_0_x mumAPI;
 extern mumble_connection_t activeConnection;
 extern mumble_plugin_id_t pluginID;
 
 void mumble_onChannelRenamed(mumble_connection_t connection, mumble_channelid_t channelID) {
+    ZoneScoped;
+
     (void) connection;
     (void) channelID;
     CEngine::getInstance()->getClient()->updateShouldSwitchChannel(true);

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_init.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_init.cpp
@@ -7,8 +7,12 @@
 #include "compat.h"
 #include "helpers.h"
 
+#include <Tracy.hpp>
+
 #define FROM_PIPENAME "\\\\.\\pipe\\acre_comm_pipe_fromTS"
 #define TO_PIPENAME   "\\\\.\\pipe\\acre_comm_pipe_toTS"
+
+const char *mumbleThreadName = "Mumble main thread";
 
 extern MumbleAPI_v_1_0_x mumAPI;
 mumble_connection_t activeConnection = -1;
@@ -23,6 +27,10 @@ void mumble_registerAPIFunctions(void *apiStruct) {
 }
 
 mumble_error_t mumble_init(mumble_plugin_id_t id) {
+    ZoneScoped;
+
+    tracy::SetThreadName(mumbleThreadName);
+
     pluginID = id;
 
     acre::MumbleEventLoop::getInstance().start();
@@ -49,7 +57,13 @@ mumble_error_t mumble_init(mumble_plugin_id_t id) {
 }
 
 void mumble_onServerSynchronized(mumble_connection_t connection) {
+    ZoneScoped;
+
+    tracy::SetThreadName(mumbleThreadName);
+
     acre::MumbleEventLoop::getInstance().queue([connection]() {
+        ZoneScoped;
+
         activeConnection = connection;
 
         // set ID on every new connection
@@ -66,7 +80,11 @@ void mumble_onServerSynchronized(mumble_connection_t connection) {
 }
 
 void mumble_onServerDisconnected(mumble_connection_t connection) {
+    ZoneScoped;
+
     acre::MumbleEventLoop::getInstance().queue([connection]() {
+        ZoneScoped;
+
         activeConnection = -1;
 
         if ((CEngine::getInstance()->getClient()->getState() != acre::State::stopped) &&
@@ -77,7 +95,11 @@ void mumble_onServerDisconnected(mumble_connection_t connection) {
 }
 
 void mumble_shutdown() {
+    ZoneScoped;
+
     acre::MumbleEventLoop::getInstance().queue([]() {
+        ZoneScoped;
+
         if ((CEngine::getInstance()->getClient()->getState() != acre::State::stopped) &&
             (CEngine::getInstance()->getClient()->getState() != acre::State::stopping)) {
             CEngine::getInstance()->getClient()->stop();

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_init.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_init.cpp
@@ -35,7 +35,7 @@ mumble_error_t mumble_init(mumble_plugin_id_t id) {
 
     acre::MumbleEventLoop::getInstance().start();
 
-    if (mumAPI.getActiveServerConnection(pluginID, &activeConnection) != MUMBLE_STATUS_OK) {
+    if (API_CALL(getActiveServerConnection, pluginID, &activeConnection) != MUMBLE_STATUS_OK) {
         activeConnection = -1;
     }
 
@@ -68,7 +68,7 @@ void mumble_onServerSynchronized(mumble_connection_t connection) {
 
         // set ID on every new connection
         acre::id_t clientId = 0;
-        mumAPI.getLocalUserID(pluginID, activeConnection, (mumble_userid_t*)&clientId);
+        API_CALL(getLocalUserID, pluginID, activeConnection, (mumble_userid_t*)&clientId);
         CEngine::getInstance()->getSelf()->setId(clientId);
         CEngine::getInstance()->getExternalServer()->setId(clientId);
 

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_init.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_init.cpp
@@ -67,8 +67,12 @@ void mumble_onServerSynchronized(mumble_connection_t connection) {
         activeConnection = connection;
 
         // set ID on every new connection
-        acre::id_t clientId = 0;
-        API_CALL(getLocalUserID, pluginID, activeConnection, (mumble_userid_t*)&clientId);
+        acre::id_t clientId = 5;
+        mumble_error_t retCode = API_CALL(getLocalUserID, pluginID, activeConnection, (mumble_userid_t*)&clientId);
+        if (retCode != MUMBLE_STATUS_OK) {
+            LOG("ERROR, FAILED TO FETCH LOCAL USER'S ID: %s (%d)", mumble_errorMessage(retCode), retCode);
+        }
+        TRACE("Local user's ID is %d", clientId);
         CEngine::getInstance()->getSelf()->setId(clientId);
         CEngine::getInstance()->getExternalServer()->setId(clientId);
 

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_pluginEvents.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_pluginEvents.cpp
@@ -4,14 +4,20 @@
 #include "MumbleEventLoop.h"
 #include "compat.h"
 
+#include <Tracy.hpp>
+
 //
 // Handle a command event
 //
 bool mumble_onReceiveData(mumble_connection_t connection, mumble_userid_t sender, const uint8_t *data, size_t dataLength, const char *dataID) {
+    ZoneScoped;
+
     if ((dataLength > 0U) && CEngine::getInstance()->getExternalServer()) {
         // Copy data to make sure it stays available in the async processing
         std::string dataString(reinterpret_cast<const char *>(data), dataLength);
         acre::MumbleEventLoop::getInstance().queue([dataString]() {
+            ZoneScoped;
+
             CEngine::getInstance()->getExternalServer()->handleMessage((unsigned char *)dataString.data(), dataString.size());
         });
         return true;

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_sound.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_sound.cpp
@@ -108,6 +108,8 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
 }
 
 bool mumble_onAudioOutputAboutToPlay(float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRate) {
+    tracy::SetThreadName("Mumble audio output thread");
+
     (void) sampleRate;
 
     if (CEngine::getInstance()->getSoundSystemOverride()) {

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_sound.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_sound.cpp
@@ -6,6 +6,8 @@
 #include "Wave.h"
 #include "compat.h"
 
+#include <Tracy.hpp>
+
 #include <map>
 #define _USE_MATH_DEFINES
 
@@ -17,6 +19,8 @@
 using LIMITER = std::numeric_limits<int16_t>;
 
 bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRate, bool isSpeech, mumble_userid_t userID) {
+    ZoneScoped;
+
     (void) sampleRate;
 
     if (CEngine::getInstance()->getSoundSystemOverride()) {
@@ -104,6 +108,8 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
 }
 
 bool mumble_onAudioOutputAboutToPlay(float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRate) {
+    ZoneScoped;
+
     (void) sampleRate;
 
     if (CEngine::getInstance()->getSoundSystemOverride()) {

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_sound.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_sound.cpp
@@ -19,8 +19,6 @@
 using LIMITER = std::numeric_limits<int16_t>;
 
 bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRate, bool isSpeech, mumble_userid_t userID) {
-    ZoneScoped;
-
     (void) sampleRate;
 
     if (CEngine::getInstance()->getSoundSystemOverride()) {
@@ -34,6 +32,8 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
     if (!CEngine::getInstance()->getGameServer()->getConnected()) {
         return false;
     }
+
+    ZoneScoped;
 
     // Make this faster
     const std::uint32_t mixdownSampleLength = sampleCount;
@@ -108,8 +108,6 @@ bool mumble_onAudioSourceFetched(float *outputPCM, uint32_t sampleCount, uint16_
 }
 
 bool mumble_onAudioOutputAboutToPlay(float *outputPCM, uint32_t sampleCount, uint16_t channelCount, uint32_t sampleRate) {
-    ZoneScoped;
-
     (void) sampleRate;
 
     if (CEngine::getInstance()->getSoundSystemOverride()) {
@@ -123,6 +121,8 @@ bool mumble_onAudioOutputAboutToPlay(float *outputPCM, uint32_t sampleCount, uin
     if (!CEngine::getInstance()->getGameServer()->getConnected()) {
         return false;
     }
+
+    ZoneScoped;
 
     uint32_t speakerMask = SPEAKER_STEREO;
 

--- a/extensions/src/ACRE2Mumble/MumbleCallbacks_speaking.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCallbacks_speaking.cpp
@@ -6,11 +6,16 @@
 #include "Types.h"
 #include "compat.h"
 
+#include <Tracy.hpp>
 //
 // Mumble Speaking callbacks
 //
 void mumble_onUserTalkingStateChanged(mumble_connection_t connection, mumble_userid_t userID, mumble_talking_state_t status) {
+    ZoneScoped;
+
     acre::MumbleEventLoop::getInstance().queue([connection, userID, status]() {
+        ZoneScoped;
+
         TRACE("mumble_onUserTalkingStateChanged ENTER: %d", status);
         if (static_cast<acre::id_t>(userID) != CEngine::getInstance()->getSelf()->getId()) {
             return;

--- a/extensions/src/ACRE2Mumble/MumbleClient.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleClient.cpp
@@ -433,8 +433,6 @@ uint64_t CMumbleClient::findChannelByNames(std::vector<std::string> details_) {
 }
 
 acre::Result CMumbleClient::updateChannelDetails(std::vector<std::string> details_) {
-    ZoneScoped;
-
     setChannelDetails(details_);
     if (!details_.empty()) {
         updateShouldSwitchChannel(true);
@@ -443,14 +441,10 @@ acre::Result CMumbleClient::updateChannelDetails(std::vector<std::string> detail
 }
 
 acre::Result CMumbleClient::updateShouldSwitchChannel(const bool state_) {
-    ZoneScoped;
-
     setShouldSwitchChannel(state_);
     return acre::Result::ok;
 }
 
 bool CMumbleClient::shouldSwitchChannel() {
-    ZoneScoped;
-
     return getShouldSwitchChannel();
 }

--- a/extensions/src/ACRE2Mumble/MumbleClient.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleClient.cpp
@@ -8,6 +8,8 @@
 #include "compat.h"
 #include "shlobj.h"
 
+#include <Tracy.hpp>
+
 #pragma comment(lib, "Shlwapi.lib")
 
 static constexpr std::int32_t invalid_mumble_channel = -1;
@@ -18,28 +20,38 @@ extern mumble_connection_t activeConnection;
 extern mumble_plugin_id_t pluginID;
 
 acre::Result CMumbleClient::initialize() {
+    ZoneScoped;
+
     setPreviousChannel(invalid_mumble_channel);
     return acre::Result::ok;
 }
 
 acre::Result CMumbleClient::setMuted(const acre::id_t id_, const bool muted_) {
+    ZoneScoped;
+
     (void) id_;
     (void) muted_;
     return acre::Result::ok;
 }
 
 acre::Result CMumbleClient::setMuted(std::list<acre::id_t> idList_, bool muted_) {
+    ZoneScoped;
+
     (void) idList_;
     (void) muted_;
     return acre::Result::ok;
 }
 
 acre::Result CMumbleClient::getMuted(acre::id_t id_) {
+    ZoneScoped;
+
     (void) id_;
     return acre::Result::ok;
 }
 
 acre::Result CMumbleClient::stop() {
+    ZoneScoped;
+
     if (CEngine::getInstance() != nullptr) {
         CEngine::getInstance()->stop();
         this->setState(acre::State::stopping);
@@ -55,6 +67,8 @@ acre::Result CMumbleClient::stop() {
 }
 
 acre::Result CMumbleClient::start(const acre::id_t id_) {
+    ZoneScoped;
+
     CEngine::getInstance()->start(id_);
     this->setInputActive(false);
     this->setDirectFirst(false);
@@ -75,6 +89,8 @@ acre::Result CMumbleClient::start(const acre::id_t id_) {
 }
 
 bool CMumbleClient::getVAD() {
+    ZoneScoped;
+
     mumble_transmission_mode_t transmitMode;
     const mumble_error_t err = mumAPI.getLocalUserTransmissionMode(pluginID, &transmitMode);
     if (err != MUMBLE_STATUS_OK) {
@@ -85,11 +101,15 @@ bool CMumbleClient::getVAD() {
 }
 
 acre::Result CMumbleClient::localStartSpeaking(const acre::Speaking speakingType_) {
+    ZoneScoped;
+
     this->localStartSpeaking(speakingType_, "");
     return acre::Result::ok;
 }
 
 acre::Result CMumbleClient::localStartSpeaking(const acre::Speaking speakingType_, std::string radioId_) {
+    ZoneScoped;
+
     bool stopDirectSpeaking = false;
 
     const bool VADactive = this->getVAD();
@@ -133,6 +153,8 @@ acre::Result CMumbleClient::localStartSpeaking(const acre::Speaking speakingType
 }
 
 acre::Result CMumbleClient::localStopSpeaking(const acre::Speaking speakingType_) {
+    ZoneScoped;
+
     bool resendDirectSpeaking = false;
 
     const bool VADactive = this->getVAD();
@@ -205,11 +227,15 @@ acre::Result CMumbleClient::localStopSpeaking(const acre::Speaking speakingType_
 }
 
 acre::Result CMumbleClient::enableMicrophone(const bool status_) {
+    ZoneScoped;
+
     (void) status_;
     return acre::Result::ok;
 }
 
 acre::Result CMumbleClient::playSound(std::string path_, acre::vec3_fp32_t position_, const float32_t volume_, const int32_t looping_) {
+    ZoneScoped;
+
     return acre::Result::ok;
 }
 
@@ -239,6 +265,8 @@ std::string CMumbleClient::getTempFilePath(void) {
 }
 
 acre::Result CMumbleClient::microphoneOpen(bool status_) {
+    ZoneScoped;
+
     const mumble_error_t res = mumAPI.requestMicrophoneActivationOvewrite(pluginID, status_);
     if (res != MUMBLE_STATUS_OK) {
         if (status_) {
@@ -255,10 +283,14 @@ acre::Result CMumbleClient::microphoneOpen(bool status_) {
 }
 
 acre::Result CMumbleClient::unMuteAll(void) {
+    ZoneScoped;
+
     return acre::Result::ok;
 }
 
 acre::Result CMumbleClient::moveToServerChannel() {
+    ZoneScoped;
+
     TRACE("moveToServerChannel ENTER");
     if (!CAcreSettings::getInstance()->getDisableChannelSwitch()) {
         mumble_userid_t clientId;
@@ -289,6 +321,8 @@ acre::Result CMumbleClient::moveToServerChannel() {
 }
 
 acre::Result CMumbleClient::moveToPreviousChannel() {
+    ZoneScoped;
+
     TRACE("moveToPreviousChannel ENTER");
     if (!CAcreSettings::getInstance()->getDisableChannelSwitch()) {
         mumble_userid_t clientId = -1;
@@ -310,6 +344,8 @@ acre::Result CMumbleClient::moveToPreviousChannel() {
 }
 
 uint64_t CMumbleClient::findChannelByNames(std::vector<std::string> details_) {
+    ZoneScoped;
+
     TRACE("findChannelByNames ENTER");
     mumble_channelid_t *channelList = nullptr;
     std::size_t channelCount        = 0U;
@@ -383,6 +419,8 @@ uint64_t CMumbleClient::findChannelByNames(std::vector<std::string> details_) {
 }
 
 acre::Result CMumbleClient::updateChannelDetails(std::vector<std::string> details_) {
+    ZoneScoped;
+
     setChannelDetails(details_);
     if (!details_.empty()) {
         updateShouldSwitchChannel(true);
@@ -391,10 +429,14 @@ acre::Result CMumbleClient::updateChannelDetails(std::vector<std::string> detail
 }
 
 acre::Result CMumbleClient::updateShouldSwitchChannel(const bool state_) {
+    ZoneScoped;
+
     setShouldSwitchChannel(state_);
     return acre::Result::ok;
 }
 
 bool CMumbleClient::shouldSwitchChannel() {
+    ZoneScoped;
+
     return getShouldSwitchChannel();
 }

--- a/extensions/src/ACRE2Mumble/MumbleClient.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleClient.cpp
@@ -307,6 +307,7 @@ acre::Result CMumbleClient::moveToServerChannel() {
 
             if ((API_CALL(getChannelOfUser, pluginID, activeConnection, clientId, &currentChannelId) == MUMBLE_STATUS_OK) &&
                 (getPreviousChannel() == invalid_mumble_channel)) {
+                TRACE("Setting previous channel ID to %d", currentChannelId);
                 setPreviousChannel(currentChannelId);
             }
 
@@ -317,8 +318,11 @@ acre::Result CMumbleClient::moveToServerChannel() {
                     password = details.at(1);
                 }
 
+                TRACE("Requesting local user to be moved to channel %d", channelId);
                 API_CALL(requestUserMove, pluginID, activeConnection, clientId, channelId, password.c_str());
             }
+        } else {
+            LOG("ERROR, FAILED TO OBTAIN LOCAL USER'S ID");
         }
     }
     setShouldSwitchChannel(false);
@@ -364,6 +368,8 @@ uint64_t CMumbleClient::findChannelByNames(std::vector<std::string> details_) {
         if (!details_.at(0).empty()) {
             name = details_.at(0);
         }
+
+        TRACE("Searching for channel \"%s\"", name.c_str());
 
         for (std::int32_t idx = 0U; idx < channelCount; idx++) {
             channelId         = *channelList + idx;
@@ -419,6 +425,8 @@ uint64_t CMumbleClient::findChannelByNames(std::vector<std::string> details_) {
             }
         }
         return bestChannelId;
+    } else {
+        LOG("ERROR, FAILED TO GET CHANNEL LIST");
     }
 
     return 0;

--- a/extensions/src/ACRE2Mumble/MumbleClient.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleClient.cpp
@@ -244,7 +244,13 @@ std::string CMumbleClient::getUniqueId() {
 }
 
 std::string CMumbleClient::getConfigFilePath(void) {
-    std::string tempFolder = ".\\acre";
+    // For the time being Mumble doesn't expose a config file path via its API, so we just fall back
+    // to using a sub-directory in Arma 3's AppData directory
+    std::string tempFolder = "acre";
+    std::array<char, MAX_PATH> appDataPath{""};
+    if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, appDataPath.data()))) {
+        tempFolder = std::string(appDataPath.data()) + "\\Arma 3\\" + tempFolder;
+    }
     if (!PathFileExistsA(tempFolder.c_str()) && !CreateDirectoryA(tempFolder.c_str(), nullptr)) {
         LOG("ERROR: UNABLE TO CREATE TEMP DIR");
     }

--- a/extensions/src/ACRE2Mumble/MumbleCommandServer.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCommandServer.cpp
@@ -4,6 +4,8 @@
 #include "MumbleFunctions.h"
 #include "TextMessage.h"
 
+#include <Tracy.hpp>
+
 #include <mutex>
 
 extern MumbleAPI_v_1_0_x mumAPI;
@@ -23,6 +25,8 @@ acre::Result CMumbleCommandServer::shutdown() {
 }
 
 acre::Result CMumbleCommandServer::sendMessage(IMessage *msg) {
+    ZoneScoped;
+
     std::lock_guard<CLockable> guard(*this);
 
     mumble_userid_t *channelUsers     = nullptr;
@@ -62,6 +66,8 @@ acre::Result CMumbleCommandServer::handleMessage(unsigned char *data) {
 }
 
 acre::Result CMumbleCommandServer::handleMessage(unsigned char *data, size_t length) {
+    ZoneScoped;
+
     CTextMessage *msg = nullptr;
     // TRACE("recv: [%s]", data);
     msg = new (std::nothrow) CTextMessage((char *) data, length);

--- a/extensions/src/ACRE2Mumble/MumbleCommandServer.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleCommandServer.cpp
@@ -33,24 +33,24 @@ acre::Result CMumbleCommandServer::sendMessage(IMessage *msg) {
     size_t userCount                  = 0U;
     mumble_channelid_t currentChannel = 0;
 
-    mumble_error_t err = mumAPI.getChannelOfUser(pluginID, activeConnection, this->getId(), &currentChannel);
+    mumble_error_t err = API_CALL(getChannelOfUser, pluginID, activeConnection, this->getId(), &currentChannel);
     if (err != MUMBLE_STATUS_OK) {
         LOG("ERROR, UNABLE TO GET CHANNEL OF USER: %s (%d)", mumble_errorMessage(err), err);
         return acre::Result::error;
     }
 
-    err = mumAPI.getUsersInChannel(pluginID, activeConnection, currentChannel, &channelUsers, &userCount);
+    err = API_CALL(getUsersInChannel, pluginID, activeConnection, currentChannel, &channelUsers, &userCount);
     if (err != MUMBLE_STATUS_OK) {
         LOG("ERROR, UNABLE TO GET USERS IN CHANNEL: %s (%d)", mumble_errorMessage(err), err);
         return acre::Result::error;
     }
 
-    err = mumAPI.sendData(pluginID, activeConnection, channelUsers, userCount, (const uint8_t *) msg->getData(), msg->getLength(), "ACRE2");
+    err = API_CALL(sendData, pluginID, activeConnection, channelUsers, userCount, (const uint8_t *) msg->getData(), msg->getLength(), "ACRE2");
     if (err != MUMBLE_STATUS_OK) {
         LOG("ERROR, UNABLE TO SEND MESSAGE DATA: %s (%d)", mumble_errorMessage(err), err);
         return acre::Result::error;
     }
-    err = mumAPI.freeMemory(pluginID, (void *) channelUsers);
+    err = API_CALL(freeMemory, pluginID, (void *) channelUsers);
     if (err != MUMBLE_STATUS_OK) {
         LOG("ERROR, UNABLE TO FREE CHANNEL USER LIST: %s (%d)", mumble_errorMessage(err), err);
         return acre::Result::error;

--- a/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
@@ -19,7 +19,7 @@ namespace acre {
         }
 
         {
-            std::lock_guard<std::mutex> guard(m_lock);
+            std::lock_guard<LockableBase(std::mutex)> guard(m_lock);
             m_keepRunning = true;
         }
 
@@ -30,7 +30,7 @@ namespace acre {
         ZoneScoped;
 
         {
-            std::lock_guard<std::mutex> guard(m_lock);
+            std::lock_guard<LockableBase(std::mutex)> guard(m_lock);
             m_keepRunning = false;
             m_drain       = true;
 
@@ -46,7 +46,7 @@ namespace acre {
     void MumbleEventLoop::queue(const std::function<void()>& callable) {
         ZoneScoped;
 
-        std::lock_guard<std::mutex> guard(m_lock);
+        std::lock_guard<LockableBase(std::mutex)> guard(m_lock);
 
         m_queuedFunctions.push_back(callable);
 
@@ -56,7 +56,7 @@ namespace acre {
     void MumbleEventLoop::queue(std::function<void()>&& callable) {
         ZoneScoped;
 
-        std::unique_lock<std::mutex> guard(m_lock);
+        std::unique_lock<LockableBase(std::mutex)> guard(m_lock);
 
         m_queuedFunctions.push_back(std::move(callable));
 
@@ -67,7 +67,7 @@ namespace acre {
         ZoneScoped;
         tracy::SetThreadName("ACRE2-Mumble-EventLoop");
 
-        std::unique_lock<std::mutex> guard(m_lock);
+        std::unique_lock<LockableBase(std::mutex)> guard(m_lock);
 
         while (m_keepRunning || m_drain) {
             {

--- a/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
@@ -64,31 +64,32 @@ namespace acre {
     }
 
     void MumbleEventLoop::run() {
-        ZoneScoped;
         tracy::SetThreadName("ACRE2-Mumble-EventLoop");
 
         std::unique_lock<LockableBase(std::mutex)> guard(m_lock);
 
+        const char *frameName = "ACRE2 MumbleEventLoop";
         while (m_keepRunning || m_drain) {
-            {
-                ZoneScopedN("MumbleEventLoop::run - process pending events");
-                m_drain = false;
+            FrameMarkStart(frameName);
 
-                // Process all pending events
-                while (!m_queuedFunctions.empty()) {
-                    std::function<void()> currentFunc = std::move(m_queuedFunctions.front());
-                    m_queuedFunctions.pop_front();
+            m_drain = false;
 
-                    // Execute the current funtion. However, during the time this function is executing, there is no need to
-                    // keep holding m_lock. By releasing it for that time, we allow further functions to be queued by other threads.
-                    // This gets especially important if the called function will call a Mumble API function. This function will require
-                    // to run in Mumble's main thread but if that thread is in turn waiting until a new event is queued (in one of the
-                    // plugin callbacks in this plugin), we end up with a deadlock.
-                    guard.unlock();
-                    currentFunc();
-                    guard.lock();
-                }
+            // Process all pending events
+            while (!m_queuedFunctions.empty()) {
+                std::function<void()> currentFunc = std::move(m_queuedFunctions.front());
+                m_queuedFunctions.pop_front();
+
+                // Execute the current funtion. However, during the time this function is executing, there is no need to
+                // keep holding m_lock. By releasing it for that time, we allow further functions to be queued by other threads.
+                // This gets especially important if the called function will call a Mumble API function. This function will require
+                // to run in Mumble's main thread but if that thread is in turn waiting until a new event is queued (in one of the
+                // plugin callbacks in this plugin), we end up with a deadlock.
+                guard.unlock();
+                currentFunc();
+                guard.lock();
             }
+
+            FrameMarkEnd(frameName);
 
             if (!m_keepRunning) {
                 break;

--- a/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
@@ -64,6 +64,7 @@ namespace acre {
     }
 
     void MumbleEventLoop::run() {
+        ZoneScoped;
         tracy::SetThreadName("ACRE2-Mumble-EventLoop");
 
         std::unique_lock<std::mutex> guard(m_lock);

--- a/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
+++ b/extensions/src/ACRE2Mumble/MumbleEventLoop.cpp
@@ -1,5 +1,7 @@
 #include "MumbleEventLoop.h"
 
+#include <Tracy.hpp>
+
 namespace acre {
 
     MumbleEventLoop& MumbleEventLoop::getInstance() {
@@ -25,9 +27,12 @@ namespace acre {
     }
 
     void MumbleEventLoop::stop() {
+        ZoneScoped;
+
         {
             std::lock_guard<std::mutex> guard(m_lock);
             m_keepRunning = false;
+            m_drain       = true;
 
             m_waiter.notify_all();
         }
@@ -39,6 +44,8 @@ namespace acre {
     }
 
     void MumbleEventLoop::queue(const std::function<void()>& callable) {
+        ZoneScoped;
+
         std::lock_guard<std::mutex> guard(m_lock);
 
         m_queuedFunctions.push_back(callable);
@@ -47,6 +54,8 @@ namespace acre {
     }
 
     void MumbleEventLoop::queue(std::function<void()>&& callable) {
+        ZoneScoped;
+
         std::unique_lock<std::mutex> guard(m_lock);
 
         m_queuedFunctions.push_back(std::move(callable));
@@ -55,22 +64,29 @@ namespace acre {
     }
 
     void MumbleEventLoop::run() {
+        tracy::SetThreadName("ACRE2-Mumble-EventLoop");
+
         std::unique_lock<std::mutex> guard(m_lock);
 
-        while (m_keepRunning) {
-            // Process all pending events
-            while (!m_queuedFunctions.empty()) {
-                std::function<void()> currentFunc = std::move(m_queuedFunctions.front());
-                m_queuedFunctions.pop_front();
+        while (m_keepRunning || m_drain) {
+            {
+                ZoneScopedN("MumbleEventLoop::run - process pending events");
+                m_drain = false;
 
-                // Execute the current funtion. However, during the time this function is executing, there is no need to
-                // keep holding m_lock. By releasing it for that time, we allow further functions to be queued by other threads.
-                // This gets especially important if the called function will call a Mumble API function. This function will require
-                // to run in Mumble's main thread but if that thread is in turn waiting until a new event is queued (in one of the
-                // plugin callbacks in this plugin), we end up with a deadlock.
-                guard.unlock();
-                currentFunc();
-                guard.lock();
+                // Process all pending events
+                while (!m_queuedFunctions.empty()) {
+                    std::function<void()> currentFunc = std::move(m_queuedFunctions.front());
+                    m_queuedFunctions.pop_front();
+
+                    // Execute the current funtion. However, during the time this function is executing, there is no need to
+                    // keep holding m_lock. By releasing it for that time, we allow further functions to be queued by other threads.
+                    // This gets especially important if the called function will call a Mumble API function. This function will require
+                    // to run in Mumble's main thread but if that thread is in turn waiting until a new event is queued (in one of the
+                    // plugin callbacks in this plugin), we end up with a deadlock.
+                    guard.unlock();
+                    currentFunc();
+                    guard.lock();
+                }
             }
 
             if (!m_keepRunning) {

--- a/extensions/src/ACRE2Mumble/MumbleEventLoop.h
+++ b/extensions/src/ACRE2Mumble/MumbleEventLoop.h
@@ -42,6 +42,7 @@ namespace acre {
         std::mutex m_lock;
         std::condition_variable m_waiter;
         bool m_keepRunning = true;
+        bool m_drain       = false;
         std::deque<std::function<void()>> m_queuedFunctions;
         std::thread m_thread;
 

--- a/extensions/src/ACRE2Mumble/MumbleEventLoop.h
+++ b/extensions/src/ACRE2Mumble/MumbleEventLoop.h
@@ -6,6 +6,8 @@
 #include <condition_variable>
 #include <thread>
 
+#include <Tracy.hpp>
+
 namespace acre {
 
     /**
@@ -39,8 +41,8 @@ namespace acre {
         void queue(std::function<void()>&& callable);
 
     protected:
-        std::mutex m_lock;
-        std::condition_variable m_waiter;
+        TracyLockable(std::mutex, m_lock);
+        std::condition_variable_any m_waiter;
         bool m_keepRunning = true;
         bool m_drain       = false;
         std::deque<std::function<void()>> m_queuedFunctions;

--- a/extensions/src/ACRE2Mumble/MumbleFunctions.h
+++ b/extensions/src/ACRE2Mumble/MumbleFunctions.h
@@ -3,3 +3,16 @@
 #include "MumbleAPI_v_1_0_x.h"
 #define MUMBLE_PLUGIN_NO_DEFAULT_FUNCTION_DEFINITIONS
 #include "MumblePlugin_v_1_1_x.h"
+
+
+#include <Tracy.hpp>
+
+#ifndef TRACY_ENABLE
+#define API_CALL(function, ...)             mumAPI.function(__VA_ARGS__)
+#else
+#define API_CALL(function, ...)                               \
+    [=]() mutable {                                           \
+        ZoneScopedN("Mumble API function \"" #function "\""); \
+        return mumAPI.function(__VA_ARGS__);                  \
+    }()
+#endif

--- a/extensions/src/ACRE2Mumble/MumbleFunctions.h
+++ b/extensions/src/ACRE2Mumble/MumbleFunctions.h
@@ -11,7 +11,7 @@
 #define API_CALL(function, ...)             mumAPI.function(__VA_ARGS__)
 #else
 #define API_CALL(function, ...)                               \
-    [=]() mutable {                                           \
+    [&]() mutable {                                           \
         ZoneScopedN("Mumble API function \"" #function "\""); \
         return mumAPI.function(__VA_ARGS__);                  \
     }()

--- a/extensions/src/ACRE2Profiling/CMakeLists.txt
+++ b/extensions/src/ACRE2Profiling/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required (VERSION 3.0)
+
+option(USE_TRACY "USE_TRACY" OFF)
+
+set(ACRE_NAME "ACRE2Profiling")
+
+acre_set_linker_options()
+
+file(GLOB SOURCES *.h *.hpp *.c *.cpp)
+
+add_library( ${ACRE_NAME} STATIC ${SOURCES} ${GLOBAL_SOURCES} ${DSP_SOURCES})
+target_link_libraries( ${ACRE_NAME} )
+set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2)
+
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tracy/CMakeLists.txt")
+	message(FATAL_ERROR "Unable to locate tracy submodule - did you forget to run git submodule update --init?")
+endif()
+
+set(TRACY_ENABLE ${USE_TRACY} CACHE BOOL "" FORCE)
+set(TRACY_ON_DEMAND ON CACHE BOOL "" FORCE)
+add_subdirectory("tracy")
+
+target_link_libraries( ${ACRE_NAME} Tracy::TracyClient)

--- a/extensions/src/ACRE2Profiling/CMakeLists.txt
+++ b/extensions/src/ACRE2Profiling/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 set(TRACY_ENABLE ${USE_TRACY} CACHE BOOL "" FORCE)
 set(TRACY_ON_DEMAND OFF CACHE BOOL "" FORCE)
+# We require the delayed init mode to prevent freezes on unloading/shutdown of the (Mumble) plugin
+set(TRACY_DELAYED_INIT ON CACHE BOOL "" FORCE)
 add_subdirectory("tracy")
 
 target_link_libraries( ${ACRE_NAME} Tracy::TracyClient)

--- a/extensions/src/ACRE2Profiling/CMakeLists.txt
+++ b/extensions/src/ACRE2Profiling/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tracy/CMakeLists.txt")
 endif()
 
 set(TRACY_ENABLE ${USE_TRACY} CACHE BOOL "" FORCE)
-set(TRACY_ON_DEMAND ON CACHE BOOL "" FORCE)
+set(TRACY_ON_DEMAND OFF CACHE BOOL "" FORCE)
 add_subdirectory("tracy")
 
 target_link_libraries( ${ACRE_NAME} Tracy::TracyClient)

--- a/extensions/src/ACRE2Profiling/CMakeLists.txt
+++ b/extensions/src/ACRE2Profiling/CMakeLists.txt
@@ -8,9 +8,7 @@ acre_set_linker_options()
 
 file(GLOB SOURCES *.h *.hpp *.c *.cpp)
 
-add_library( ${ACRE_NAME} STATIC ${SOURCES} ${GLOBAL_SOURCES} ${DSP_SOURCES})
-target_link_libraries( ${ACRE_NAME} )
-set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2)
+add_library( ${ACRE_NAME} INTERFACE)
 
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tracy/CMakeLists.txt")
 	message(FATAL_ERROR "Unable to locate tracy submodule - did you forget to run git submodule update --init?")
@@ -22,4 +20,4 @@ set(TRACY_ON_DEMAND OFF CACHE BOOL "" FORCE)
 set(TRACY_DELAYED_INIT ON CACHE BOOL "" FORCE)
 add_subdirectory("tracy")
 
-target_link_libraries( ${ACRE_NAME} Tracy::TracyClient)
+target_link_libraries( ${ACRE_NAME} INTERFACE Tracy::TracyClient)

--- a/extensions/src/ACRE2Shared/CMakeLists.txt
+++ b/extensions/src/ACRE2Shared/CMakeLists.txt
@@ -7,5 +7,5 @@ acre_set_linker_options()
 file(GLOB SOURCES *.h *.hpp *.c *.cpp)
 
 add_library( ${ACRE_NAME} STATIC ${SOURCES} ${GLOBAL_SOURCES})
-target_link_libraries( ${ACRE_NAME})
+target_link_libraries( ${ACRE_NAME} ACRE2Profiling)
 set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2)

--- a/extensions/src/ACRE2Shared/EntrantWorker.h
+++ b/extensions/src/ACRE2Shared/EntrantWorker.h
@@ -7,6 +7,8 @@
 #include <queue>
 #include <thread>
 
+#include <Tracy.hpp>
+
 template<typename T> class TEntrantWorker : public CLockable {
 public:
     TEntrantWorker() {
@@ -17,6 +19,8 @@ public:
     }
 
     acre::Result startWorker(void) {
+        ZoneScoped;
+
         LOCK(this);
         setShuttingDown(false);
         std::queue<T>().swap(m_processQueue); // Clear the queue
@@ -27,6 +31,8 @@ public:
     }
 
     acre::Result stopWorker(void) {
+        ZoneScoped;
+        
         setShuttingDown(true);
         setRunning(false);
         if (m_workerThread.joinable()) {
@@ -41,9 +47,13 @@ public:
     }
 
     acre::Result exWorkerThread() {
+        ZoneScoped;
+
         while (!getShuttingDown()) {
             LOCK(this);
             if (!m_processQueue.empty()) {
+                ZoneScopedN("exWorkerThread - processing queue item");
+
                 const T item = m_processQueue.front();
                 m_processQueue.pop();
                 exProcessItem(item);

--- a/extensions/src/ACRE2Shared/EntrantWorker.h
+++ b/extensions/src/ACRE2Shared/EntrantWorker.h
@@ -47,13 +47,9 @@ public:
     }
 
     acre::Result exWorkerThread() {
-        ZoneScoped;
-
         while (!getShuttingDown()) {
             LOCK(this);
             if (!m_processQueue.empty()) {
-                ZoneScopedN("exWorkerThread - processing queue item");
-
                 const T item = m_processQueue.front();
                 m_processQueue.pop();
                 exProcessItem(item);

--- a/extensions/src/ACRE2Shared/Lockable.h
+++ b/extensions/src/ACRE2Shared/Lockable.h
@@ -3,9 +3,11 @@
 
 #include <mutex>
 
+#include <Tracy.hpp>
+
 class CLockable {
 private:
-    std::recursive_mutex m_lockable_mutex;
+    TracyLockable(std::recursive_mutex, m_lockable_mutex);
 public:
     void lock() {
         m_lockable_mutex.lock();

--- a/extensions/src/ACRE2TS/CMakeLists.txt
+++ b/extensions/src/ACRE2TS/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB_RECURSE SOURCES *.h *.hpp *.c *.cpp *.asm inc/*)
 include_directories(inc)
 
 add_library( ${ACRE_NAME} MODULE ${SOURCES} ${GLOBAL_SOURCES})
-target_link_libraries(${ACRE_NAME} ACRE2Core ACRE2Shared x3daudio)
+target_link_libraries(${ACRE_NAME} ACRE2Core ACRE2Shared ACRE2Profiling x3daudio)
 set_target_properties(${ACRE_NAME} PROPERTIES FOLDER ACRE2 LINK_FLAGS -SAFESEH:NO)
 target_compile_features(${ACRE_NAME} PRIVATE cxx_std_17)
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add Tracy support in order to be able to investigate the performance issues encountered in the Mumble plugin. Note that Tracy needs to be activated via `-DUSE_TRACY=ON` when calling cmake
- Fix a small issue in the Mumble plugin where the returned config path would be inaccessible (due to lying in programs directory)
- Add CMake option to enable tracing (OFF by default)
