### PR TITLE
External - Share radios when unconscious

### DIFF
--- a/addons/sys_external/fnc_getSharedExternalRadios.sqf
+++ b/addons/sys_external/fnc_getSharedExternalRadios.sqf
@@ -24,6 +24,6 @@ if (
     !(alive _unit) ||
     {captive _unit} ||
     {lifeState _unit isEqualTo "INCAPACITATED"}
-    ) exitWith {_radioList};
+) exitWith {_radioList};
 
 _radioList select {[_x, "getState", "radioShared"] call EFUNC(sys_data,dataEvent)}

--- a/addons/sys_external/fnc_getSharedExternalRadios.sqf
+++ b/addons/sys_external/fnc_getSharedExternalRadios.sqf
@@ -23,7 +23,7 @@ private _radioList = _radios select {_x call EFUNC(sys_radio,isUniqueRadio)};
 if (
     !(alive _unit) ||
     {captive _unit} ||
-    {_unit getVariable ["ACE_isUnconscious", false]}
+    {lifeState _unit isEqualTo "INCAPACITATED"}
     ) exitWith {_radioList};
 
 _radioList select {[_x, "getState", "radioShared"] call EFUNC(sys_data,dataEvent)}

--- a/addons/sys_external/fnc_getSharedExternalRadios.sqf
+++ b/addons/sys_external/fnc_getSharedExternalRadios.sqf
@@ -20,6 +20,10 @@ params ["_unit"];
 private _radios = [_unit] call EFUNC(sys_core,getGear);
 private _radioList = _radios select {_x call EFUNC(sys_radio,isUniqueRadio)};
 
-if (!(alive _unit) || {captive _unit}) exitWith {_radioList};
+if (
+    !(alive _unit) ||
+    {captive _unit} ||
+    {_unit getVariable ["ACE_isUnconscious", false]}
+    ) exitWith {_radioList};
 
 _radioList select {[_x, "getState", "radioShared"] call EFUNC(sys_data,dataEvent)}


### PR DESCRIPTION
**When merged this pull request will:**
- One's radios will be shared with other players while unconscious;

This extends the current behaviour of radios becoming shared when dying or being handcuffed.