### PR TITLE
Extension - Fix array index out-of-bounds

### DIFF
--- a/extensions/src/ACRE2Core/AcreDsp.cpp
+++ b/extensions/src/ACRE2Core/AcreDsp.cpp
@@ -21,7 +21,7 @@ namespace Dsp {
         if (divisor < 5)
             divisor = 5;
         for (int i = 0; i < count; i += divisor) {
-            for (int x = 1; x < divisor && i + value < count; x++) {
+            for (int x = 1; x < divisor && i + x < count; x++) {
                 samples[i + x] = samples[i];
             }
         }


### PR DESCRIPTION
**When merged this pull request will:**
- Replace part of a array loop conditional that uses "volume" (`value`, [0 1]) to check for index out of bound instead of the indexing variables.