### PR TITLE
Core - Fix Fast Channel Switch of VRC-64

### DIFF
--- a/addons/api/fnc_getRadioChannel.sqf
+++ b/addons/api/fnc_getRadioChannel.sqf
@@ -24,4 +24,9 @@ if !(_radioId isEqualType "") exitWith { -1 };
 private _channelNumber = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
 
 if (isNil "_channelNumber") exitWith { -1 };
+
+private _radioType = [_radioId] call EFUNC(sys_radio,getRadioBaseClassname);
+
+if (_radioType == "ACRE_PRC77") exitWith { _channelNumber };
+
 _channelNumber + 1

--- a/addons/api/fnc_setRadioChannel.sqf
+++ b/addons/api/fnc_setRadioChannel.sqf
@@ -24,10 +24,10 @@ params [
 if !(_radioId isEqualType "") exitWith { false };
 
 if (_channelNumber isEqualType 0) then {
-    private _eventData = if (([_radioId] call FUNC(getBaseRadio)) == "ACRE_PRC77") then {
+    private _eventData = _channelNumber - 1;
+    if (([_radioId] call FUNC(getBaseRadio)) == "ACRE_PRC77") then {
         [_channelNumber, 0] // ACRE_PRC77 expects an array of [mhzKnob, khzKnob]
-    } else {
-        _channelNumber - 1
+    }
     };
     [_radioId, "setCurrentChannel", _eventData] call EFUNC(sys_data,dataEvent);
 } else {

--- a/addons/api/fnc_setRadioChannel.sqf
+++ b/addons/api/fnc_setRadioChannel.sqf
@@ -24,9 +24,10 @@ params [
 if !(_radioId isEqualType "") exitWith { false };
 
 if (_channelNumber isEqualType 0) then {
-    private _eventData = _channelNumber - 1;
-    if (([_radioId] call FUNC(getBaseRadio)) == "ACRE_PRC77") then {
-        _eventData = [_eventData, 0]; // ACRE_PRC77 expects an array of [mhzKnob, khzKnob]
+    private _eventData = if (([_radioId] call FUNC(getBaseRadio)) == "ACRE_PRC77") then {
+        [_channelNumber, 0] // ACRE_PRC77 expects an array of [mhzKnob, khzKnob]
+    } else {
+        _channelNumber - 1
     };
     [_radioId, "setCurrentChannel", _eventData] call EFUNC(sys_data,dataEvent);
 } else {

--- a/addons/api/fnc_setRadioChannel.sqf
+++ b/addons/api/fnc_setRadioChannel.sqf
@@ -26,8 +26,7 @@ if !(_radioId isEqualType "") exitWith { false };
 if (_channelNumber isEqualType 0) then {
     private _eventData = _channelNumber - 1;
     if (([_radioId] call FUNC(getBaseRadio)) == "ACRE_PRC77") then {
-        [_channelNumber, 0] // ACRE_PRC77 expects an array of [mhzKnob, khzKnob]
-    }
+        _eventData = [_channelNumber, 0] // ACRE_PRC77 expects an array of [mhzKnob, khzKnob]
     };
     [_radioId, "setCurrentChannel", _eventData] call EFUNC(sys_data,dataEvent);
 } else {

--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -37,6 +37,15 @@ if (_isManpack == 0 || {_isRackRadio}) then {
         case "ACRE_PRC152": {
             _channel = (_channel + _dir) min 5;
         };
+        case "ACRE_PRC77": {
+            _channel = (_channel select 0) + _dir;
+            if (_channel > 22) then {
+                _channel = 0;
+            };
+            if (_channel < 0) then {
+                _channel = 22;
+            };
+        };
         default {
             _channel = _channel + _dir;
         };

--- a/addons/sys_prc77/radio/fnc_getCurrentChannel.sqf
+++ b/addons/sys_prc77/radio/fnc_getCurrentChannel.sqf
@@ -23,6 +23,4 @@ TRACE_1("GET CURRENT CHANNEL",_this);
 
 params ["", "", "", "_radioData", ""];
 
-private _return = 0;
-
-_return
+HASH_GET(_radioData,"currentChannel")


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the fast channel switch keybind for rack mounted PRC-77s. Now it will have the same behaviour as turning the MHz knob in the UI, when stepping below/above the range, it will jump to the last/first valid frequency respectively.

Previously, due to `sys_prc77/radio/fnc_getCurrentChannel.sqf` always returning channel index `0`, the fast channel switch keybind would only switch between channels of index `-1` (breaks the radio UI) and `+1` (31MHz).