### PR TITLE
PRC152 - Previous/Next Channel Stepping via PRE+/- instead of Knob

### DIFF
--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -35,7 +35,20 @@ if (_isManpack == 0 || {_isRackRadio}) then {
             _channel = ((_channel + _dir) max (_currentBlock*16 + 1)) min ((_currentBlock + 1)*16);
         };
         case "ACRE_PRC152": {
-            _channel = (_channel + _dir) min 5;
+            if (_dir == 1) then {
+                if (_channel < 99) then {
+                    _channel = _channel + 1;
+                } else {
+                    _channel = 0;
+                };
+            } else {
+                if (_channel > 1) then {
+                    _channel = _channel - 1;
+                } else {
+                    // Go to the last preset
+                    _channel = 99;
+                };
+            };
         };
         default {
             _channel = _channel + _dir;

--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -35,20 +35,7 @@ if (_isManpack == 0 || {_isRackRadio}) then {
             _channel = ((_channel + _dir) max (_currentBlock*16 + 1)) min ((_currentBlock + 1)*16);
         };
         case "ACRE_PRC152": {
-            if (_dir == 1) then {
-                if (_channel < 99) then {
-                    _channel = _channel + 1;
-                } else {
-                    _channel = 0;
-                };
-            } else {
-                if (_channel > 1) then {
-                    _channel = _channel - 1;
-                } else {
-                    // Go to the last preset
-                    _channel = 99;
-                };
-            };
+            _channel = (_channel + _dir + 98) % 99 + 1;
         };
         default {
             _channel = _channel + _dir;


### PR DESCRIPTION
**When merged this pull request will:**
- Modify the Previous/Next Channel Keybind logic for the PRC-152, to simulate manipulation of the PRE+/- buttons instead of turning of the knob.
This allows stepping beyond channel 5, which I previously found pretty limiting in many situations. Realistically IMO, one could and would use the buttons blindly without having to stop and pull out the radio.