### PR TITLE
Intercom - Improve Infantry Phone Limitations and add Custom Positions to Vanilla Vehicles

### DIFF
--- a/addons/sys_intercom/CfgVehicles.hpp
+++ b/addons/sys_intercom/CfgVehicles.hpp
@@ -288,6 +288,27 @@ class CfgVehicles {
         acre_infantryPhonePosition[] = {-0.70, -4.51, -0.67};
     };
 
+    class LT_01_base_F;
+    class LT_01_AA_base_F: LT_01_base_F;
+    class I_LT_01_AA_F: LT_01_AA_base_F {
+        acre_infantryPhonePosition[] = {-1.10, -1.66, -0.83};
+    };
+
+    class LT_01_AT_base_F: LT_01_base_F;
+    class I_LT_01_AT_F: LT_01_AT_base_F {
+        acre_infantryPhonePosition[] = {-1.10, -1.66, -0.83};
+    };
+
+    class LT_01_cannon_base_F: LT_01_base_F;
+    class I_LT_01_cannon_F: LT_01_cannon_base_F {
+        acre_infantryPhonePosition[] = {-1.10, -1.90, -0.78};
+    };
+
+    class LT_01_scout_base_F: LT_01_base_F;
+    class I_LT_01_scout_F: LT_01_scout_base_F {
+        acre_infantryPhonePosition[] = {-1.10, -1.90, -0.78};
+    };
+
     class Air;
     class Helicopter: Air {
         class AcreIntercoms {

--- a/addons/sys_intercom/CfgVehicles.hpp
+++ b/addons/sys_intercom/CfgVehicles.hpp
@@ -147,6 +147,21 @@ class CfgVehicles {
         acre_infantryPhonePosition[] = {1.38, -4.77, -1.1};
     };
 
+    class O_MBT_02_railgun_base_F;
+    class O_MBT_02_railgun_F: O_MBT_02_railgun_base_F {
+        acre_infantryPhonePosition[] = {1.38, -4.77, -1.1};
+    };
+
+    class MBT_04_cannon_base_F;
+    class O_MBT_04_cannon_F: MBT_04_cannon_base_F {
+        acre_infantryPhonePosition[] = {-1.47, -5.68, -0.82};
+    };
+
+    class MBT_04_command_base_F;
+    class O_MBT_04_command_F: MBT_04_command_base_F {
+        acre_infantryPhonePosition[] = {-1.47, -5.68, -1.17};
+    };
+
     class O_MBT_02_arty_base_F;
     class O_MBT_02_arty_F: O_MBT_02_arty_base_F {
         acre_infantryPhonePosition[] = {1.4, -5.4, -1.65};

--- a/addons/sys_intercom/CfgVehicles.hpp
+++ b/addons/sys_intercom/CfgVehicles.hpp
@@ -27,6 +27,11 @@ class CfgVehicles {
                 connectedByDefault = 1;
             };
         };
+
+        acre_hasInfantryPhone = 1;
+        acre_infantryPhoneIntercom[] = {"all"};
+        acre_infantryPhoneControlActions[] = {"intercom_1"};
+        acre_eventInfantryPhone = QFUNC(noApiFunction);
     };
 
     class LandVehicle;
@@ -139,6 +144,12 @@ class CfgVehicles {
                 connectedByDefault = 0;
             };
         };
+
+        acre_infantryPhonePosition[] = {-0.70, -4.61, -1.00};
+    };
+
+    class AFV_Wheeled_01_base_F: Wheeled_APC_F {
+        acre_infantryPhonePosition[] = {-1.24, -4.35, -0.81};
     };
 
     // OPFOR
@@ -197,7 +208,7 @@ class CfgVehicles {
     };
 
     class APC_Wheeled_02_base_F;
-    class O_APC_Wheeled_02_base_F: APC_Wheeled_02_base_F {
+    class APC_Wheeled_02_base_v2_F: APC_Wheeled_02_base_F {
         class AcreIntercoms {
             class Intercom_1 {
                 displayName = CSTRING(crewIntercom);
@@ -217,6 +228,8 @@ class CfgVehicles {
                 connectedByDefault = 0;
             };
         };
+
+        acre_infantryPhonePosition[] = {1.10, -4.45, -0.65};
     };
 
     // INDEPENDENT
@@ -271,6 +284,8 @@ class CfgVehicles {
                 connectedByDefault = 0;
             };
         };
+
+        acre_infantryPhonePosition[] = {-0.70, -4.51, -0.67};
     };
 
     class Air;

--- a/addons/sys_intercom/CfgVehicles.hpp
+++ b/addons/sys_intercom/CfgVehicles.hpp
@@ -28,7 +28,7 @@ class CfgVehicles {
             };
         };
 
-        acre_hasInfantryPhone = 1;
+        acre_hasInfantryPhone = 0;
         acre_infantryPhoneIntercom[] = {"all"};
         acre_infantryPhoneControlActions[] = {"intercom_1"};
         acre_eventInfantryPhone = QFUNC(noApiFunction);
@@ -145,10 +145,12 @@ class CfgVehicles {
             };
         };
 
+        acre_hasInfantryPhone = 1;
         acre_infantryPhonePosition[] = {-0.70, -4.61, -1.00};
     };
 
     class AFV_Wheeled_01_base_F: Wheeled_APC_F {
+        acre_hasInfantryPhone = 1;
         acre_infantryPhonePosition[] = {-1.24, -4.35, -0.81};
     };
 
@@ -229,6 +231,7 @@ class CfgVehicles {
             };
         };
 
+        acre_hasInfantryPhone = 1;
         acre_infantryPhonePosition[] = {1.10, -4.45, -0.65};
     };
 
@@ -285,6 +288,7 @@ class CfgVehicles {
             };
         };
 
+        acre_hasInfantryPhone = 1;
         acre_infantryPhonePosition[] = {-0.70, -4.51, -0.67};
     };
 

--- a/addons/sys_intercom/CfgVehicles.hpp
+++ b/addons/sys_intercom/CfgVehicles.hpp
@@ -154,6 +154,10 @@ class CfgVehicles {
         acre_infantryPhonePosition[] = {-1.24, -4.35, -0.81};
     };
 
+    class AFV_Wheeled_01_up_base_F: AFV_Wheeled_01_base_F {
+        acre_infantryPhonePosition[] = {-1.24, -4.35, -0.92};
+    };
+
     // OPFOR
     class O_MBT_02_base_F;
     class O_MBT_02_cannon_F: O_MBT_02_base_F {

--- a/addons/sys_intercom/fnc_infantryPhoneAction.sqf
+++ b/addons/sys_intercom/fnc_infantryPhoneAction.sqf
@@ -47,7 +47,8 @@ private _infantryPhoneAction = [
         // Only manually check distance if under main node (not a custom position on hull)
         // Main interaction node is not shown on destroyed vehicle, so we only check that if not main node
         //USES_VARIABLES ["_target", "_player"];
-        if ((_this select 2) isNotEqualTo [0, 0, 0]) exitWith {alive _target};
+        private _targetAlive = alive _target;
+        if (!_targetAlive || {(_this select 2) isNotEqualTo [0, 0, 0]}) exitWith {_targetAlive};
         ([_player, _target] call ace_interaction_fnc_getInteractionDistance) < PHONE_MAXDISTANCE_DEFAULT
     },
     {_this call FUNC(infantryPhoneChildrenActions)},

--- a/addons/sys_intercom/fnc_intercomPFH.sqf
+++ b/addons/sys_intercom/fnc_intercomPFH.sqf
@@ -42,7 +42,7 @@ for "_i" from 0 to ((count _intercoms) - 1) do {
         private _playerPosition = ASLToAGL (getPosASL _player);
         TRACE_4("Infantry Phone PFH Check",_infantryPhonePosition,_playerPosition,_infantryPhoneMaxDistance,_player distance _infantryPhonePosition);
         // Add an extra meter leeway due to 3d position check height differences and movement
-        if (_playerPosition distance _infantryPhonePosition >= _infantryPhoneMaxDistance + 1 || {vehicle _player == _vehicle} || {!alive _player} || {captive _player}) then {
+        if (_playerPosition distance _infantryPhonePosition >= _infantryPhoneMaxDistance + 1 || {vehicle _player == _vehicle} || {!alive _player} || {captive _player} || {lifeState _player isEqualTo "INCAPACITATED"}) then {
             [_vehicle, _player, 0, _i] call FUNC(updateInfantryPhoneStatus);
             _intercomUnits = [];
         } else {


### PR DESCRIPTION
**When merged this pull request will:**
- Hide Infantry Phone interaction on destroyed vehicles;
- Return Infantry Phone when going unconscious;
- Add Infantry Phone to ~~`Wheeled_APC_F` class inheritors~~ Vanilla Wheeled APCs;
- **Add Custom Infantry Phone position on Vanilla vehicles:**
    - `Wheeled_APC_F` inheritors:
        - NATO AMV-7 Marshall (Badger IFV);
        - NATO Rhino MGS Tank Destroyer (Rooikat 120);
        - CSAT MSE-3 Marid (Otokar ARMA);
        - AAF AFV-4 Gorgon (Pandur II);
    - `Tanks` inheritors: 
        - CSAT T-100X Futura;
        - CSAT T-140 Angara (T-14 Armata);
        - AAF AWC 301/304 Nyx (Wiesel 2);