### PR TITLE
Racks/Intercom - Enable without ACE Interaction Menu (requires Intercom to access racked radios)

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -1,4 +1,5 @@
 name = "ACRE2"
+mainprefix = "idi"
 prefix = "acre"
 author = "ACRE2 Team"
 
@@ -36,4 +37,9 @@ folder = "acre2"
 workshop = [
     "450814997", # CBA_A3's Workshop ID
     "463939057", # ACE3's Workshop ID
+]
+
+[hemtt.launch.cba]
+workshop = [
+    "450814997", # CBA_A3's Workshop ID
 ]

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -1,9 +1,6 @@
 #include "script_component.hpp"
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
-// Exit if ACE3 not loaded
-if (!isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) exitWith {};
-
 private _addClassEH = {
     ["Tank", "init", FUNC(initVehicleIntercom), nil, nil, true] call CBA_fnc_addClassEventHandler;
     ["Car_F", "init", FUNC(initVehicleIntercom), nil, nil, true] call CBA_fnc_addClassEventHandler;

--- a/addons/sys_rack/XEH_postInit.sqf
+++ b/addons/sys_rack/XEH_postInit.sqf
@@ -1,7 +1,6 @@
 #include "script_component.hpp"
 
 if (!hasInterface) exitWith {};
-if (!isClass (configFile >> "CfgPatches" >> "ace_interact_menu")) exitWith {};
 
 ["vehicle", {
     params ["_player", "_newVehicle"];

--- a/docs/wiki/user/vehicle-intercom.md
+++ b/docs/wiki/user/vehicle-intercom.md
@@ -2,8 +2,6 @@
 title: Vehicle Intercom
 ---
 
-{% include important.html content="Requires ACE3 Interaction Menu!" %}
-
 ## Vehicle Intercom
 
 Vehicle intercom consists of two separate networks depending on the vehicle type: crew and passenger (pax) intercom. Intercom gives the ability to speak to other players within the same network using a headset. This allows them to communicate without the disturbance of the vehicle's noise.

--- a/docs/wiki/user/vehicle-racks.md
+++ b/docs/wiki/user/vehicle-racks.md
@@ -2,7 +2,7 @@
 title: Vehicle Racks
 ---
 
-{% include important.html content="Requires ACE3 Interaction Menu!" %}
+{% include important.html content="Requires ACE3 Interaction Menu if no Intercom is configured for a given vehicle!" %}
 
 ACRE2 allows the possibility of using racks in vehicles in order to increase the transmission power of a particular radio. There are different types of vehicle racks:
 


### PR DESCRIPTION
**When merged this pull request will:**
- title

Reasoning:
ACRE intercom menu allows you to use the radios in tanks without ACE Interact menu, you can just set the "Work" to the radio you want to use and open the configuration menu via keybinds.

Vehicles without the ~~rack~~intercom would need some other way (scroll menu?) but that could be done in separate PR IMHO.