### PR TITLE
Radio - Fix Half-Duplex keying not muting ongoing transmissions

### DIFF
--- a/addons/sys_core/XEH_preInit.sqf
+++ b/addons/sys_core/XEH_preInit.sqf
@@ -27,6 +27,7 @@ DGVAR(speakers) = [];
 DGVAR(enableDistanceMuting) = true;
 DGVAR(ts3id) = -1;
 DGVAR(keyedMicRadios) = [];
+DGVAR(previousSortedParams) = [[],[]];
 DGVAR(keyedRadioIds) = HASH_CREATE;
 DGVAR(globalVolume) = 1.0;
 DGVAR(maxVolume) = 1.0;

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -90,7 +90,8 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
     #endif
 
     _radioParamsSorted params ["_radios","_sources"];
-
+    GVAR(previousSortedParams) = _radioParamsSorted;
+    
     #ifdef ENABLE_PERFORMANCE_COUNTERS
         if (_radios isNotEqualTo []) then {
             BEGIN_COUNTER(radio_loop);

--- a/addons/sys_core/fnc_speaking.sqf
+++ b/addons/sys_core/fnc_speaking.sqf
@@ -91,7 +91,7 @@ if (GVAR(keyedMicRadios) isNotEqualTo []) then {
 
     _radioParamsSorted params ["_radios","_sources"];
     GVAR(previousSortedParams) = _radioParamsSorted;
-    
+
     #ifdef ENABLE_PERFORMANCE_COUNTERS
         if (_radios isNotEqualTo []) then {
             BEGIN_COUNTER(radio_loop);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the issue of keying a radio not muting ongoing transmissions despite having Full-Duplex disabled, which resolves #1236;

Yesterday @Fratee and I debugged the issue via `systemChat` calls.

When starting to transmit on any radio (half-duplex mode), the following portion of code in [`sys_core/fnc_localStartSpeaking.sqf`](https://github.com/IDI-Systems/acre2/blob/192952f1ed1bd1b3b90b4fa7f6d88ee4229b8f2d/addons/sys_core/fnc_localStartSpeaking.sqf#L42C1-L56C3) is responsible for muting any client that would be audible through the same radio.
```sqf
// Make all the present speakers on the radio net, volume go to 0
if (!GVAR(fullDuplex) && {ACRE_BROADCASTING_RADIOID != ""}) then {
    GVAR(previousSortedParams) params ["_radios","_sources"];
    {
        if (ACRE_BROADCASTING_RADIOID == _x) exitWith {
            {
                private _unit = _x select 0;
                if (!isNull _unit && {_unit != acre_player}) then {
                    private _canUnderstand = [_unit] call FUNC(canUnderstand);
                    ["updateSpeakingData", ["r", GET_TS3ID(_unit), !_canUnderstand, 1, 0, 1, 0, false, [0, 0, 0]]] call EFUNC(sys_rpc,callRemoteProcedure);
                };
            } forEach (_sources select _forEachIndex);
        };
    } forEach _radios;
};
```
The issue is that the line `GVAR(previousSortedParams) params ["_radios","_sources"];` doesn't work, the global var `previousSortedParams` is never set at any point in the codebase, causing `_radios` and `_sources` to remain unset/empty and the `forEach _radios` loop to never execute.

We fixed it by initializing `previousSortedParams` in the appropriate `XEH_preInit.sqf` and assigning it in `fnc_speaking`, right where a `["_radios","_sources"]` array identical to the one required by `fnc_localStartSpeaking.sqf` is generated.