### PR TITLE
Extensions - Require CMake 3.10

### DIFF
--- a/extensions/src/ACRE2Arma/CMakeLists.txt
+++ b/extensions/src/ACRE2Arma/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/extensions/src/ACRE2Arma/acre/CMakeLists.txt
+++ b/extensions/src/ACRE2Arma/acre/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 set(ACRE_EXTENSION_NAME "acre")
 

--- a/extensions/src/ACRE2Arma/arma2ts/CMakeLists.txt
+++ b/extensions/src/ACRE2Arma/arma2ts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 set(ACRE_NAME "Arma2TS")
 

--- a/extensions/src/ACRE2Core/CMakeLists.txt
+++ b/extensions/src/ACRE2Core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 set(ACRE_NAME "ACRE2Core")
 

--- a/extensions/src/ACRE2DistortionTestPlugin/CMakeLists.txt
+++ b/extensions/src/ACRE2DistortionTestPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 set(ACRE_NAME "ACRE2DistortionTestPlugin")
 

--- a/extensions/src/ACRE2Shared/CMakeLists.txt
+++ b/extensions/src/ACRE2Shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 set(ACRE_NAME "ACRE2Shared")
 

--- a/extensions/src/ACRE2Steam/CMakeLists.txt
+++ b/extensions/src/ACRE2Steam/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 set(ACRE_NAME "ACRE2Steam")
 

--- a/extensions/src/Wav2B64/CMakeLists.txt
+++ b/extensions/src/Wav2B64/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 project(Wav2B64)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Extras/")


### PR DESCRIPTION
**When merged this pull request will:**
- Require CMake 3.10, as CMake 3.27 throws deprecation warning regarding CMake <3.5 support removal