### PR TITLE
Babel - Persistent Language Hint for non-primary language

### DIFF
--- a/addons/sys_core/fnc_cycleLanguage.sqf
+++ b/addons/sys_core/fnc_cycleLanguage.sqf
@@ -24,7 +24,7 @@ if (_numSpokenLanguages > 1) then {
 
     // Set hint duration to infinite when you're not speaking your first language (setting dependent)
     private _hintTime = 1;
-    if (EGVAR(sys_list,LanguageHintPersistence) && {_nextId > 0}) then {
+    if (EGVAR(sys_list,LanguageHintPersist) && {_nextId > 0}) then {
         _hintTime = -1;
     };
 

--- a/addons/sys_core/fnc_cycleLanguage.sqf
+++ b/addons/sys_core/fnc_cycleLanguage.sqf
@@ -21,11 +21,19 @@ if (_numSpokenLanguages > 1) then {
     if (_nextId > _numSpokenLanguages - 1) then {
         _nextId = 0;
     };
+
+    // Set hint duration to infinite when you're not speaking your first language (setting dependent)
+    //systemChat format ["nextLangID: %1", _nextId];
+    private _hintTime = 1;
+    if (EGVAR(sys_list,LanguageHintPersistence) && {_nextId > 0}) then {
+        _hintTime = -1;
+    };
+
     private _languageId = ACRE_SPOKEN_LANGUAGES select _nextId;
     private _language = GVAR(languages) select _languageId;
     _language params ["_languageKey","_languageName"];
     [_languageKey] call FUNC(setSpeakingLanguage);
-    ["acre_cycleLanguage", _languageName, "Now speaking", "", 1, EGVAR(sys_list,LanguageColor)] call EFUNC(sys_list,displayHint);
+    ["acre_cycleLanguage", _languageName, "Now speaking", "", _hintTime, EGVAR(sys_list,LanguageColor)] call EFUNC(sys_list,displayHint);
     [] call FUNC(updateSelf);
     if (ACRE_LOCAL_SPEAKING) then {
         //@TODO: This is an uber hack, should probably be set up as a TS event.

--- a/addons/sys_core/fnc_cycleLanguage.sqf
+++ b/addons/sys_core/fnc_cycleLanguage.sqf
@@ -23,7 +23,6 @@ if (_numSpokenLanguages > 1) then {
     };
 
     // Set hint duration to infinite when you're not speaking your first language (setting dependent)
-    //systemChat format ["nextLangID: %1", _nextId];
     private _hintTime = 1;
     if (EGVAR(sys_list,LanguageHintPersistence) && {_nextId > 0}) then {
         _hintTime = -1;

--- a/addons/sys_list/initSettings.inc.sqf
+++ b/addons/sys_list/initSettings.inc.sqf
@@ -66,6 +66,15 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
     {}
 ] call CBA_fnc_addSetting;
 
+// Babel Language Hint Persistence
+[
+    QGVAR(LanguageHintPersistence),
+    "CHECKBOX",
+    [localize LSTRING(LanguageHintPersistence_DisplayName), localize LSTRING(LanguageHintPersistence_Description)],
+    ELSTRING(sys_core,CategoryUI),
+    true
+] call CBA_fnc_addSetting;
+
 // PTT1 Color
 [
     QGVAR(PTT1Color),

--- a/addons/sys_list/initSettings.inc.sqf
+++ b/addons/sys_list/initSettings.inc.sqf
@@ -70,7 +70,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
 [
     QGVAR(LanguageHintPersist),
     "CHECKBOX",
-    [localize LSTRING(LanguageHintPersistence_DisplayName), localize LSTRING(LanguageHintPersistence_Description)],
+    [localize LSTRING(LanguageHintPersist_DisplayName), localize LSTRING(LanguageHintPersist_Description)],
     ELSTRING(sys_core,CategoryUI),
     true
 ] call CBA_fnc_addSetting;

--- a/addons/sys_list/initSettings.inc.sqf
+++ b/addons/sys_list/initSettings.inc.sqf
@@ -68,7 +68,7 @@ private _fonts = ["EtelkaMonospacePro", "EtelkaMonospaceProBold", "LCD14", "Puri
 
 // Babel Language Hint Persistence
 [
-    QGVAR(LanguageHintPersistence),
+    QGVAR(LanguageHintPersist),
     "CHECKBOX",
     [localize LSTRING(LanguageHintPersistence_DisplayName), localize LSTRING(LanguageHintPersistence_Description)],
     ELSTRING(sys_core,CategoryUI),

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -102,9 +102,9 @@
             <Italian>Indicatore di lingua persistente</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_list_LanguageHintPersistence_Description">
-            <English>When enabled, the Babel Language Indicator in the bottom right will not fade out if a language other than the "main language" (the first assigned spokenLanguage) is being spoken.</English>
-            <German>Wenn eingeschaltet wird die Babel Sprachanzeige nicht verschwinden während eine andere Sprache als die "Muttersprache" (die erste zugewiesene Sprache) gesprochen wird.</German>
-            <Italian>Se attivato, l'indicatore della lingua selezionata non scomparirà mentre si parla una lingua diversa da quella "madre" (la prima lingua assegnata).</Italian>
+            <English>Prevent the Babel Language Indicator in the bottom right from fading out if a language other than the "main language" (the first assigned spoken language) is selected.</English>
+            <German>Verhindert, wenn eingeschaltet, dass die Babel Sprachanzeige unten-rechts verschwindet während eine andere Sprache als die "Muttersprache" (die erste zugewiesene Sprache) gesprochen wird.</German>
+            <Italian>Se attivato, l'indicatore della lingua selezionata in basso a destra non scomparirà mentre si parla una lingua diversa da quella "madre" (la prima lingua assegnata).</Italian>
         </Key>
         <Key ID="STR_ACRE_sys_list_SwitchChannelColor_DisplayName">
             <English>Switch Channel Color</English>

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -96,6 +96,16 @@
             <Portuguese>Cor: Alternar Idiomas do Babel</Portuguese>
             <Turkish>Babel Dil Değiştirme Rengi</Turkish>
         </Key>
+        <Key ID="STR_ACRE_sys_list_LanguageHintPersistence_DisplayName">
+            <English>Persistent Babel Language Indicator</English>
+            <German>Babel Sprachanzeige bleibt sichtbar</German>
+            <Italian>Indicatore di lingua persistente</Italian>
+        </Key>
+        <Key ID="STR_ACRE_sys_list_LanguageHintPersistence_Description">
+            <English>When enabled, the Babel Language Indicator in the bottom right will not fade out if a language other than the "main language" (the first assigned spokenLanguage) is being spoken.</English>
+            <German>Wenn eingeschaltet wird die Babel Sprachanzeige nicht verschwinden während eine andere Sprache als die "Muttersprache" (die erste zugewiesene Sprache) gesprochen wird.</German>
+            <Italian>Se attivato, l'indicatore della lingua selezionata non scomparirà mentre si parla una lingua diversa da quella "madre" (la prima lingua assegnata).</Italian>
+        </Key>
         <Key ID="STR_ACRE_sys_list_SwitchChannelColor_DisplayName">
             <English>Switch Channel Color</English>
             <German>Farbe bei Funkkanalwechsel</German>

--- a/addons/sys_list/stringtable.xml
+++ b/addons/sys_list/stringtable.xml
@@ -96,12 +96,12 @@
             <Portuguese>Cor: Alternar Idiomas do Babel</Portuguese>
             <Turkish>Babel Dil Değiştirme Rengi</Turkish>
         </Key>
-        <Key ID="STR_ACRE_sys_list_LanguageHintPersistence_DisplayName">
-            <English>Persistent Babel Language Indicator</English>
+        <Key ID="STR_ACRE_sys_list_LanguageHintPersist_DisplayName">
+            <English>Persist Babel Language Indicator</English>
             <German>Babel Sprachanzeige bleibt sichtbar</German>
             <Italian>Indicatore di lingua persistente</Italian>
         </Key>
-        <Key ID="STR_ACRE_sys_list_LanguageHintPersistence_Description">
+        <Key ID="STR_ACRE_sys_list_LanguageHintPersist_Description">
             <English>Prevent the Babel Language Indicator in the bottom right from fading out if a language other than the "main language" (the first assigned spoken language) is selected.</English>
             <German>Verhindert, wenn eingeschaltet, dass die Babel Sprachanzeige unten-rechts verschwindet während eine andere Sprache als die "Muttersprache" (die erste zugewiesene Sprache) gesprochen wird.</German>
             <Italian>Se attivato, l'indicatore della lingua selezionata in basso a destra non scomparirà mentre si parla una lingua diversa da quella "madre" (la prima lingua assegnata).</Italian>


### PR DESCRIPTION
**When merged this pull request will:**
- Add a setting under `ACRE2 UI` that allows for a persistent language hint (it doesn't fade out) whenever a language other than the "main language" (the first assigned) is selected.