### PR TITLE
Core - Fix GSA rope helper objects being placed below buildings

### DIFF
--- a/addons/sys_core/fnc_handleConnectorRope.sqf
+++ b/addons/sys_core/fnc_handleConnectorRope.sqf
@@ -50,7 +50,7 @@ if (_state) then {
             _connectorRope = ropeCreate [_fromObject, _fromPoint, 3, nil, nil, QGVAR(connectorWire)];
 
             // Create helper object on player pelvis
-            _connectorRopeHelpers set [0, ROPE_HELPER createVehicle position _toObject];
+            _connectorRopeHelpers set [0, ROPE_HELPER createVehicle (getPosATL _toObject)];
             (_connectorRopeHelpers select 0) ropeAttachTo _connectorRope;
             (_connectorRopeHelpers select 0) attachTo [_toObject, [-0.1, 0.1, 0.25], "Pelvis"];
             (_connectorRopeHelpers select 0) allowDamage false;
@@ -60,13 +60,13 @@ if (_state) then {
         };
         case 1: { // Connect rope to Ground Spike Antenna
             // Create helper object on GSA
-            _connectorRopeHelpers set [0, ROPE_HELPER createVehicle position _fromObject];
+            _connectorRopeHelpers set [0, ROPE_HELPER createVehicle (getPosATL _fromObject)];
             (_connectorRopeHelpers select 0) disableCollisionWith _fromObject;
-            (_connectorRopeHelpers select 0) setPos (position _fromObject);
+            (_connectorRopeHelpers select 0) setPosATL (getPosATL _fromObject);
             (_connectorRopeHelpers select 0) allowDamage false;
 
             // Create helper object on player pelvis
-            _connectorRopeHelpers set [1, ROPE_HELPER createVehicle position _toObject];
+            _connectorRopeHelpers set [1, ROPE_HELPER createVehicle (getPosATL _toObject)];
             (_connectorRopeHelpers select 1) attachTo [_toObject, [-0.1, 0.1, 0.15], "Pelvis"];
             (_connectorRopeHelpers select 1) allowDamage false;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes connector-rope helper objects being placed below the building the GSA was placed on, at terrain-level.
The helper object's position was being set with [`setPos`](https://community.bistudio.com/wiki/setPos), on the [`position`](https://community.bistudio.com/wiki/position) of the GSA. The use case of placing something on top of a surface with it is in fact advised against.