### PR TITLE
Core - Use `fnc_getDescriptiveName` for all ACE Action Names

### DIFF
--- a/addons/ace_interact/stringtable.xml
+++ b/addons/ace_interact/stringtable.xml
@@ -38,6 +38,11 @@
             <German>%1 Bk %2 Kn %3</German>
             <Italian>%1 Bc %2 Cn %3</Italian>
         </Key>
+        <Key ID="STR_ACRE_ace_interact_channelNetIDShort">
+            <English>Chn %1 NetID %2</English>
+            <German>SP %1 FK-Nr %2</German>
+            <Italian>Cn %1 Rete %2</Italian>
+        </Key>
         <Key ID="STR_ACRE_ace_interact_lowerHeadset">
             <English>Lower Headset</English>
             <Spanish>Bajar auriculares</Spanish>

--- a/addons/ace_interact/stringtable.xml
+++ b/addons/ace_interact/stringtable.xml
@@ -33,6 +33,11 @@
             <Portuguese>%1 Cnl: %2</Portuguese>
             <Turkish>%1 Kanal:%2</Turkish>
         </Key>
+        <Key ID="STR_ACRE_ace_interact_channelBlockShort">
+            <English>%1 Bk %2 Ch %3</English>
+            <German>%1 Bk %2 Kn %3</German>
+            <Italian>%1 Bc %2 Cn %3</Italian>
+        </Key>
         <Key ID="STR_ACRE_ace_interact_lowerHeadset">
             <English>Lower Headset</English>
             <Spanish>Bajar auriculares</Spanish>

--- a/addons/ace_interact/stringtable.xml
+++ b/addons/ace_interact/stringtable.xml
@@ -23,7 +23,7 @@
             <German>%1 Kanal: %2</German>
             <Japanese>%1 チャンネル: %2</Japanese>
             <Czech>%1 Chn: %2</Czech>
-            <Italian>%1 Chn: %2</Italian>
+            <Italian>%1 Canale: %2</Italian>
             <French>%1 Canal: %2</French>
             <Korean>%1 채널: %2</Korean>
             <Polish>%1 Kanał: %2</Polish>

--- a/addons/sys_core/fnc_getDescriptiveName.sqf
+++ b/addons/sys_core/fnc_getDescriptiveName.sqf
@@ -38,15 +38,24 @@ private _name = if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS || {_radioId in ACRE
 };
 
 // Display current radio channel
-private _maxChannels = [_radioId, "getState", "channels"] call EFUNC(sys_data,dataEvent);
+private _radioClass = [_radioId] call EFUNC(sys_radio,getRadioBaseClassname);
 
-private _text = if (isNil "_maxChannels") then {
-    // Display frequency for single-channel radios (e.g. AN/PRC-77)
-    private _txData = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
-    private _currentFreq = HASH_GET(_txData,"frequencyTX");
-    format ["%1 %2 MHz", _name, _currentFreq];
-} else {
-    format [LELSTRING(ace_interact,channelShort), _name, _radioId call EFUNC(api,getRadioChannel)]
+private _text = switch (_radioClass) do {
+    case "ACRE_PRC77": {
+        // Display frequency for single-channel radios (e.g. AN/PRC-77)
+        private _txData = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
+        private _currentFreq = HASH_GET(_txData,"frequencyTX");
+        format ["%1 %2 MHz", _name, _currentFreq]
+    };
+    case "ACRE_PRC343": {
+        private _channelRaw = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
+        private _block = floor (_channelRaw / 16) + 1;
+        private _channel = (_channelRaw % 16) + 1;
+        format [LELSTRING(ace_interact,channelBlockShort), _name, _block, _channel]
+    };
+    default {
+        format [LELSTRING(ace_interact,channelShort), _name, _radioId call EFUNC(api,getRadioChannel)]
+    };
 };
 
 // Display radio keys in front of those which are bound

--- a/addons/sys_core/fnc_getDescriptiveName.sqf
+++ b/addons/sys_core/fnc_getDescriptiveName.sqf
@@ -70,7 +70,7 @@ private _text = switch (_radioClass) do {
         } else {
             // AKW (Automatic Channel) Mode
             private _channelNumber = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
-            format ["Chn %1 NetID %2", (_channelNumber), HASH_GET(_hashData,"networkID")]
+            format [LELSTRING(ace_interact,channelNetIDShort), (_channelNumber), HASH_GET(_hashData,"networkID")]
         };
         format ["%1 %2", _name, _description]
     };

--- a/addons/sys_core/fnc_getDescriptiveName.sqf
+++ b/addons/sys_core/fnc_getDescriptiveName.sqf
@@ -24,8 +24,8 @@ _radioId = toLower _radioId;
 // Get the radio's name
 private _name = if (_radioId in ACRE_ACCESSIBLE_RACK_RADIOS || {_radioId in ACRE_HEARABLE_RACK_RADIOS}) then {
     private _radioRack = [_radioId] call EFUNC(sys_rack,getRackFromRadio);
-    private _radioClass = [_radioRack] call EFUNC(sys_rack,getRackBaseClassname);
-    getText (configFile >> "CfgAcreComponents" >> _radioClass >> "name")
+    private _rackClass = [_radioRack] call EFUNC(sys_rack,getRackBaseClassname);
+    getText (configFile >> "CfgAcreComponents" >> _rackClass >> "name")
 } else {
     // Include the owner's name for external radios
     private _owner = if (_radioId in ACRE_ACTIVE_EXTERNAL_RADIOS) then {

--- a/addons/sys_core/fnc_getDescriptiveName.sqf
+++ b/addons/sys_core/fnc_getDescriptiveName.sqf
@@ -45,7 +45,7 @@ private _text = switch (_radioClass) do {
         // Display frequency for single-channel radios (e.g. AN/PRC-77)
         private _txData = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
         private _currentFreq = HASH_GET(_txData,"frequencyTX");
-        format ["%1 %2 MHz", _name, _currentFreq]
+        format ["%1 %2 MHz", _name, [_currentFreq, 1, 2] call CBA_fnc_formatNumber]
     };
     case "ACRE_PRC343": {
         private _channelRaw = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_core/fnc_getDescriptiveName.sqf
+++ b/addons/sys_core/fnc_getDescriptiveName.sqf
@@ -53,6 +53,15 @@ private _text = switch (_radioClass) do {
         private _channel = (_channelRaw % 16) + 1;
         format [LELSTRING(ace_interact,channelBlockShort), _name, _block, _channel]
     };
+    case "ACRE_SEM52SL": {
+        private _channel = _radioId call EFUNC(api,getRadioChannel);
+        _channel = switch (_channel) do {
+            case 13: { "H" };
+            case 14: { "P" };
+            default { _channel };
+        };
+        format [LELSTRING(ace_interact,channelShort), _name, _channel]
+    };
     default {
         format [LELSTRING(ace_interact,channelShort), _name, _radioId call EFUNC(api,getRadioChannel)]
     };

--- a/addons/sys_core/fnc_getDescriptiveName.sqf
+++ b/addons/sys_core/fnc_getDescriptiveName.sqf
@@ -62,6 +62,18 @@ private _text = switch (_radioClass) do {
         };
         format [LELSTRING(ace_interact,channelShort), _name, _channel]
     };
+    case "ACRE_SEM70": {
+        private _hashData = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
+        private _description = if (HASH_GET(_hashData,"mode") == "singleChannel") then {
+            // HW (Manual Channel) Mode
+            format ["%1 MHz", [HASH_GET(_hashData,"frequencyTX"), 1, 3] call CBA_fnc_formatNumber]
+        } else {
+            // AKW (Automatic Channel) Mode
+            private _channelNumber = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
+            format ["Chn %1 NetID %2", (_channelNumber), HASH_GET(_hashData,"networkID")]
+        };
+        format ["%1 %2", _name, _description]
+    };
     default {
         format [LELSTRING(ace_interact,channelShort), _name, _radioId call EFUNC(api,getRadioChannel)]
     };

--- a/addons/sys_external/fnc_listChildrenActions.sqf
+++ b/addons/sys_external/fnc_listChildrenActions.sqf
@@ -43,9 +43,7 @@ private _ownSharedRadios = [acre_player] call FUNC(getSharedExternalRadios);
 
     private _baseRadio = [_x] call EFUNC(api,getBaseRadio);
     private _item = configFile >> "CfgWeapons" >> _baseRadio;
-    private _displayName = getText (_item >> "displayName") + _owner;
-    private _currentChannel = [_x] call EFUNC(api,getRadioChannel);
-    _displayName = format [localize ELSTRING(ace_interact,channelShort), _displayName, _currentChannel];
+    private _displayName = [_x] call EFUNC(sys_core,getDescriptiveName);
     private _picture = getText (_item >> "picture");
 
     if ([_x, acre_player] call FUNC(checkListChildrenActions)) then {

--- a/addons/sys_gsa/fnc_connectChildrenActions.sqf
+++ b/addons/sys_gsa/fnc_connectChildrenActions.sqf
@@ -31,17 +31,7 @@ private _actions = [];
     private _baseRadio = [_x] call EFUNC(api,getBaseRadio);
     private _item = configFile >> "CfgWeapons" >> _baseRadio;
 
-    private "_displayName";
-    if (_x in ACRE_ACCESSIBLE_RACK_RADIOS || {_x in ACRE_HEARABLE_RACK_RADIOS}) then {
-        private _radioRack = [_x] call EFUNC(sys_rack,getRackFromRadio);
-        private _radioClass = [_radioRack] call EFUNC(sys_rack,getRackBaseClassname);
-        _displayName = getText (configFile >> "CfgAcreComponents" >> _radioClass >> "name");
-    } else {
-        _displayName = format ["%1%2", getText (_item >> "displayName"), _owner];
-    };
-
-    private _currentChannel = [_x] call EFUNC(api,getRadioChannel);
-    _displayName = format [localize ELSTRING(ace_interact,channelShort), _displayName, _currentChannel];
+    private _displayName = [_x] call EFUNC(sys_core,getDescriptiveName);
     private _picture = getText (_item >> "picture");
 
     private _action = [

--- a/addons/sys_prc77/radio/fnc_getChannelDescription.sqf
+++ b/addons/sys_prc77/radio/fnc_getChannelDescription.sqf
@@ -11,7 +11,7 @@
  * 4: Remote <BOOL> (Unused)
  *
  * Return Value:
- * Description of the channel in the form "Block x - Channel y" <STRING>
+ * Description of the channel in the form "Frequency: x.y MHz" <STRING>
  *
  * Example:
  * ["ACRE_PRC77_ID_1", "getChannelDescription", [], [], false] call acre_sys_prc77_fnc_getChannelDescription

--- a/addons/sys_prc77/radio/fnc_getChannelDescription.sqf
+++ b/addons/sys_prc77/radio/fnc_getChannelDescription.sqf
@@ -23,6 +23,6 @@ params ["_radioId", "",  "", "", ""];
 
 private _hashData = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
 
-private _description = format["Frequency: %1 MHz", HASH_GET(_hashData,"frequencyTX")];
+private _description = format["Frequency: %1 MHz", [HASH_GET(_hashData,"frequencyTX"), 1, 2] call CBA_fnc_formatNumber];
 
 _description

--- a/addons/sys_rack/fnc_generateMountableRadioActions.sqf
+++ b/addons/sys_rack/fnc_generateMountableRadioActions.sqf
@@ -28,9 +28,8 @@ _radioList = [_rackClassName, _radioList] call FUNC(getMountableRadios);
 {
     private _baseRadio = [_x] call EFUNC(api,getBaseRadio);
     private _item = configFile >> "CfgWeapons" >> _baseRadio;
-    private _displayName = getText (_item >> "displayName");
+    private _displayName = [_x] call EFUNC(sys_core,getDescriptiveName);
     private _currentChannel = [_x] call EFUNC(api,getRadioChannel);
-    _displayName = format [localize ELSTRING(ace_interact,channelShort), _displayName, _currentChannel];
     private _picture = getText (_item >> "picture");
     //private _isActive = _x isEqualTo _currentRadio;
 

--- a/addons/sys_sem52sl/radio/fnc_getChannelDescription.sqf
+++ b/addons/sys_sem52sl/radio/fnc_getChannelDescription.sqf
@@ -40,7 +40,11 @@
 
 params ["_radioId", "", "", ""];
 
-private _channelNumber = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
-private _description = format ["Channel %1", ([(_channelNumber+1), 2] call CBA_fnc_formatNumber)];
+private _channelNumber = ([_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent)) + 1;
+private _description = switch (_channelNumber) do {
+    case 13: { "Channel H" };
+    case 14: { "Channel P" };
+    default { format ["Channel %1", ([_channelNumber, 2] call CBA_fnc_formatNumber)] };
+};
 
 _description

--- a/addons/sys_sem70/radio/fnc_getChannelDescription.sqf
+++ b/addons/sys_sem70/radio/fnc_getChannelDescription.sqf
@@ -48,7 +48,7 @@ if (_manualChannel isEqualTo 1) then {
     _description = format["Frequency: %1 MHz", [HASH_GET(_hashData,"frequencyTX"), 1, 3] call CBA_fnc_formatNumber];
 } else {
     private _channelNumber = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
-    _description = format["Channel %1 -- Network ID %2", ([(_channelNumber), 1] call CBA_fnc_formatNumber), HASH_GET(_hashData,"networkID")];
+    _description = format["Channel %1 -- Network ID %2", (_channelNumber), HASH_GET(_hashData,"networkID")];
 };
 
 _description

--- a/addons/sys_sem70/radio/fnc_getChannelDescription.sqf
+++ b/addons/sys_sem70/radio/fnc_getChannelDescription.sqf
@@ -45,7 +45,7 @@ private _hashData = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,data
 private _description = "";
 if (_manualChannel isEqualTo 1) then {
     //private _hashData = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
-    _description = format["Frequency: %1 MHz", HASH_GET(_hashData,"frequencyTX")];
+    _description = format["Frequency: %1 MHz", [HASH_GET(_hashData,"frequencyTX"), 1, 3] call CBA_fnc_formatNumber];
 } else {
     private _channelNumber = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
     _description = format["Channel %1 -- Network ID %2", ([(_channelNumber), 1] call CBA_fnc_formatNumber), HASH_GET(_hashData,"networkID")];


### PR DESCRIPTION
**When merged this pull request will:**
- Make all ACE Interaction Names use `sys_core_fnc_getDescriptiveName` in favour of `format ["%1 Chn: %2", _radioName, api_fnc_getRadioChannel]`.
I noticed yesterday that the GSA action to connect a PRC-77 displayed the radio's frequency as `[MHzKnobPos, KHzKnobPos]`, since `api_fnc_getRadioChannel` returns that raw data in its case. `getDescriptiveName`'s return is IMO better in all situations, as it will properly format channel data for all radios and also display useful info like the PTT number.
- Improve the PRC-343 description to show `Bk x Ch y` instead of the absolute (overflowing) channel number.
- Improve the SEM52SL description (and `switchChannelFast` hint) to show H and P channels as letters instead of numbers.
- Improve the SEM70 (and SEM90 Rack) description to show `x MHz` in HW mode and `Chn x NetID y` in AKW mode.
- Always pad out the decimal positions of frequency-based radios, i.e: `30.00 MHz` for the PRC-77 and `30.000 MHz` for the SEM 70 (in HW mode).