### PR TITLE
BF-888S - Add Arsenal Stats

### DIFF
--- a/addons/sys_bf888s/CfgWeapons.hpp
+++ b/addons/sys_bf888s/CfgWeapons.hpp
@@ -20,6 +20,11 @@ class CfgWeapons {
         class Library {
             libTextDesc = QUOTE(NAME_BF888S);
         };
+
+        EGVAR(arsenalStats,frequencyMin) = 400; // internet says 400-470MHz
+        EGVAR(arsenalStats,frequencyMax) = 400.62; // code implies 63 channels 0.01 apart?
+        EGVAR(arsenalStats,transmitPower) = 5000;
+        EGVAR(arsenalStats,effectiveRange) = "3km"; // internet says everything from 3km to 15miles
     };
 
     RADIO_ID_LIST(ACRE_BF888S)

--- a/addons/sys_bf888s/CfgWeapons.hpp
+++ b/addons/sys_bf888s/CfgWeapons.hpp
@@ -24,7 +24,7 @@ class CfgWeapons {
         EGVAR(arsenalStats,frequencyMin) = 400; // internet says 400-470MHz
         EGVAR(arsenalStats,frequencyMax) = 400.62; // code implies 63 channels 0.01 apart?
         EGVAR(arsenalStats,transmitPower) = 5000;
-        EGVAR(arsenalStats,effectiveRange) = "3km"; // internet says everything from 3km to 15miles
+        EGVAR(arsenalStats,effectiveRange) = "5km (3km)"; // 5km in ideal conditions, 3km otherwise?
     };
 
     RADIO_ID_LIST(ACRE_BF888S)

--- a/addons/sys_bf888s/CfgWeapons.hpp
+++ b/addons/sys_bf888s/CfgWeapons.hpp
@@ -21,10 +21,10 @@ class CfgWeapons {
             libTextDesc = QUOTE(NAME_BF888S);
         };
 
-        EGVAR(arsenalStats,frequencyMin) = 400; // internet says 400-470MHz
-        EGVAR(arsenalStats,frequencyMax) = 400.62; // code implies 63 channels 0.01 apart?
+        EGVAR(arsenalStats,frequencyMin) = 400;
+        EGVAR(arsenalStats,frequencyMax) = 470;
         EGVAR(arsenalStats,transmitPower) = 5000;
-        EGVAR(arsenalStats,effectiveRange) = "5km (3km)"; // 5km in ideal conditions, 3km otherwise?
+        EGVAR(arsenalStats,effectiveRange) = "3-5km (2-3km)";
     };
 
     RADIO_ID_LIST(ACRE_BF888S)


### PR DESCRIPTION
**When merged this pull request will:**
- Add arsenal stat entries for min/max frequency, power and range to BF888S config


Only value I am absolute certain is power. Frequency I might have misunderstood and the range is from a quick google search.