### PR TITLE
CI - Fix HEMTT CI artifacts not uploaded

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@main
+      uses: arma-actions/hemtt@v1
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder

--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -50,3 +50,4 @@ jobs:
       with:
         name: acre2-${{ github.sha }}-nobin
         path: .hemttout/@*
+        include-hidden-files: true # Because .hemttout is a hidden directory

--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@v1
+      uses: arma-actions/hemtt@main
     - name: Run HEMTT build
       run: hemtt build
     - name: Rename build folder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@main
+      uses: arma-actions/hemtt@v1
     - name: Setup Binarize
       run: |
         C:\msys64\usr\bin\wget.exe ${{ secrets.FTP_SERVER }}/tools/acre2_tools.zip --user ${{ secrets.FTP_USERNAME }} --password ${{ secrets.FTP_PASSWORD }} -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
     - name: Setup HEMTT
-      uses: arma-actions/hemtt@v1
+      uses: arma-actions/hemtt@main
     - name: Setup Binarize
       run: |
         C:\msys64\usr\bin\wget.exe ${{ secrets.FTP_SERVER }}/tools/acre2_tools.zip --user ${{ secrets.FTP_USERNAME }} --password ${{ secrets.FTP_PASSWORD }} -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
         name: acre2
         path: .hemttout/@*
         retention-days: 1
+        include-hidden-files: true # Because .hemttout is a hidden directory
 
   compile:
     if: github.repository == 'IDI-Systems/acre2' && ! contains(github.event.head_commit.message, '[ci skip]')


### PR DESCRIPTION
**When merged this pull request will:**
- ~~Fix HEMTT CI annotations not shown since HEMTT v1.11. This was fixed by arma-actions/hemtt#2.~~ Edit: Tag was updated.
- Fix HEMTT artifacts not uploaded. `actions/upload-artifact` v4.4 changed the behavior of hidden files. They're now excluded by default [[Source]](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes).
