### PR TITLE
GUI - Allow Volume Control during ACE Progressbar Dialog

### DIFF
--- a/addons/sys_gui/fnc_volumeKeyDown.sqf
+++ b/addons/sys_gui/fnc_volumeKeyDown.sqf
@@ -20,11 +20,8 @@ if (!alive acre_player || ACRE_IS_SPECTATOR || GVAR(volumeOpen)) exitWith {false
 // Abort on open Dialogs that aren't an ACE Progressbar
 private _aceProgressBar = displayNull;
 if (
-    dialog && 
-    {
-        !EGVAR(sys_core,aceLoaded) || 
-        {_aceProgressBar = (uiNamespace getVariable ["ace_common_dlgProgress", displayNull]); _aceProgressBar isEqualTo displayNull}
-    }
+    (dialog && !EGVAR(sys_core,aceLoaded)) || 
+    {_aceProgressBar = (uiNamespace getVariable ["ace_common_dlgProgress", displayNull]); _aceProgressBar isEqualTo displayNull}
 ) exitWith {false};
 
 // Add MouseScroll EH to open ACE Progressbar, for volume control

--- a/addons/sys_gui/fnc_volumeKeyDown.sqf
+++ b/addons/sys_gui/fnc_volumeKeyDown.sqf
@@ -15,7 +15,23 @@
  * Public: No
  */
 
-if (!alive acre_player || dialog || ACRE_IS_SPECTATOR || GVAR(volumeOpen)) exitWith {false};
+if (!alive acre_player || ACRE_IS_SPECTATOR || GVAR(volumeOpen)) exitWith {false};
+
+// Abort on open Dialogs that aren't an ACE Progressbar
+private _aceProgressBar = displayNull;
+if (
+    dialog && 
+    {
+        !EGVAR(sys_core,aceLoaded) || 
+        {_aceProgressBar = (uiNamespace getVariable ["ace_common_dlgProgress", displayNull]); _aceProgressBar isEqualTo displayNull}
+    }
+) exitWith {false};
+
+// Add MouseScroll EH to open ACE Progressbar, for volume control
+if (dialog && {!(_aceProgressBar getVariable [QGVAR(mouseScrollEHAdded), false])}) then {
+    _aceProgressBar displayAddEventHandler ["MouseZChanged", LINKFUNC(onMouseZChanged)];
+    _aceProgressBar setVariable [QGVAR(mouseScrollEHAdded), true];
+};
 
 inGameUISetEventHandler ["PrevAction", "true"];
 inGameUISetEventHandler ["NextAction", "true"];


### PR DESCRIPTION
**When merged this pull request will:**
- Dynamically add the `"MouseZChanged"` `displayEventHandler` to an opened ACE Progressbar, to allow Volume Control while performing an Interaction.

This is the simplest way I figured out to implement this.
I guess a cleaner and slightly more efficient implementation would be an XEH that fires upon creation of the progressbar dialog, but that appears to require implementing it into ACE first.