### PR TITLE
Extensions - Fix acre2.ini Configuration Path

### DIFF
--- a/extensions/src/ACRE2TS/TS3Client.cpp
+++ b/extensions/src/ACRE2TS/TS3Client.cpp
@@ -456,7 +456,7 @@ std::string CTS3Client::getTempFilePath( void ) {
     char tempPath[MAX_PATH - 14];
     GetTempPathA(sizeof(tempPath), tempPath);
     std::string tempFolder = std::string(tempPath);
-    tempFolder += "acre";
+    tempFolder += "//acre";
     if (!PathFileExistsA(tempFolder.c_str())) {
         if (!CreateDirectoryA(tempFolder.c_str(), NULL)) {
             LOG("ERROR: UNABLE TO CREATE TEMP DIR");

--- a/extensions/src/ACRE2TS/TS3Client.cpp
+++ b/extensions/src/ACRE2TS/TS3Client.cpp
@@ -442,7 +442,7 @@ std::string CTS3Client::getConfigFilePath(void) {
     ts3Functions.getConfigPath(tempPath, MAX_PATH - 14);
 
     std::string tempFolder = std::string(tempPath);
-    tempFolder += "\\acre";
+    tempFolder += "acre";
     if (!PathFileExistsA(tempFolder.c_str())) {
         if (!CreateDirectoryA(tempFolder.c_str(), NULL)) {
             LOG("ERROR: UNABLE TO CREATE TEMP DIR");
@@ -456,7 +456,7 @@ std::string CTS3Client::getTempFilePath( void ) {
     char tempPath[MAX_PATH - 14];
     GetTempPathA(sizeof(tempPath), tempPath);
     std::string tempFolder = std::string(tempPath);
-    tempFolder += "\\acre";
+    tempFolder += "acre";
     if (!PathFileExistsA(tempFolder.c_str())) {
         if (!CreateDirectoryA(tempFolder.c_str(), NULL)) {
             LOG("ERROR: UNABLE TO CREATE TEMP DIR");

--- a/extensions/src/ACRE2TS/TS3Client.cpp
+++ b/extensions/src/ACRE2TS/TS3Client.cpp
@@ -456,7 +456,7 @@ std::string CTS3Client::getTempFilePath( void ) {
     char tempPath[MAX_PATH - 14];
     GetTempPathA(sizeof(tempPath), tempPath);
     std::string tempFolder = std::string(tempPath);
-    tempFolder += "//acre";
+    tempFolder += "\\acre";
     if (!PathFileExistsA(tempFolder.c_str())) {
         if (!CreateDirectoryA(tempFolder.c_str(), NULL)) {
             LOG("ERROR: UNABLE TO CREATE TEMP DIR");


### PR DESCRIPTION
**When merged this pull request will:**
- Edit CTS3Client::getConfigFilePath to Fix config path not loaded, error causing by double slash.

Example of Error:
```
Configuration Path: {C:\Users\%USERNAME%\AppData\Roaming\TS3Client\\acre\acre2.ini}
Failed to load ACRE ini file. Using defaults...
```
ts3Functions.getConfigPath(`tempFolder`) is maybe return `AppData\Roaming\TS3Client\`
`\\acre2` is return `\acre2`
so `tempFolder += "\\acre";` is returns `AppData\Roaming\TS3Client\\acre`

I'm not familiar with C, so please correct me if this is a problem.
Also, I haven't tried this fix yet because I don't know how to build and test the plugin...