### PR TITLE
PRC117F/PRC152 - Fix undefined macro

### DIFF
--- a/.hemtt/lints.toml
+++ b/.hemtt/lints.toml
@@ -2,3 +2,8 @@
 options.ignore = [
     "addPublicVariableEventHandler", # Alt syntax is broken, we are using main syntax
 ]
+
+[sqf.var_all_caps]
+options.ignore = [
+    "ACRE_*"
+]

--- a/addons/sys_prc117f/script_component.hpp
+++ b/addons/sys_prc117f/script_component.hpp
@@ -20,6 +20,8 @@
 #define CHANNEL_NAME_MAX_LENGTH 12
 #define CHANNEL_PADDING_STRING "            " // Should be same length as CHANNEL_NAME_MAX_LENGTH
 
+#define MAIN_DISPLAY (findDisplay 31337)
+
 #include "\idi\acre\addons\sys_prc117f\menus\script_menus.hpp"
 
 #include "\idi\acre\addons\sys_components\script_acre_component_defines.hpp"

--- a/addons/sys_prc152/script_component.hpp
+++ b/addons/sys_prc152/script_component.hpp
@@ -20,6 +20,8 @@
 #define CHANNEL_NAME_MAX_LENGTH 12
 #define CHANNEL_PADDING_STRING "            " // Should be same length as CHANNEL_NAME_MAX_LENGTH
 
+#define MAIN_DISPLAY (findDisplay 31337)
+
 #include "\idi\acre\addons\sys_prc152\menus\script_menus.hpp"
 
 #include "\idi\acre\addons\sys_components\script_acre_component_defines.hpp"


### PR DESCRIPTION
this fixes being able to use other cba keybinds while the radio ui is open