### PR TITLE
General - Optimize in-vehicle checks

### DIFF
--- a/.hemtt/lints.toml
+++ b/.hemtt/lints.toml
@@ -1,3 +1,6 @@
+[config.file_type]
+enabled = false
+
 [sqf.banned_commands]
 options.ignore = [
     "addPublicVariableEventHandler", # Alt syntax is broken, we are using main syntax

--- a/addons/sys_components/fnc_getAntennaDirMan.sqf
+++ b/addons/sys_components/fnc_getAntennaDirMan.sqf
@@ -19,7 +19,7 @@ private ["_forwardV", "_upV"];
 params ["_obj"];
 
 // This is a hack fix for vehicles having funky up vectors when people are inside...
-if (vehicle _obj == _obj) then {
+if (isNull objectParent _obj) then {
     // These vectors are in model space (it is assumed these will never be parallel)
     private _spineMV = (_obj selectionPosition "Spine3") vectorFromTo (_obj selectionPosition "Neck");
     private _shoulderMV = (_obj selectionPosition "leftshoulder") vectorFromTo (_obj selectionPosition "rightshoulder");

--- a/addons/sys_core/fnc_hasAccessToVehicleSystem.sqf
+++ b/addons/sys_core/fnc_hasAccessToVehicleSystem.sqf
@@ -25,7 +25,7 @@ private _systemAvailable = false;
 if (!alive _vehicle) exitWith {_systemAvailable};
 
 // Check external systems
-if ((vehicle _unit == _unit) && {"external" in _allowedPositions}) exitWith {
+if ((isNull objectParent _unit) && {"external" in _allowedPositions}) exitWith {
     if (_vehicle distance _unit <= _maxDistance) then {
         _systemAvailable = true
     };

--- a/addons/sys_core/fnc_switchChannelFast.sqf
+++ b/addons/sys_core/fnc_switchChannelFast.sqf
@@ -23,7 +23,7 @@ private _radioId = ACRE_ACTIVE_RADIO;
 private _radioType = [_radioId] call EFUNC(sys_radio,getRadioBaseClassname);
 private _typeName = getText (configFile >> "CfgAcreComponents" >> _radioType >> "name");
 private _isManpack = getNumber (configFile >> "CfgAcreComponents" >> _radioType >> "isPackRadio");
-private _isRackRadio = (vehicle acre_player != acre_player) && {_radioId in (([vehicle acre_player] call EFUNC(api,getVehicleRacks)) apply {[_x] call EFUNC(api,getMountedRackRadio)})} && {[_radioId, acre_player] call EFUNC(sys_rack,isRadioAccessible)};
+private _isRackRadio = (!isNull objectParent acre_player) && {_radioId in (([vehicle acre_player] call EFUNC(api,getVehicleRacks)) apply {[_x] call EFUNC(api,getMountedRackRadio)})} && {[_radioId, acre_player] call EFUNC(sys_rack,isRadioAccessible)};
 
 if (_isManpack == 0 || {_isRackRadio}) then {
     private _channel = [_radioId] call EFUNC(api,getRadioChannel);

--- a/addons/sys_external/fnc_isExternalRadioAvailable.sqf
+++ b/addons/sys_external/fnc_isExternalRadioAvailable.sqf
@@ -29,4 +29,4 @@ if (((_owner distance acre_player) > EXTERNAL_RADIO_MAXDISTANCE) && {vehicle _ow
 if (captive acre_player) exitWith {false};
 
 // Check if actual owner of the radio and the player are on the same vehicle.
-!((vehicle _owner != _owner) && {vehicle acre_player != acre_player} && {vehicle _owner != vehicle acre_player})
+!((!isNull objectParent _owner) && {!isNull objectParent acre_player} && {vehicle _owner != vehicle acre_player})

--- a/addons/sys_external/fnc_radioCheckChildrenActions.sqf
+++ b/addons/sys_external/fnc_radioCheckChildrenActions.sqf
@@ -19,4 +19,4 @@ params ["_radioId"];
 
 if (_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS) exitWith {false};
 
-vehicle acre_player == acre_player
+isNull objectParent acre_player

--- a/addons/sys_intercom/fnc_updateVehicleInfoText.sqf
+++ b/addons/sys_intercom/fnc_updateVehicleInfoText.sqf
@@ -22,7 +22,7 @@ params ["_vehicle", "_unit"];
 #define WHITE "#ffffff"
 #define GREEN "#008000"
 
-if (vehicle _unit == _unit) exitWith {
+if (isNull objectParent _unit) exitWith {
     [false] call EFUNC(sys_gui,showVehicleInfo); // Hide
 };
 

--- a/addons/sys_prc117f/radio/fnc_setState.sqf
+++ b/addons/sys_prc117f/radio/fnc_setState.sqf
@@ -18,4 +18,4 @@
 
 params ["", "", "_eventData", ""];
 
-HASH_SET(_radioData,_eventData select 0,_eventData select 1);
+HASH_SET(_radioData,_eventData select 0,_eventData select 1); //IGNORE_PRIVATE_WARNING ["_radioData"]

--- a/addons/sys_rack/XEH_postInit.sqf
+++ b/addons/sys_rack/XEH_postInit.sqf
@@ -9,7 +9,7 @@ if (!hasInterface) exitWith {};
 
 // Handle the case of starting inside a vehicle. addPlayerEventhandler retrospectively would not work
 // when initialising the racks since we have to execute it once radios are being initialised
-if (vehicle acre_player != acre_player) then {
+if (!isNull objectParent acre_player) then {
     [FUNC(enterVehicle), [vehicle acre_player, acre_player]] call CBA_fnc_execNextFrame; // Make sure vehicle info UI is created
 };
 

--- a/addons/sys_rack/fnc_isRackAccessible.sqf
+++ b/addons/sys_rack/fnc_isRackAccessible.sqf
@@ -19,7 +19,7 @@
 
 params ["_rackId", "_unit", ["_vehicle", objNull]];
 
-if (isNull _vehicle || {vehicle _unit == _unit}) then {
+if (isNull _vehicle || {isNull objectParent _unit}) then {
     _vehicle = [_rackId] call FUNC(getVehicleFromRack);
 };
 

--- a/addons/sys_rack/fnc_isRackHearable.sqf
+++ b/addons/sys_rack/fnc_isRackHearable.sqf
@@ -26,7 +26,7 @@ if (isNull _vehicle) then {
 if (!alive _vehicle) exitWith {false};
 
 // Infantry phone units are not allowed
-if (_unit == vehicle _unit) exitWith {false};
+if (isNull objectParent _unit) exitWith {false};
 
 private _wiredIntercoms = [_rackId] call FUNC(getWiredIntercoms);
 

--- a/addons/sys_rack/fnc_rackPFH.sqf
+++ b/addons/sys_rack/fnc_rackPFH.sqf
@@ -22,7 +22,7 @@ params ["_param", ""];
 _param params ["_player", "_vehicle"];
 
 // Check if the player entered a position with a rack already active in intercom
-if (_player != vehicle _player) then {
+if (!isNull objectParent _player) then {
     {
         private _radioId = [_x] call FUNC(getMountedRadio);
         if (_radioId != "" && {!(_radioId in ACRE_HEARABLE_RACK_RADIOS || {_radioId in ACRE_ACCESSIBLE_RACK_RADIOS})}) then {
@@ -82,7 +82,7 @@ if (_remove isNotEqualTo []) then {
     [_vehicle, _player] call EFUNC(sys_intercom,updateVehicleInfoText);
 };
 
-if ((_player == vehicle _player) && {ACRE_ACCESSIBLE_RACK_RADIOS isEqualTo []} && {ACRE_HEARABLE_RACK_RADIOS isEqualTo []}) then {
+if ((isNull objectParent _player) && {ACRE_ACCESSIBLE_RACK_RADIOS isEqualTo []} && {ACRE_HEARABLE_RACK_RADIOS isEqualTo []}) then {
     [GVAR(rackPFH)] call CBA_fnc_removePerFrameHandler;
     TRACE_1("del rack PFH",GVAR(rackPFH));
     GVAR(rackPFH) = -1;

--- a/addons/sys_spectator/fnc_handleStartedSpeaking.sqf
+++ b/addons/sys_spectator/fnc_handleStartedSpeaking.sqf
@@ -18,7 +18,7 @@
  */
 
 params ["_unit", "_speakingType", "_radioId"];
-_thisArgs params ["_display"];
+_thisArgs params ["_display"]; //IGNORE_PRIVATE_WARNING ["_thisArgs"]
 
 // Only need to handle radios
 if (_speakingType != SPEAKING_TYPE_RADIO) exitWith {};

--- a/addons/sys_spectator/fnc_handleStoppedSpeaking.sqf
+++ b/addons/sys_spectator/fnc_handleStoppedSpeaking.sqf
@@ -16,7 +16,7 @@
  */
 
 params ["_unit"];
-_thisArgs params ["_display"];
+_thisArgs params ["_display"]; //IGNORE_PRIVATE_WARNING ["_thisArgs"]
 
 private _speakers = _display getVariable QGVAR(speakers);
 


### PR DESCRIPTION
tiny bit faster using `objectParent`
skip `config.file_type` lint as it doesn't like `sound = x.b64`