### PR TITLE
Racks - Fix AN/VRC-64 (PRC-77) connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The project is entirely **open-source** and all contributions are welcome. Core 
 ### Features
 
 - Accurate simulations of AN/PRC-343, AN/PRC-77, AN/PRC-148, AN/PRC-117F, AN/PRC-152, SEM 52 SL, SEM 70, BF-888S.
-- Vehicle racks AN/VRC-103, AN/VRC-110, AN/VRC-111, SEM90.
+- Vehicle racks AN/VRC-64, AN/VRC-103, AN/VRC-110, AN/VRC-111, SEM90.
 - Deployable antennas.
 - Real time voice occlusion for world objects, including buildings.
 - Babel language system that allows you to implement virtual languages on other players.

--- a/addons/sys_components/fnc_attachComplexComponent.sqf
+++ b/addons/sys_components/fnc_attachComplexComponent.sqf
@@ -21,6 +21,7 @@
  */
 
 params ["_parentComponentId", "_parentConnector", "_childComponentId", "_childConnector", "_attributes", ["_force",false]];
+TRACE_6("attachComplexComponent",_parentComponentId,_parentConnector,_childComponentId,_childConnector,_attributes,_force);
 
 private _return = false;
 
@@ -41,6 +42,14 @@ if (_componentSimple == 1) exitWith {
 
 private _parentConnectorType = ((getArray(_parentComponentClass >> "connectors")) select _parentConnector) select 1;
 private _childConnectorType = ((getArray(_childComponentClass >> "connectors")) select _childConnector) select 1;
+if (isNil {_parentConnectorType}) exitWith {
+    WARNING_2("Parent %1 does not have connector index %2",configName _parentComponentClass,_parentConnector);
+    false
+};
+if (isNil {_childConnectorType}) exitWith {
+    WARNING_2("Child %1 does not have connector index %2",configName _childComponentClass,_childConnector);
+    false
+};
 
 if (_parentConnectorType == _childConnectorType) then {
     private _exit = false;

--- a/addons/sys_components/script_acre_component_defines.hpp
+++ b/addons/sys_components/script_acre_component_defines.hpp
@@ -22,3 +22,4 @@
 #define ACRE_CONNECTOR_CONN_26PIN 7 // Harris 26 AIC pin - 117F to VRC103
 #define ACRE_CONNECTOR_CONN_18PIN 8 // 18pin for the 148 Side connector
 #define ACRE_CONNECTOR_CONN_57PIN 9 // 57pin is the SEM70/80/90 interconnecting connector
+#define ACRE_CONNECTOR_CONN_14PIN 10 // 14 pin CX-4655

--- a/addons/sys_prc77/CfgAcreRadios.hpp
+++ b/addons/sys_prc77/CfgAcreRadios.hpp
@@ -16,7 +16,8 @@ class CfgAcreComponents {
 
         connectors[] = {
             {"Antenna", ACRE_CONNECTOR_3_8},
-            {"Audio/Data", ACRE_CONNECTOR_U_283}
+            {"Audio/Data", ACRE_CONNECTOR_U_283},
+            {"Radio", ACRE_CONNECTOR_CONN_14PIN},
         };
         defaultComponents[] = {
             { 0,"ACRE_AT271_38" }

--- a/addons/sys_rack/CfgAcreRacks.hpp
+++ b/addons/sys_rack/CfgAcreRacks.hpp
@@ -8,7 +8,7 @@ class CfgAcreComponents {
                             {"Audio In", ACRE_CONNECTOR_U_283},
                             {"Audio Out", ACRE_CONNECTOR_U_283},
                             {"Power In", ACRE_CONNECTOR_U_283},
-                            {"Radio", ACRE_CONNECTOR_CONN_32PIN}
+                            {"Radio", ACRE_CONNECTOR_CONN_14PIN}
                         };
         defaultComponents[] = {
                                 {0, "ACRE_AS1729_38"}

--- a/addons/sys_rack/vrc64/fnc_vrc64MountRadio.sqf
+++ b/addons/sys_rack/vrc64/fnc_vrc64MountRadio.sqf
@@ -19,7 +19,7 @@ params ["_rackId", "", "_eventData", ""];
 
 private _radioId = _eventData;
 
-// 26 Pin Connector
+// 14 Pin Connector
 private _attributes = HASH_CREATE;
 [_rackId, 4, _radioId, 2, _attributes, false] call EFUNC(sys_components,attachComplexComponent);
 

--- a/docs/wiki/frameworks/vehicle-racks.md
+++ b/docs/wiki/frameworks/vehicle-racks.md
@@ -118,6 +118,7 @@ The framework recognises the following entries and wildcards for the configurati
   - `"external"`: rack can be used only externally.
   - `"all"` can be combined with  `"cargo"`, `"turret"`, `"ffv"` and `"turnedout"` and selects all entries of this category. For example `{{"cargo", 1}, {"ffv", "all"}}`.
 - **Racks**:
+  - `"ACRE_VRC64"`: Can mount a `"ACRE_PRC77"`
   - `"ACRE_VRC103"`: Can mount a `"ACRE_PRC117F"`.
   - `"ACRE_VRC110"`: Can mount a `"ACRE_PRC152"`.
   - `"ACRE_VRC111"`: Can mount a `"ACRE_PRC148"` (20W version).

--- a/docs/wiki/frameworks/vehicle-racks.md
+++ b/docs/wiki/frameworks/vehicle-racks.md
@@ -118,7 +118,7 @@ The framework recognises the following entries and wildcards for the configurati
   - `"external"`: rack can be used only externally.
   - `"all"` can be combined with  `"cargo"`, `"turret"`, `"ffv"` and `"turnedout"` and selects all entries of this category. For example `{{"cargo", 1}, {"ffv", "all"}}`.
 - **Racks**:
-  - `"ACRE_VRC64"`: Can mount a `"ACRE_PRC77"`
+  - `"ACRE_VRC64"`: Can mount a `"ACRE_PRC77"`.
   - `"ACRE_VRC103"`: Can mount a `"ACRE_PRC117F"`.
   - `"ACRE_VRC110"`: Can mount a `"ACRE_PRC152"`.
   - `"ACRE_VRC111"`: Can mount a `"ACRE_PRC148"` (20W version).

--- a/docs/wiki/user/vehicle-racks.md
+++ b/docs/wiki/user/vehicle-racks.md
@@ -6,10 +6,11 @@ title: Vehicle Racks
 
 ACRE2 allows the possibility of using racks in vehicles in order to increase the transmission power of a particular radio. There are different types of vehicle racks:
 
-- **AN/VRC 103**: Allows mounting an *AN/PRC 117F*. Such radio will see its transmitting power increase from 20W to 50W.
-- **AN/VRC 110**: Allows mounting an *AN/PRC 152*. A mounted radio will see its transmitting power increased from 5W to 50W.
-- **AN/VRC 111**: Allows mounting an *AN/PRC 148*. A mounted radio will see its transmitting power increased from 5W to 20W.
-- **SEM 90**: Allows mounting a *SEM 70*. This will increase transmitting power to 4W on low power and 40W on high power for the SEM 70.
+- **AN/VRC 64**: Allows mounting an *AN/PRC 77*, increasing its transmitting power from 3.5W to 50W.
+- **AN/VRC 103**: Allows mounting an *AN/PRC 117F*, increasing its transmitting power from 20W to 50W.
+- **AN/VRC 110**: Allows mounting an *AN/PRC 152*, increasing its transmitting power from 5W to 20W.
+- **AN/VRC 111**: Allows mounting an *AN/PRC 148*, increasing its transmitting power from 5W to 20W.
+- **SEM 90**: Allows mounting a *SEM 70*, maintaining its transmitting power at 4W on low poer or increasing it to 40W on high power.
 
 In order to use and mount and unmount (when possible) a vehicle rack, ACE3 Interaction Menu is needed: simply interact with the vehicle when being in a seat with access to vehicle racks and select *use radio*. Multiple players will be able to use the radio simultaneously, except for the case of sending a transmission when the radio is already transmitting! Some vehicle racks, however, can be also accessed from outside the vehicle.
 

--- a/docs/wiki/user/vehicle-racks.md
+++ b/docs/wiki/user/vehicle-racks.md
@@ -10,7 +10,7 @@ ACRE2 allows the possibility of using racks in vehicles in order to increase the
 - **AN/VRC 103**: Allows mounting an *AN/PRC 117F*, increasing its transmitting power from 20W to 50W.
 - **AN/VRC 110**: Allows mounting an *AN/PRC 152*, increasing its transmitting power from 5W to 20W.
 - **AN/VRC 111**: Allows mounting an *AN/PRC 148*, increasing its transmitting power from 5W to 20W.
-- **SEM 90**: Allows mounting a *SEM 70*, maintaining its transmitting power at 4W on low poer or increasing it to 40W on high power.
+- **SEM 90**: Allows mounting a *SEM 70*, maintaining its transmitting power at 4W on low power or increasing it to 40W on high power.
 
 In order to use and mount and unmount (when possible) a vehicle rack, ACE3 Interaction Menu is needed: simply interact with the vehicle when being in a seat with access to vehicle racks and select *use radio*. Multiple players will be able to use the radio simultaneously, except for the case of sending a transmission when the radio is already transmitting! Some vehicle racks, however, can be also accessed from outside the vehicle.
 


### PR DESCRIPTION
Calling `[_vehicle] call acre_api_fnc_areVehicleRacksInitialized;` from scheduled will throw
```
 Error in expression < select 1;
if (_parentConnectorType == _childConnectorType) then {
private _exi>
   Error position: <_childConnectorType) then {
private _exi>
  Error Undefined variable in expression: _childconnectortype
 File idi\acre\addons\sys_components\fnc_attachComplexComponent.sqf..., line 45
```
https://github.com/IDI-Systems/acre2/blob/10d20356df3f3b1e74ab910e99a191ebcbfc612a/addons/sys_rack/vrc64/fnc_vrc64MountRadio.sqf#L24
but there isn't a index 2 `connectors[]` on the radio


This adds a new 14 pin connector, I think this was the original intent, but I'm not positive
