### PR TITLE
Racks - Add Use to Intercom-Radios and Increase access on MRAPs

### DIFF
--- a/addons/sys_rack/CfgVehicles.hpp
+++ b/addons/sys_rack/CfgVehicles.hpp
@@ -94,7 +94,7 @@ class CfgVehicles {
                 displayName = CSTRING(dashUpper); // Name is displayed in the interaction menu.
                 shortName = CSTRING(dashUpperShort);
                 componentName = "ACRE_VRC110";
-                allowedPositions[] = {"driver", {"cargo", 0}}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
+                allowedPositions[] = {"driver", {"cargo", 0}, "commander"}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
                 isRadioRemovable = 1;
                 intercom[] = {"intercom_1"};
             };
@@ -102,7 +102,7 @@ class CfgVehicles {
                 displayName = CSTRING(dashLower); // If you have multiple racks a text label helps identify the particular rack.
                 shortName = CSTRING(dashLowerShort);
                 componentName = "ACRE_VRC103";
-                allowedPositions[] = {"driver", {"cargo", 0}};
+                allowedPositions[] = {"driver", {"cargo", 0}, "commander"};
                 mountedRadio = "ACRE_PRC117F";
                 intercom[] = {"intercom_1"};
             };

--- a/addons/sys_rack/CfgVehicles.hpp
+++ b/addons/sys_rack/CfgVehicles.hpp
@@ -188,7 +188,6 @@ class CfgVehicles {
                 componentName = "ACRE_VRC103";
                 allowedPositions[] = {"driver", "commander", "gunner"}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
                 mountedRadio = "ACRE_PRC117F";
-                intercom[] = {"intercom_1"};
             };
         };
     };
@@ -202,7 +201,6 @@ class CfgVehicles {
                 componentName = "ACRE_VRC103";
                 allowedPositions[] = {"driver", "commander", "gunner"}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
                 mountedRadio = "ACRE_PRC117F";
-                intercom[] = {"intercom_1"};
             };
         };
     };

--- a/addons/sys_rack/CfgVehicles.hpp
+++ b/addons/sys_rack/CfgVehicles.hpp
@@ -188,6 +188,7 @@ class CfgVehicles {
                 componentName = "ACRE_VRC103";
                 allowedPositions[] = {"driver", "commander", "gunner"}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
                 mountedRadio = "ACRE_PRC117F";
+                intercom[] = {"intercom_1"};
             };
         };
     };
@@ -201,6 +202,7 @@ class CfgVehicles {
                 componentName = "ACRE_VRC103";
                 allowedPositions[] = {"driver", "commander", "gunner"}; // Who has access "inside" - anyone inside, "external" - provides access upto 10m away, "driver", "gunner", "copilot", "commander"
                 mountedRadio = "ACRE_PRC117F";
+                intercom[] = {"intercom_1"};
             };
         };
     };

--- a/addons/sys_rack/XEH_PREP.hpp
+++ b/addons/sys_rack/XEH_PREP.hpp
@@ -29,6 +29,7 @@ PREP(configureRackIntercom);
 PREP(initializeRack);
 PREP(getRackBaseClassname);
 PREP(getRackFromRadio);
+PREP(getRackLetterFromRadio);
 PREP(getMountableRadios);
 PREP(getMountedRadio);
 PREP(getWiredIntercoms);

--- a/addons/sys_rack/fnc_getRackLetterFromRadio.sqf
+++ b/addons/sys_rack/fnc_getRackLetterFromRadio.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team, mrschick
+ * Returns the rack letter if a radio is currently mounted.
+ *
+ * Arguments:
+ * 0: Radio ID <STRING>
+ *
+ * Return Value:
+ * letter on work knob corresponding to the rack, or "" if radio is not a rack <STRING>
+ *
+ * Example:
+ * ["ACRE_PRC152_ID_1"] call acre_sys_rack_fnc_getRackLetterFromRadio
+ *
+ * Public: No
+ */
+ 
+params ["_radioId"];
+
+private _return = "";
+
+private _wiredRacks = [vehicle acre_player, acre_player, EGVAR(sys_intercom,activeIntercom), "wiredRacks"] call EFUNC(sys_intercom,getStationConfiguration);
+{
+    private _rackId = _x select 0;
+    if (([_rackId] call FUNC(getMountedRadio)) == _radioId) exitWith {
+        _return = [RACK_LETTERS] select _forEachIndex;
+    };
+} forEach _wiredRacks;
+
+_return

--- a/addons/sys_rack/fnc_getRackLetterFromRadio.sqf
+++ b/addons/sys_rack/fnc_getRackLetterFromRadio.sqf
@@ -7,7 +7,7 @@
  * 0: Radio ID <STRING>
  *
  * Return Value:
- * letter on work knob corresponding to the rack, or "" if radio is not a rack <STRING>
+ * Letter on Work knob corresponding to the rack, or "" if radio is not in a rack <STRING>
  *
  * Example:
  * ["ACRE_PRC152_ID_1"] call acre_sys_rack_fnc_getRackLetterFromRadio

--- a/addons/sys_rack/fnc_rackChildrenActions.sqf
+++ b/addons/sys_rack/fnc_rackChildrenActions.sqf
@@ -151,13 +151,18 @@ if (_mountedRadio == "") then { // Empty
                     _direction = 1;
                 };
 
-                // After a delay, turn the work knob N times towards the desired position
+                // After a delay, turn the work knob N times towards the desired position in 0.2s intervals
                 [{
                     params ["_direction", "_curWorkPos", "_newWorkPos"];
                     private _i = 0;
+                    private _delay = 0;
                     while {_i < abs (_curWorkPos - _newWorkPos)} do {
-                        [0, _direction] call EFUNC(sys_intercom,vic3ffcsOnWorkKnobPress);
+                        [{
+                            params ["_direction"];
+                            [0, _direction] call EFUNC(sys_intercom,vic3ffcsOnWorkKnobPress);
+                        }, [_direction], _delay] call CBA_fnc_waitAndExecute;
                         _i = _i + 1;
+                        _delay = _delay + 0.2;
                     };
                 }, [_direction, _curWorkPos, _newWorkPos], 0.5] call CBA_fnc_waitAndExecute;
             },

--- a/addons/sys_rack/fnc_rackChildrenActions.sqf
+++ b/addons/sys_rack/fnc_rackChildrenActions.sqf
@@ -131,6 +131,8 @@ if (_mountedRadio == "") then { // Empty
             {
                 [_this] spawn {
                     params ["_this"];
+
+                    // Find the work knob position that corresponds to the mounted radio
                     private _mountedRadio = _this select 2;
                     private _newWorkPos = 0;
                     private _wiredRacks = [vehicle acre_player, acre_player, EGVAR(sys_intercom,activeIntercom), "wiredRacks"] call EFUNC(sys_intercom,getStationConfiguration);
@@ -142,15 +144,18 @@ if (_mountedRadio == "") then { // Empty
                         };
                     } forEach _wiredRacks;
 
+                    // Open FFCS GUI
                     [] call EFUNC(sys_intercom,openGui);
                     sleep 0.5;
 
+                    // Find current knob position and the direction to move it to the desired position
                     private _curWorkPos = [vehicle acre_player, acre_player, EGVAR(sys_intercom,activeIntercom), "workKnob"] call EFUNC(sys_intercom,getStationConfiguration);
                     private _direction = 0;
                     if (_newWorkPos < _curWorkPos) then {
                         _direction = 1;
                     };
 
+                    // Turn the work knob N times towards the desired position
                     private _i = 0;
                     while {_i < abs (_curWorkPos - _newWorkPos)} do {
                         [0, _direction] call EFUNC(sys_intercom,vic3ffcsOnWorkKnobPress);

--- a/addons/sys_rack/fnc_rackChildrenActions.sqf
+++ b/addons/sys_rack/fnc_rackChildrenActions.sqf
@@ -129,40 +129,37 @@ if (_mountedRadio == "") then { // Empty
             localize LSTRING(useRadio),
             "",
             {
-                [_this] spawn {
-                    params ["_this"];
-
-                    // Find the work knob position that corresponds to the mounted radio
-                    private _mountedRadio = _this select 2;
-                    private _newWorkPos = 0;
-                    private _wiredRacks = [vehicle acre_player, acre_player, EGVAR(sys_intercom,activeIntercom), "wiredRacks"] call EFUNC(sys_intercom,getStationConfiguration);
-                    {
-                        private _rack = _x select 0;
-                        private _radio = [_rack] call FUNC(getMountedRadio);
-                        if (_radio isEqualTo _mountedRadio) exitWith {
-                            _newWorkPos = _forEachIndex + 1;
-                        };
-                    } forEach _wiredRacks;
-
-                    // Open FFCS GUI
-                    [] call EFUNC(sys_intercom,openGui);
-                    sleep 0.5;
-
-                    // Find current knob position and the direction to move it to the desired position
-                    private _curWorkPos = [vehicle acre_player, acre_player, EGVAR(sys_intercom,activeIntercom), "workKnob"] call EFUNC(sys_intercom,getStationConfiguration);
-                    private _direction = 0;
-                    if (_newWorkPos < _curWorkPos) then {
-                        _direction = 1;
+                // Find the work knob position that corresponds to the mounted radio
+                private _mountedRadio = _this select 2;
+                private _newWorkPos = 0;
+                private _wiredRacks = [vehicle acre_player, acre_player, EGVAR(sys_intercom,activeIntercom), "wiredRacks"] call EFUNC(sys_intercom,getStationConfiguration);
+                {
+                    private _rack = _x select 0;
+                    private _radio = [_rack] call FUNC(getMountedRadio);
+                    if (_radio isEqualTo _mountedRadio) exitWith {
+                        _newWorkPos = _forEachIndex + 1;
                     };
+                } forEach _wiredRacks;
 
-                    // Turn the work knob N times towards the desired position
+                // Open FFCS GUI
+                [] call EFUNC(sys_intercom,openGui);
+
+                // Find current knob position and the direction to move it to the desired position
+                private _curWorkPos = [vehicle acre_player, acre_player, EGVAR(sys_intercom,activeIntercom), "workKnob"] call EFUNC(sys_intercom,getStationConfiguration);
+                private _direction = 0;
+                if (_newWorkPos < _curWorkPos) then {
+                    _direction = 1;
+                };
+
+                // After a delay, turn the work knob N times towards the desired position
+                [{
+                    params ["_direction", "_curWorkPos", "_newWorkPos"];
                     private _i = 0;
                     while {_i < abs (_curWorkPos - _newWorkPos)} do {
                         [0, _direction] call EFUNC(sys_intercom,vic3ffcsOnWorkKnobPress);
                         _i = _i + 1;
-                        sleep 0.2;
                     };
-                };
+                }, [_direction, _curWorkPos, _newWorkPos], 0.5] call CBA_fnc_waitAndExecute;
             },
             {true},
             {},

--- a/addons/sys_rack/script_component.hpp
+++ b/addons/sys_rack/script_component.hpp
@@ -25,3 +25,5 @@
 
 #include "\idi\acre\addons\sys_components\script_acre_component_defines.hpp"
 #include "\idi\acre\addons\sys_intercom\script_acre_rackIntercom_defines.hpp"
+/*#include "\idi\acre\addons\sys_intercom\script_component.hpp"
+#include "\idi\acre\addons\sys_intercom\vic3\script_component.hpp"*/

--- a/addons/sys_rack/script_component.hpp
+++ b/addons/sys_rack/script_component.hpp
@@ -21,9 +21,9 @@
 
 #define MAX_EXTERNAL_RACK_DISTANCE 10
 
+#define RACK_LETTERS "A", "B", "C", "D", "E", "F"
+
 #include "script_acre_rack_defines.hpp"
 
 #include "\idi\acre\addons\sys_components\script_acre_component_defines.hpp"
 #include "\idi\acre\addons\sys_intercom\script_acre_rackIntercom_defines.hpp"
-/*#include "\idi\acre\addons\sys_intercom\script_component.hpp"
-#include "\idi\acre\addons\sys_intercom\vic3\script_component.hpp"*/

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -90,9 +90,9 @@
             <Turkish>Kullan</Turkish>
         </Key>
         <Key ID="STR_ACRE_sys_rack_useIntercomRadio">
-            <English>Use via Intercom (WK: %1)</English>
-            <German>Durch Intercom verwenden (Work-Knob auf %1 stellen)</German>
-            <Italian>Usa tramite l'intercom (manopola Work su %1)</Italian>
+            <English>Use via Intercom (Work: %1)</English>
+            <German>Durch Intercom verwenden (Work: %1)</German>
+            <Italian>Usa tramite l'intercom (Work: %1)</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_rack_unableUnmount">
             <English>Unable to unmount radio as you have no inventory space.</English>

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -89,6 +89,11 @@
             <Russian>Использовать</Russian>
             <Turkish>Kullan</Turkish>
         </Key>
+        <Key ID="STR_ACRE_sys_rack_useIntercomRadio">
+            <English>Use by turning Work-Knob to %1</English>
+            <German>Durch drehen des Work-Knobs auf %1 verwenden</German>
+            <Italian>Usa girando la manopola Work su %1</Italian>
+        </Key>
         <Key ID="STR_ACRE_sys_rack_unableUnmount">
             <English>Unable to unmount radio as you have no inventory space.</English>
             <German>Funkgerät kann nicht deinstalliert werden. Nicht genug Platz im Inventar.</German>

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -90,9 +90,9 @@
             <Turkish>Kullan</Turkish>
         </Key>
         <Key ID="STR_ACRE_sys_rack_useIntercomRadio">
-            <English>Use by turning Work-Knob to %1</English>
-            <German>Durch drehen des Work-Knobs auf %1 verwenden</German>
-            <Italian>Usa girando la manopola Work su %1</Italian>
+            <English>Use via Intercom (Work-Knob to %1)</English>
+            <German>Durch Intercom verwenden (Work-Knob auf %1 stellen)</German>
+            <Italian>Usa tramite l'intercom (manopola Work su %1)</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_rack_unableUnmount">
             <English>Unable to unmount radio as you have no inventory space.</English>

--- a/addons/sys_rack/stringtable.xml
+++ b/addons/sys_rack/stringtable.xml
@@ -90,7 +90,7 @@
             <Turkish>Kullan</Turkish>
         </Key>
         <Key ID="STR_ACRE_sys_rack_useIntercomRadio">
-            <English>Use via Intercom (Work-Knob to %1)</English>
+            <English>Use via Intercom (WK: %1)</English>
             <German>Durch Intercom verwenden (Work-Knob auf %1 stellen)</German>
             <Italian>Usa tramite l'intercom (manopola Work su %1)</Italian>
         </Key>


### PR DESCRIPTION
**When merged this pull request will:**

- ~~**Fix AN/VRC-103 not being usable on Tracked Vehicles**~~
~~On all inheritors of `Tank_F` and `Wheeled_APC_F`, which includes all Tanks, tracked/wheeled APCs+IFVs, SPAA and Tank Destroyers, the (only) integrated AN/VRC-103 rack was unusable. You could open the radio interface but not make it appear in your Self Interact radio list to actually T/R with it.~~
~~Image~~
~~I compared the [non-functional](https://github.com/IDI-Systems/acre2/blob/d0ffb0d2a4d3241ddd547a202725b72af5b638ec/addons/sys_rack/CfgVehicles.hpp#L185C1-L192C15) VRC-103 definition to the [working one](https://github.com/IDI-Systems/acre2/blob/d0ffb0d2a4d3241ddd547a202725b72af5b638ec/addons/sys_rack/CfgVehicles.hpp#L59C1-L66C15) of MRAPs, the most probable cause appeared to be `intercom[] = {"intercom_1"};`, so I tried removing that and it now works. It appears to have been last changed in e95821a04, maybe `"intercom_1"` blocks the rack when a crew intercom channel exists?~~
~~Image~~

- **Descriptive "Use" interaction for racks wired to intercom:**
Since on MRAPs and Aircraft racks can be used with just a "use" function, players who haven't read the Intercom documentation in detail won't easily realize that they need to manipulate the FFCS's Work Knob to start using the racks on armoured vehicles.
To explain the process on the fly, an interaction named "Use via Intercom (Work-Knob to A/B/C/D/E/F)" will point out the FFCS knob to turn before opening the FFCS GUI, so that the player can set it himself and have learned how to do it in the future.

- **Increase access to racks on MRAPs**
By default the racks on MRAPs are available only to the driver and front (first) passenger, this makes complete sense on the unarmed NATO M-ATV (and pretty much any other light military vehicle configuration), as you'd want the vehicle commander or navigator to be in that seat.
On the AAF MRAP however, there is a "Commander" position with access to an extendable IR sensor turret and laser designator, IMO it makes complete sense for that guy to have access to radios as well, so I added it to the `allowedPositions[]` list of `MRAP_03_base_F`.
(Picture is from the Commander seat's POV on an armed AAF MRAP)
![AAF-MRAP-Interior](https://github.com/IDI-Systems/acre2/assets/58027418/05f41aae-f3fc-4bc1-8c23-aff97946bd3f)
![Racks-Available-on-MRAP](https://github.com/IDI-Systems/acre2/assets/58027418/3a997cab-b164-4970-b341-fe17ec12bacb)
I guess it would make sense for the Gunners of all vanilla MRAPs to also have access to the Racks, since they use remote turrets and sit in front of a whole terminal. However I can see how putting that in the config would also allow Gunners on modded MRAPs with conventional manned turrets to access the Racks, which doesn't make much sense.