### PR TITLE
Zeus - Improve voice source switch between Remote and Player

### DIFF
--- a/addons/sys_zeus/CfgVehicles.hpp
+++ b/addons/sys_zeus/CfgVehicles.hpp
@@ -5,11 +5,13 @@ class CfgVehicles {
             class GVAR(remoteEars) {
                 displayName = CSTRING(Remote);
                 condition = QUOTE(acre_current_player isNotEqualTo player && {acre_player isEqualTo player});
+                exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting"};
                 statement = QUOTE([false] call FUNC(setUsePlayer));
             };
             class GVAR(playerEars) {
                 displayName = CSTRING(Player);
                 condition = QUOTE(acre_current_player isNotEqualTo player && {acre_player isNotEqualTo player});
+                exceptions[] = {"isNotSwimming", "isNotInside", "isNotSitting"};
                 statement = QUOTE([true] call FUNC(setUsePlayer));
             };
         };


### PR DESCRIPTION
**When merged this pull request will:**
- Allow the "Zeus Ears" or "Zeus Voice Source" to be switched between the player and remote controlled AI even while it is sitting in vehicles/chairs or swimming;

While remote controlling AI as Zeus in smaller matches, I regularly ran into the issue of not being able to switch Zeus voice source from within vehicles to maintain radio contact with players. While in most of the situations it can be resolved by just changing the default voice source to "Player", it doesn't always suffice, so I looked into how other interactions that do work on remote controlled AI in vehicles are set up.
The ACE Hearing interaction for putting earplugs in/out matches that description, unlike the Zeus Ears interactions, [it implements](https://github.com/acemod/ACE3/blob/aead9a8eb4949714ddcb5d7b07b57f0c798a4ea0/addons/hearing/CfgVehicles.hpp#L9C21-L9C85) an `exceptions[]` array ([ACE Interaction Documentation](https://ace3.acemod.org/wiki/framework/interactionmenu-framework#2-adding-actions-via-config)), so I reused that for Zeus Ears and it works.