### PR TITLE
Racks - Fix vehicle racks unable to use certain intercoms

### DIFF
--- a/addons/sys_rack/fnc_configWiredIntercoms.sqf
+++ b/addons/sys_rack/fnc_configWiredIntercoms.sqf
@@ -8,7 +8,7 @@
  * 1: Rack class <STRING>
  *
  * Return Value:
- * None
+ * Wired Intercoms <ARRAY>
  *
  * Example:
  * [cursorTarget] call acre_sys_rack_configWiredIntercoms

--- a/addons/sys_rack/fnc_configWiredIntercoms.sqf
+++ b/addons/sys_rack/fnc_configWiredIntercoms.sqf
@@ -33,11 +33,10 @@ if (_intercoms isEqualTo [] || {"none" in _intercoms}) then {
     } else {
         private _intercomIds = _configuredIntercoms apply {_x select 0};
         {
-            private _int = _x;
-            if (_int in _intercomIds) then {
-                _wiredIntercoms pushBack _int;
+            if (_x in _intercomIds) then {
+                _wiredIntercoms pushBack _x;
             } else {
-                WARNING_3("No intercom %1 defined but rack %2 can have access to its network for %3 - skipping",_int,_rack,typeOf _vehicle)
+                WARNING_3("No intercom %1 defined but rack %2 can have access to its network for %3 - skipping",_x,_rack,typeOf _vehicle)
             };
         } forEach _intercoms;
     };

--- a/addons/sys_rack/fnc_configWiredIntercoms.sqf
+++ b/addons/sys_rack/fnc_configWiredIntercoms.sqf
@@ -25,16 +25,17 @@ private _wiredIntercoms = [];
 if (_intercoms isEqualTo [] || {"none" in _intercoms}) then {
     _wiredIntercoms = [];
 } else {
+    private _configuredIntercoms = _vehicle getVariable [QEGVAR(sys_intercom,intercomNames), []];
     if ("all" in _intercoms) then {
         {
             _wiredIntercoms pushBack (_x select 0);
-        } forEach (_vehicle getVariable [QEGVAR(sys_intercom,intercomNames), []]);
+        } forEach _configuredIntercoms;
     } else {
+        private _intercomIds = _configuredIntercoms apply {_x select 0};
         {
             private _int = _x;
-            private _configuredIntercoms = _vehicle getVariable [QEGVAR(sys_intercom,intercomNames), []];
-            if (_int in (_configuredIntercoms select 0)) then {
-                _wiredIntercoms pushBack _x;
+            if (_int in _intercomIds) then {
+                _wiredIntercoms pushBack _int;
             } else {
                 WARNING_3("No intercom %1 defined but rack %2 can have access to its network for %3 - skipping",_int,_rack,typeOf _vehicle)
             };


### PR DESCRIPTION
This PR fixes a bug where vehicle racks are only able to use the first configured intercom.

This is bug occurs because `acre_sys_intercom_intercomNames` contains a list of intercoms in the following format:
```
[["intercom_1","Crew Intercom","Crew"],["intercom_2","Pax Intercom","Pax"]]
```
However, the following code only checks the first entry in the above list:
```
private _configuredIntercoms = _vehicle getVariable [QEGVAR(sys_intercom,intercomNames), []];
if (_int in (_configuredIntercoms select 0)) then {
```