### PR TITLE
BF-888S - Show current channel on channel knob

### DIFF
--- a/addons/sys_bf888s/functions/fnc_render.sqf
+++ b/addons/sys_bf888s/functions/fnc_render.sqf
@@ -40,6 +40,7 @@ _currentViewFrame = 0;
 
 RADIO_CTRL(106) ctrlSetText format ["\idi\acre\addons\sys_bf888s\Data\knobs\channel\bf888s_ui_pre_%1.paa", _currentChannel + 1];
 RADIO_CTRL(107) ctrlSetText format ["\idi\acre\addons\sys_bf888s\Data\knobs\volume\bf888s_ui_vol_%1.paa", _currentVolumeKnobState];
+RADIO_CTRL(201) ctrlSetTooltip format ["Current Channel: %1", _currentChannel + 1];
 RADIO_CTRL(202) ctrlSetTooltip format ["Current Volume: %1%2", round (_currentVolume * 100), "%"];
 RADIO_CTRL(99999) ctrlSetText QPATHTOF(Data\static\bf888s_ui_backplate.paa);
 


### PR DESCRIPTION
**When merged this pull request will:**
- Make the Beofeng BF-888S channel knob tooltip display the currently selected channel number;

The Beofeng BF-888S does have numbers around its channel knob, however they are only visible when looked at from the top.
![bf888s-channel-knob](https://github.com/IDI-Systems/acre2/assets/58027418/49cd8f9b-1fab-478e-8640-d1cc5a58c0cc)

Since the Beofeng's GUI in ACRE only shows it from the front, we can't always tell at a glance which position the channel knob is in.
To improve usability I made the channel knob tooltip display the current channel, in the same way the volume knob tooltip displays the current volume in %.
![new-bf888s-tooltip](https://github.com/IDI-Systems/acre2/assets/58027418/7759d1bf-ee8d-42ca-a8a0-073134c9f74f)