### PR TITLE
API - Fix Rack functions when called from 3DEN init box

### DIFF
--- a/addons/api/fnc_initVehicleRacks.sqf
+++ b/addons/api/fnc_initVehicleRacks.sqf
@@ -38,25 +38,30 @@ if ([_vehicle] call FUNC(areVehicleRacksInitialized)) exitWith {
     false
 };
 
-// A player must do the action of initialising a rack
-private _player = objNull;
+// Exec the rest on the next frame, to prevent issues if the function is called in a 3DEN init box
+[{
+    params ["_vehicle", "_condition"];
 
-private _vehiclePresetName = [_vehicle] call FUNC(getVehicleRacksPreset);
-if (_condition isEqualTo {} && {_vehiclePresetName isNotEqualTo ""}) then {
-    _player = ([] call CBA_fnc_players) select 0;
-} else {
-    private _players = [] call CBA_fnc_players;
-    private _index = _players findIf {[_x] call _condition};
+    // A player must do the action of initialising a rack
+    private _player = objNull;
 
-    if (_index == -1) then {
-        WARNING_1("No unit found for condition %1 - defaulting to first player",_condition);
-        _index = 0;
+    private _vehiclePresetName = [_vehicle] call FUNC(getVehicleRacksPreset);
+    if (_condition isEqualTo {} && {_vehiclePresetName isNotEqualTo ""}) then {
+        _player = ([] call CBA_fnc_players) select 0;
+    } else {
+        private _players = [] call CBA_fnc_players;
+        private _index = _players findIf {[_x] call _condition};
+
+        if (_index == -1) then {
+            WARNING_1("No unit found for condition %1 - defaulting to first player",_condition);
+            _index = 0;
+        };
+        _player = _players select _index;
     };
-    _player = _players select _index;
-};
 
-_vehicle setVariable [QEGVAR(sys_rack,initPlayer), _player, true];
+    _vehicle setVariable [QEGVAR(sys_rack,initPlayer), _player, true];
 
-[QEGVAR(sys_rack,initVehicleRacks), [_vehicle], _player] call CBA_fnc_targetEvent;
+    [QEGVAR(sys_rack,initVehicleRacks), [_vehicle], _player] call CBA_fnc_targetEvent;
+}, [_vehicle, _condition]] call CBA_fnc_execNextFrame;
 
 true

--- a/addons/api/fnc_removeAllRacksFromVehicle.sqf
+++ b/addons/api/fnc_removeAllRacksFromVehicle.sqf
@@ -40,26 +40,26 @@ if (!_success) exitWith {
     WARNING_1("Vehicle %1 failed to initialise",_vehicle);
 };
 
-// A player must do the action of removing a rack
-private _player = objNull;
-
-if (isDedicated) then {
-    // Pick the first player
-    _player = (allPlayers - entities "HeadlessClient_F") select 0;
-} else {
-    _player = acre_player;
-};
-
 [{
-    params ["_vehicle", "_player"];
+    params ["_vehicle"];
     [_vehicle] call FUNC(areVehicleRacksInitialized)
 }, {
-    params ["_vehicle", "_player"];
+    params ["_vehicle"];
+
+    // A player must do the action of removing a rack
+    private _player = objNull;
+
+    if (isDedicated) then {
+        // Pick the first player
+        _player = (allPlayers - entities "HeadlessClient_F") select 0;
+    } else {
+        _player = acre_player;
+    };
 
     private _racks = [_vehicle] call FUNC(getVehicleRacks);
     for "_i" from (count _racks) - 1 to 0 step -1 do {
         [QEGVAR(sys_rack,removeVehicleRacks), [_vehicle, _racks select _i], _player] call CBA_fnc_targetEvent;
     };
-}, [_vehicle, _player]] call CBA_fnc_waitUntilAndExecute;
+}, [_vehicle]] call CBA_fnc_waitUntilAndExecute;
 
 true


### PR DESCRIPTION
**When merged this pull request will:**
- Fix `acre_api_fnc_initVehicleRacks` not working from a 3DEN init box due to players not being properly initialized yet.
- Fix `acre_api_fnc_removeAllRacksFromVehicle` not working from a 3DEN init box by making its player finding logic wait for completed Rack Init.