### PR TITLE
Attenuation - Fix missing `MrapAttenuation` Sound Effect

### DIFF
--- a/addons/sys_attenuate/CfgSoundEffects.hpp
+++ b/addons/sys_attenuate/CfgSoundEffects.hpp
@@ -24,6 +24,10 @@ class CfgSoundEffects {
             acreAttenuation = 0;
             acreAttenuationTurnedOut = 0;
         };
+        class MrapAttenuation {
+            acreAttenuation = 0.5;
+            acreAttenuationTurnedOut = 0.25;
+        };
         class TankAttenuation {
             acreAttenuation = 0.6;
             acreAttenuationTurnedOut = 0.3;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix MRAPs counting as open vehicles by adding car-like attenuation to `MrapAttenuation`.

This sound effect entry was previously unsupported, I'm guessing it was added to the game some time in the past and ACRE wasn't updated to use it.