### PR TITLE
Add new Optional to fit AN/PRC-117F into Contact Radiopacks

### DIFF
--- a/optionals/sys_radpacks/$PBOPREFIX$
+++ b/optionals/sys_radpacks/$PBOPREFIX$
@@ -1,0 +1,1 @@
+idi\acre\addons\sys_radpacks

--- a/optionals/sys_radpacks/README.md
+++ b/optionals/sys_radpacks/README.md
@@ -1,0 +1,4 @@
+sys_radpacks
+===
+
+Compatibility with Contact DLC radio packs, increasing their max load so that they can carry an AN/PRC-117F and a small amount of additional gear.

--- a/optionals/sys_radpacks/config.cpp
+++ b/optionals/sys_radpacks/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"acre_main"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Rotators Collective"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+class CfgVehicles {
+    class Bag_Base;
+    class B_RadioBag_01_base_F: Bag_Base {
+        maximumLoad = 150;
+    };
+};

--- a/optionals/sys_radpacks/meta.cpp
+++ b/optionals/sys_radpacks/meta.cpp
@@ -1,0 +1,3 @@
+protocol = 1;
+//publishedid = 0;
+name = "ACRE2 Contact DLC Radio Packs Compatibility";

--- a/optionals/sys_radpacks/script_component.hpp
+++ b/optionals/sys_radpacks/script_component.hpp
@@ -1,0 +1,13 @@
+#define COMPONENT sys_radpacks
+#define COMPONENT_BEAUTIFIED Contact Radiopacks Compatibility
+#include "\idi\acre\addons\main\script_mod.hpp"
+
+#ifdef DEBUG_ENABLED_SYS_RADPACKS
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_ENABLED_SYS_RADPACKS
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_SYS_RADPACKS
+#endif
+
+#include "\idi\acre\addons\main\script_macros.hpp"


### PR DESCRIPTION
As explained in #854, this PR implements [this config](https://github.com/IDI-Systems/acre2/issues/854#issuecomment-543489897) in a new Optional, overriding the max load of Radiopacks added by the Contact DLC and allowing them to carry an AN/PRC-117F with room to spare.