### PR TITLE
Extension - Handle stereo audio from TeamSpeak (cherry pick)

### DIFF
--- a/extensions/src/ACRE2Core/FilterPosition.cpp
+++ b/extensions/src/ACRE2Core/FilterPosition.cpp
@@ -8,6 +8,7 @@
 
 #include <cmath>
 #pragma comment(lib, "x3daudio.lib")
+#pragma comment(lib, "xaudio2.lib")
 
 #define MAX_FALLOFF_DISTANCE    75
 #define MAX_FALLOFF_RANGE        150

--- a/extensions/src/ACRE2Core/SoundEngine.cpp
+++ b/extensions/src/ACRE2Core/SoundEngine.cpp
@@ -37,7 +37,7 @@ acre::Result CSoundEngine::onEditPlaybackVoiceDataEvent(acre::id_t id, short* sa
             for (size_t i = 0; i < player->channels.size(); ++i) {
                 if (player->channels[i]) {
                     player->channels[i]->lock();
-                    player->channels[i]->In(samples, sampleCount);
+                    player->channels[i]->In(samples, sampleCount, channels);
                     player->channels[i]->unlock();
                 }
             }

--- a/extensions/src/ACRE2Core/SoundMonoChannel.cpp
+++ b/extensions/src/ACRE2Core/SoundMonoChannel.cpp
@@ -44,10 +44,17 @@ CSoundChannelMono::~CSoundChannelMono() {
     }
 }
 
-int CSoundChannelMono::In(short *samples, int sampleCount) {
+int CSoundChannelMono::In(short *samples, int sampleCount, const int channels) {
     //memset(samples, 0x00, sampleCount*sizeof(short));
-    if (this->bufferLength+sampleCount <= this->bufferMaxSize) {
-        memcpy(this->buffer+this->bufferLength, samples, sampleCount*sizeof(short));
+    if (this->bufferLength + sampleCount <= this->bufferMaxSize) {
+        if (channels == 1) {
+            memcpy(this->buffer + this->bufferLength, samples, sampleCount * sizeof(short));
+        } else {
+            // rare but for multi channel input just capture mono, samples[channels*sampleCount]={Left,Right,Left,...}
+            for (int i = 0; i < sampleCount; i++) {
+                this->buffer[this->bufferLength + i] = samples[channels * i];
+            }
+        }
         this->bufferLength += sampleCount;
     }
     return this->bufferLength;

--- a/extensions/src/ACRE2Core/SoundMonoChannel.h
+++ b/extensions/src/ACRE2Core/SoundMonoChannel.h
@@ -27,7 +27,7 @@ public:
     CSoundChannelMono( int length, bool singleShot );
 
     ~CSoundChannelMono();
-    int In(short *samples, int sampleCount);
+    int In(short *samples, int sampleCount, const int channels);
     int Out(short *samples, int sampleCount);
     int GetCurrentBufferSize() { return this->bufferLength-this->bufferPos; };
     bool IsOneShot() { return this->oneShot; };

--- a/extensions/src/ACRE2Core/SoundPlayback.cpp
+++ b/extensions/src/ACRE2Core/SoundPlayback.cpp
@@ -78,7 +78,7 @@ acre::Result CSoundPlayback::playSound(std::string id, acre::vec3_fp32_t positio
             tempChannel->getMixdownEffectInsert(0)->setParam("isWorld", 0x00000000);
         }
 
-        tempChannel->In((short *)waveFile.GetData(), waveFile.GetSize()/sizeof(short));
+        tempChannel->In((short *)waveFile.GetData(), waveFile.GetSize()/sizeof(short), 1);
         CEngine::getInstance()->getSoundEngine()->getSoundMixer()->unlock();
         return acre::Result::ok;
     }


### PR DESCRIPTION
fix #1237
Cherypick the stero fix from #1105
> acre just expects mono microphone data, but TS is capable of stereo
without the mono fix, everything was pitch shifted lower because the sound data is interleaved [left, right, left]