### PR TITLE
Radios - Add a separate "signalModelLR" setting for "Long Range" radios

### DIFF
--- a/addons/sys_signal/XEH_preInit.sqf
+++ b/addons/sys_signal/XEH_preInit.sqf
@@ -15,4 +15,25 @@ if (hasInterface) then {
 // CBA Settings
 #include "initSettings.sqf"
 
+DGVAR(lrAntennas) = []; // array of antenna classname segments that count as long-ranged, i.e: "ACRE_123CM_VHF_TNC" should be "123CM" in the array.
+if !(GVAR(signalModel) isEqualTo GVAR(signalModelLR)) then { // start building the array of antenna classname segments based on the current ACRE Signal CBA settings
+    if (GVAR(radiopacksLR)) then {
+        GVAR(lrAntennas) append ["SEM70", "AT271", "123CM"];
+    };
+
+    if (GVAR(racksLR)) then {
+        GVAR(lrAntennas) append ["270CM", "FA80", "AS1729"];
+    };
+
+    if (GVAR(groundSpikeLR) != 0) then {
+        if (GVAR(groundSpikeLR) == 1) exitWith { // Only GSA with Mast is long-ranged
+            GVAR(lrAntennas) append ["643CM"];
+        };
+        if (GVAR(groundSpikeLR) == 2) exitWith { // Both GSA with and without Masts are long-ranged
+            GVAR(lrAntennas) append ["243CM", "643CM"];
+        };
+    };
+    INFO_1("Antennas that use signalModelLR: %1", GVAR(lrAntennas));
+};
+
 ADDON = true;

--- a/addons/sys_signal/fnc_getSignalCore.sqf
+++ b/addons/sys_signal/fnc_getSignalCore.sqf
@@ -25,9 +25,6 @@ if (_count == 0) then {
     private _rxAntennas = [_receiverClass] call EFUNC(sys_components,findAntenna);
     private _txAntennas = [_transmitterClass] call EFUNC(sys_components,findAntenna);
 
-    private _lrRadios = ["PRC77", "PRC117F", "SEM70"];
-    private _lrAntennas = ["SEM70", "AT271", "123CM", "270CM", "FA80", "AS1729", "243CM", "643CM"];
-
     private _model = GVAR(signalModel); // TODO: Change models on the fly if compatible (underwater, better frequency matching)
 
     // Make sure ITWOM is not used for the moment
@@ -42,10 +39,9 @@ if (_count == 0) then {
             private _rxAntenna = _x;
 
             // IF the transmitter is using a LR antenna, use signalModelLR
-            private _txRadioName = [_transmitterClass, "_"] call BIS_fnc_splitString select 1;
             private _txAntennaName = [_txAntenna select 0, "_"] call BIS_fnc_splitString select 1;
 
-            if (_txRadioName in _lrRadios || {_txAntennaName in _lrAntennas}) then {
+            if (_txAntennaName in GVAR(lrAntennas)) then {
                 _model = GVAR(signalModelLR);
                 systemChat "transmission is using signalModelLR";
             } else {

--- a/addons/sys_signal/fnc_getSignalCore.sqf
+++ b/addons/sys_signal/fnc_getSignalCore.sqf
@@ -25,6 +25,9 @@ if (_count == 0) then {
     private _rxAntennas = [_receiverClass] call EFUNC(sys_components,findAntenna);
     private _txAntennas = [_transmitterClass] call EFUNC(sys_components,findAntenna);
 
+    private _lrRadios = ["PRC77", "PRC117F", "SEM70"];
+    private _lrAntennas = ["SEM70", "AT271", "123CM", "270CM", "FA80", "AS1729", "243CM", "643CM"];
+
     private _model = GVAR(signalModel); // TODO: Change models on the fly if compatible (underwater, better frequency matching)
 
     // Make sure ITWOM is not used for the moment
@@ -37,6 +40,14 @@ if (_count == 0) then {
         private _txAntenna = _x;
         {
             private _rxAntenna = _x;
+
+            // IF the transmitter is using a LR antenna, use signalModelLR
+            private _txRadioName = [_transmitterClass, "_"] call BIS_fnc_splitString select 1;
+            private _txAntennaName = [_txAntenna select 0, "_"] call BIS_fnc_splitString select 1;
+
+            if (_txRadioName in _lrRadios || {_txAntennaName in _lrAntennas}) then {
+                _model = GVAR(signalModelLR);
+            };
 
             _count = _count + 1;
             private _id = format ["%1_%2_%3_%4", _transmitterClass, (_txAntenna select 0), _receiverClass, (_rxAntenna select 0)];

--- a/addons/sys_signal/fnc_getSignalCore.sqf
+++ b/addons/sys_signal/fnc_getSignalCore.sqf
@@ -47,6 +47,9 @@ if (_count == 0) then {
 
             if (_txRadioName in _lrRadios || {_txAntennaName in _lrAntennas}) then {
                 _model = GVAR(signalModelLR);
+                systemChat "transmission is using signalModelLR";
+            } else {
+                systemChat "transmission is using normal signalModel";
             };
 
             _count = _count + 1;

--- a/addons/sys_signal/fnc_getSignalCore.sqf
+++ b/addons/sys_signal/fnc_getSignalCore.sqf
@@ -25,17 +25,18 @@ if (_count == 0) then {
     private _rxAntennas = [_receiverClass] call EFUNC(sys_components,findAntenna);
     private _txAntennas = [_transmitterClass] call EFUNC(sys_components,findAntenna);
 
+    private _model = GVAR(signalModel); // TODO: Change models on the fly if compatible (underwater, better frequency matching)
+
+    // Make sure ITWOM is not used for the moment
+    if (_model > SIGNAL_MODEL_ITWOM || {_model < SIGNAL_MODEL_CASUAL}) then {
+        _model = SIGNAL_MODEL_LOS_MULTIPATH;  // Default to LOS Multipath if the model is out of range
+        GVAR(signalModel) = _model;           // And make sure we do not use an invalid mode next time
+    };
+
     {
         private _txAntenna = _x;
         {
             private _rxAntenna = _x;
-            private _model = GVAR(signalModel); // TODO: Change models on the fly if compatible (underwater, better frequency matching)
-
-            // Make sure ITWOM is not used for the moment
-            if (_model > SIGNAL_MODEL_ITWOM || {_model < SIGNAL_MODEL_CASUAL}) then {
-                _model = SIGNAL_MODEL_LOS_MULTIPATH;  // Default to LOS Multipath if the model is out of range
-                GVAR(signalModel) = _model;           // And make sure we do not use an invalid mode next time
-            };
 
             _count = _count + 1;
             private _id = format ["%1_%2_%3_%4", _transmitterClass, (_txAntenna select 0), _receiverClass, (_rxAntenna select 0)];

--- a/addons/sys_signal/fnc_getSignalCore.sqf
+++ b/addons/sys_signal/fnc_getSignalCore.sqf
@@ -43,9 +43,6 @@ if (_count == 0) then {
 
             if (_txAntennaName in GVAR(lrAntennas)) then {
                 _model = GVAR(signalModelLR);
-                systemChat "transmission is using signalModelLR";
-            } else {
-                systemChat "transmission is using normal signalModel";
             };
 
             _count = _count + 1;

--- a/addons/sys_signal/initSettings.sqf
+++ b/addons/sys_signal/initSettings.sqf
@@ -32,6 +32,40 @@
     {
         params ["_value"];
         private _signalModelLR = [SIGNAL_NAMES] select _value;
-        INFO_1("Using backpack radio propagation model: %1",_signalModelLR);
+        INFO_1("Using Long-Range radio propagation model: %1",_signalModelLR);
     }
+] call CBA_fnc_addSetting;
+
+// Do backpack radios use signalModelLR
+[
+    QGVAR(radiopacksLR),
+    "CHECKBOX",
+    localize LSTRING(radiopacksLR_displayName),
+    "ACRE2",
+    true,
+    true
+] call CBA_fnc_addSetting;
+
+// Do vehicle racks use signalModelLR
+[
+    QGVAR(racksLR),
+    "CHECKBOX",
+    localize LSTRING(racksLR_displayName),
+    "ACRE2",
+    true,
+    true
+] call CBA_fnc_addSetting;
+
+// Does the ground spike antenna use signalModelLR
+[
+    QGVAR(groundSpikeLR),
+    "LIST",
+    localize LSTRING(groundSpikeLR_displayName),
+    "ACRE2",
+    [
+        [0, 1, 2],
+        ["None", "Only GSA with Mast", "Both"],
+        1 // Default
+    ],
+    true
 ] call CBA_fnc_addSetting;

--- a/addons/sys_signal/initSettings.sqf
+++ b/addons/sys_signal/initSettings.sqf
@@ -16,3 +16,22 @@
         INFO_1("Using radio propagation model: %1",_signalModel);
     }
 ] call CBA_fnc_addSetting;
+
+// Signal model for Backpack Radios
+[
+    QGVAR(signalModelLR),
+    "LIST",
+    localize LSTRING(signalModelLR_displayName),
+    "ACRE2",
+    [
+        [SIGNAL_ENUMS],
+        [SIGNAL_NAMES],
+        SIGNAL_MODEL_LOS_MULTIPATH // Default
+    ],
+    true,
+    {
+        params ["_value"];
+        private _signalModelLR = [SIGNAL_NAMES] select _value;
+        INFO_1("Using backpack radio propagation model: %1",_signalModelLR);
+    }
+] call CBA_fnc_addSetting;

--- a/addons/sys_signal/stringtable.xml
+++ b/addons/sys_signal/stringtable.xml
@@ -27,5 +27,20 @@
             <Portuguese>Modelo de propagação de sinal para rádios de longo alcance</Portuguese>
             <Turkish>Uzun menzilli telsizler için sinyal yayılma modeli</Turkish>
         </Key>
+        <Key ID="STR_ACRE_sys_signal_radiopacksLR_displayName">
+            <English>Should radiopacks count as Long-Ranged</English>
+            <German>Rucksackfunkgeräte sind langstreckentauglich</German>
+            <Italian>Radio da zaino sono di lunga portata</Italian>
+        </Key>
+        <Key ID="STR_ACRE_sys_signal_racksLR_displayName">
+            <English>Should Vehicle Racks count as Long-Ranged</English>
+            <German>Fahrzeugantennen sind langstreckentauglich</German>
+            <Italian>Racks sui veicoli sono di lunga portata</Italian>
+        </Key>
+        <Key ID="STR_ACRE_sys_signal_groundSpikeLR_displayName">
+            <English>Should Ground Spikes count as Long-Ranged</English>
+            <German>Bodenbefestigte Antennen sind langstreckentauglich</German>
+            <Italian>Antenne piazzabili sono di lunga portata</Italian>
+        </Key>
     </Package>
 </Project>

--- a/addons/sys_signal/stringtable.xml
+++ b/addons/sys_signal/stringtable.xml
@@ -14,5 +14,18 @@
             <Portuguese>Modelo de propagação de sinal</Portuguese>
             <Turkish>Sinyal İletim Modeli</Turkish>
         </Key>
+        <Key ID="STR_ACRE_sys_signal_signalModelLR_displayName">
+            <English>Signal Propagation Model for Long-Range Radios</English>
+            <Spanish>Modelo de propagación de señal para radios de largo alcance</Spanish>
+            <Japanese>信号伝搬モデル</Japanese>
+            <Chinese>訊號傳遞模型</Chinese>
+            <German>Signalausbreitungsmodell für Langstreckenfunkgeräte</German>
+            <Italian>Modello di propagazione del segnale per radio a lunga portata</Italian>
+            <Russian>Модель распространения сигнала для радиостанций дальнего действия</Russian>
+            <French>Modèle de propagation des ondes pour les radios longue portée</French>
+            <Chinesesimp>讯号传递模型</Chinesesimp>
+            <Portuguese>Modelo de propagação de sinal para rádios de longo alcance</Portuguese>
+            <Turkish>Uzun menzilli telsizler için sinyal yayılma modeli</Turkish>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Add an additional `signalModelLR` setting to calculate propagation of "Long Range" Radios.

**To-Do before completing the PR:**
- [x] Add the new setting and verify that the new signal calculation works;
- [x] Allow the user to select which antennas count as "long range";
- [x] Remove any debug outputs that are not flag-dependent;
- [ ] Document new feature;

**Explanation:**

I love LOS-Multipath, it's awesome to have to think about one's own positioning in the environment down to a scale of <10 meters in order to guarantee proper comms quality, it really makes playing as the radio operator even more fun.

However, when mission design requires operating on different sides of highly signal-blocking terrain, i.e: Stratis or other mountainous maps, without the presence of relaying elements, then LOS propagation models can sometimes become too much of a hassle to use.
For that reason my unit has defaulted to the Arcade signal model in order to not incur such issues when avoiding them is not possible.

As a solution, I propose the addition of a new `signalModelLR` setting, which can be set to a different model than the current `signalModel` setting and applies only to transmissions sent from radios connected to a "Long Range" antenna.
For now "Long Range" Antennas are defined in arrays with local scope within `addons/sys_signal/fnc_getSignalCore.sqf`, and include the following:
- Backpack Radio (`PRC-77/117F`, `SEM70`) Antennas;
- Vehicle Antennas (`PRC-152` mounted to a rack will become "long range");
- Ground Spike Antennas (`PRC-152` mounted to a GS with and without mast will become "long range");

This feature will allow users more freedom of mission design without having to resort to the Arcade propagation model on all radios.
For example by setting `signalModel` to LOS-Simple and `signalModelLR` to Arcade, requiring proper positioning and unit cohesion to maintain squad-level comms in hilly terrain, while allowing for terrain-independent communications on and to higher levels of command *if* LR-Antennas are available.