### PR TITLE
Intercom - Add keybinds for fast switch of FFCS Work Knob

### DIFF
--- a/addons/sys_intercom/XEH_PREP.hpp
+++ b/addons/sys_intercom/XEH_PREP.hpp
@@ -4,6 +4,7 @@ PREP_FOLDER(vic3);
 PREP(configIntercom);
 PREP(configIntercomStations);
 PREP(enterVehicle);
+PREP(getFirstConnectedIntercom);
 PREP(getStationVariableName);
 PREP(getStationConfiguration);
 PREP(getVolumeIntercomUnit);
@@ -45,6 +46,7 @@ PREP(updateVehicleInfoText);
 
 // Keybinding
 PREP(switchIntercomFast);
+PREP(switchWorkingRadioFast);
 PREP(handlePttKeyPress);
 PREP(handlePttKeyPressUp);
 

--- a/addons/sys_intercom/XEH_PREP.hpp
+++ b/addons/sys_intercom/XEH_PREP.hpp
@@ -46,7 +46,7 @@ PREP(updateVehicleInfoText);
 
 // Keybinding
 PREP(switchIntercomFast);
-PREP(switchWorkingRadioFast);
+PREP(switchWorkKnobFast);
 PREP(handlePttKeyPress);
 PREP(handlePttKeyPressUp);
 

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -22,43 +22,44 @@ if (didJIP) then {
 if (!hasInterface) exitWith {};
 
 // Keybinds - Intercom
-["ACRE2", "IntercomPTTKey", [localize LSTRING(intercomPttKey), localize LSTRING(intercomPttKey_description)], {
+private _category = ["ACRE2", LLSTRING(intercom)];
+[_category, "IntercomPTTKey", [LLSTRING(intercomPttKey), LLSTRING(intercomPttKey_description)], {
     [ACTION_INTERCOM_PTT] call FUNC(handlePttKeyPress)
 }, {
     [ACTION_INTERCOM_PTT] call FUNC(handlePttKeyPressUp)
 }] call CBA_fnc_addKeybind;
 
-["ACRE2", "IntercomBroadcastKey", [localize LSTRING(intercomBroadcastKey), localize LSTRING(intercomBroadcastKey_description)], {
+[_category, "IntercomBroadcastKey", [LLSTRING(intercomBroadcastKey), LLSTRING(intercomBroadcastKey_description)], {
     [ACTION_BROADCAST] call FUNC(handlePttKeyPress)
 }, {
     [ACTION_BROADCAST] call FUNC(handlePttKeyPressUp)
 }] call CBA_fnc_addKeybind;
 
-["ACRE2", "PreviousIntercom", [localize LSTRING(previousIntercomKey), localize LSTRING(previousIntercomKey_description)], "", {
+[_category, "PreviousIntercom", [LLSTRING(previousIntercomKey), LLSTRING(previousIntercomKey_description)], "", {
     [-1, true] call FUNC(switchIntercomFast)
 }, [DIK_COMMA, [true, false, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "NextIntercom", [localize LSTRING(nextIntercomKey), localize LSTRING(nextIntercomKey_description)], "", {
+[_category, "NextIntercom", [LLSTRING(nextIntercomKey), LLSTRING(nextIntercomKey_description)], "", {
     [1, true] call FUNC(switchIntercomFast)
 }, [DIK_COMMA, [false, true, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "AddPreviousIntercom", [localize LSTRING(addPreviousIntercomKey), localize LSTRING(addPreviousIntercomKey_description)], "", {
+[_category, "AddPreviousIntercom", [LLSTRING(addPreviousIntercomKey), LLSTRING(addPreviousIntercomKey_description)], "", {
     [-1, false] call FUNC(switchIntercomFast)
 }, [DIK_COMMA, [true, false, true]]] call CBA_fnc_addKeybind;
 
-["ACRE2", "AddNextIntercom", [localize LSTRING(addNextIntercomKey), localize LSTRING(addNextIntercomKey_description)], "", {
+[_category, "AddNextIntercom", [LLSTRING(addNextIntercomKey), LLSTRING(addNextIntercomKey_description)], "", {
     [1, false] call FUNC(switchIntercomFast)
 }, [DIK_COMMA, [false, true, true]]] call CBA_fnc_addKeybind;
 
-["ACRE2", QGVAR(openGui), localize LSTRING(openGui), {
+[_category, QGVAR(openGui), LLSTRING(openGui), {
     [-1] call FUNC(openGui)
 }, "", [DIK_TAB, [true, true, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", QGVAR(previousWorkingRadio), [LLSTRING(previousWorkingRadioKey), LLSTRING(previousWorkingRadioKey_description)], "", {
+[_category, QGVAR(previousWorkingRadio), [LLSTRING(previousWorkingRadioKey), LLSTRING(previousWorkingRadioKey_description)], "", {
     [-1, true] call FUNC(switchWorkingRadioFast)
 }, [DIK_1, [false, true, false]]] call CBA_fnc_addKeybind;
 
-["ACRE2", QGVAR(nextWorkingRadio), [LLSTRING(nextWorkingRadioKey), LLSTRING(nextWorkingRadioKey_description)], "", {
+[_category, QGVAR(nextWorkingRadio), [LLSTRING(nextWorkingRadioKey), LLSTRING(nextWorkingRadioKey_description)], "", {
     [1, true] call FUNC(switchWorkingRadioFast)
 }, [DIK_2, [false, true, false]]] call CBA_fnc_addKeybind;
 

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -51,12 +51,12 @@ private _category = ["ACRE2", LLSTRING(intercom)];
     [1, false] call FUNC(switchIntercomFast)
 }, [DIK_COMMA, [false, true, true]]] call CBA_fnc_addKeybind;
 
-[_category, QGVAR(previousWorkingRadio), [LLSTRING(previousWorkingRadioKey), LLSTRING(previousWorkingRadioKey_description)], {
-    [-1, true] call FUNC(switchWorkingRadioFast)
+[_category, QGVAR(previousWorkKnob), [LLSTRING(previousWorkKnobKey), LLSTRING(previousWorkKnobKey_description)], {
+    [-1, true] call FUNC(switchWorkKnobFast)
 }, "", [DIK_Q, [false, true, false]]] call CBA_fnc_addKeybind;
 
-[_category, QGVAR(nextWorkingRadio), [LLSTRING(nextWorkingRadioKey), LLSTRING(nextWorkingRadioKey_description)], {
-    [1, true] call FUNC(switchWorkingRadioFast)
+[_category, QGVAR(nextWorkKnob), [LLSTRING(nextWorkKnobKey), LLSTRING(nextWorkKnobKey_description)], {
+    [1, true] call FUNC(switchWorkKnobFast)
 }, "", [DIK_E, [false, true, false]]] call CBA_fnc_addKeybind;
 
 [_category, QGVAR(openGui), LLSTRING(openGui), {

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -51,13 +51,13 @@ private _category = ["ACRE2", LLSTRING(intercom)];
     [1, false] call FUNC(switchIntercomFast)
 }, [DIK_COMMA, [false, true, true]]] call CBA_fnc_addKeybind;
 
-[_category, QGVAR(previousWorkingRadio), [LLSTRING(previousWorkingRadioKey), LLSTRING(previousWorkingRadioKey_description)], "", {
+[_category, QGVAR(previousWorkingRadio), [LLSTRING(previousWorkingRadioKey), LLSTRING(previousWorkingRadioKey_description)], {
     [-1, true] call FUNC(switchWorkingRadioFast)
-}, [DIK_1, [false, true, false]]] call CBA_fnc_addKeybind;
+}, "", [DIK_Q, [false, true, false]]] call CBA_fnc_addKeybind;
 
-[_category, QGVAR(nextWorkingRadio), [LLSTRING(nextWorkingRadioKey), LLSTRING(nextWorkingRadioKey_description)], "", {
+[_category, QGVAR(nextWorkingRadio), [LLSTRING(nextWorkingRadioKey), LLSTRING(nextWorkingRadioKey_description)], {
     [1, true] call FUNC(switchWorkingRadioFast)
-}, [DIK_2, [false, true, false]]] call CBA_fnc_addKeybind;
+}, "", [DIK_E, [false, true, false]]] call CBA_fnc_addKeybind;
 
 [_category, QGVAR(openGui), LLSTRING(openGui), {
     [-1] call FUNC(openGui)

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -1,6 +1,8 @@
 #include "script_component.hpp"
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
+LOAD_SOUND(Acre_GenericClick);
+
 private _addClassEH = {
     ["Tank", "init", FUNC(initVehicleIntercom), nil, nil, true] call CBA_fnc_addClassEventHandler;
     ["Car_F", "init", FUNC(initVehicleIntercom), nil, nil, true] call CBA_fnc_addClassEventHandler;
@@ -51,6 +53,14 @@ if (!hasInterface) exitWith {};
 ["ACRE2", QGVAR(openGui), localize LSTRING(openGui), {
     [-1] call FUNC(openGui)
 }, "", [DIK_TAB, [true, true, false]]] call CBA_fnc_addKeybind;
+
+["ACRE2", QGVAR(previousWorkingRadio), [LLSTRING(previousWorkingRadioKey), LLSTRING(previousWorkingRadioKey_description)], "", {
+    [-1, true] call FUNC(switchWorkingRadioFast)
+}, [DIK_1, [false, true, false]]] call CBA_fnc_addKeybind;
+
+["ACRE2", QGVAR(nextWorkingRadio), [LLSTRING(nextWorkingRadioKey), LLSTRING(nextWorkingRadioKey_description)], "", {
+    [1, true] call FUNC(switchWorkingRadioFast)
+}, [DIK_2, [false, true, false]]] call CBA_fnc_addKeybind;
 
 // Intercom configuration
 ["vehicle", {

--- a/addons/sys_intercom/XEH_postInit.sqf
+++ b/addons/sys_intercom/XEH_postInit.sqf
@@ -51,10 +51,6 @@ private _category = ["ACRE2", LLSTRING(intercom)];
     [1, false] call FUNC(switchIntercomFast)
 }, [DIK_COMMA, [false, true, true]]] call CBA_fnc_addKeybind;
 
-[_category, QGVAR(openGui), LLSTRING(openGui), {
-    [-1] call FUNC(openGui)
-}, "", [DIK_TAB, [true, true, false]]] call CBA_fnc_addKeybind;
-
 [_category, QGVAR(previousWorkingRadio), [LLSTRING(previousWorkingRadioKey), LLSTRING(previousWorkingRadioKey_description)], "", {
     [-1, true] call FUNC(switchWorkingRadioFast)
 }, [DIK_1, [false, true, false]]] call CBA_fnc_addKeybind;
@@ -62,6 +58,10 @@ private _category = ["ACRE2", LLSTRING(intercom)];
 [_category, QGVAR(nextWorkingRadio), [LLSTRING(nextWorkingRadioKey), LLSTRING(nextWorkingRadioKey_description)], "", {
     [1, true] call FUNC(switchWorkingRadioFast)
 }, [DIK_2, [false, true, false]]] call CBA_fnc_addKeybind;
+
+[_category, QGVAR(openGui), LLSTRING(openGui), {
+    [-1] call FUNC(openGui)
+}, "", [DIK_TAB, [true, true, false]]] call CBA_fnc_addKeybind;
 
 // Intercom configuration
 ["vehicle", {

--- a/addons/sys_intercom/fnc_getFirstConnectedIntercom.sqf
+++ b/addons/sys_intercom/fnc_getFirstConnectedIntercom.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Returns the first connected intercom network.
+ *
+ * Arguments:
+ * 0: Vehicle <OBJECT>
+ *
+ * Return Value:
+ * Intercom network or -1 if no connected intercom network exist <NUMBER>
+ *
+ * Example:
+ * [vehicle acre_player] call acre_sys_intercom_fnc_getFirstConnectedIntercom
+ *
+ * Public: No
+ */
+
+params ["_vehicle"];
+
+private _intercomNames = _vehicle getVariable [QGVAR(intercomNames), []];
+
+if (_vehicle isEqualTo acre_player || {_intercomNames isEqualTo []}) exitWith {-1};
+
+private _activeIntercom = -1;
+{
+    private _connectionStatus = [_vehicle, acre_player, _forEachIndex, INTERCOM_STATIONSTATUS_CONNECTION] call FUNC(getStationConfiguration);
+    if (_connectionStatus > INTERCOM_DISCONNECTED) exitWith {
+        _activeIntercom = _forEachIndex;
+    }
+} forEach _intercomNames;
+
+_activeIntercom

--- a/addons/sys_intercom/fnc_openGui.sqf
+++ b/addons/sys_intercom/fnc_openGui.sqf
@@ -24,34 +24,19 @@ if (GVAR(guiOpened)) exitWith {
 };
 
 private _vehicle = vehicle acre_player;
-private _intercomNames = _vehicle getVariable [QGVAR(intercomNames), []];
 
-if (_vehicle isEqualTo acre_player || {_intercomNames isEqualTo []}) exitWith {false};
+if (_vehicle isEqualTo acre_player) exitWith {false};
 
 if (_intercomNetwork != -1) then {
     GVAR(activeIntercom) = _intercomNetwork;
 } else {
-    private _getActiveIntercom = {
-        params ["_vehicle"];
-
-        private _activeIntercom = -1;
-        {
-            private _connectionStatus = [_vehicle, acre_player, _forEachIndex, INTERCOM_STATIONSTATUS_CONNECTION] call FUNC(getStationConfiguration);
-            if (_connectionStatus > INTERCOM_DISCONNECTED) exitWith {
-                _activeIntercom = _forEachIndex;
-            }
-        } forEach _intercomNames;
-
-        _activeIntercom;
-    };
-
     if (GVAR(activeIntercom) != -1) then {
         private _connectionStatus = [_vehicle, acre_player, GVAR(activeIntercom), INTERCOM_STATIONSTATUS_CONNECTION] call FUNC(getStationConfiguration);
         if (_connectionStatus == INTERCOM_DISCONNECTED) then {
-            GVAR(activeIntercom) = [_vehicle] call _getActiveIntercom;
+            GVAR(activeIntercom) = [_vehicle] call FUNC(getFirstConnectedIntercom);
         };
     } else {
-        GVAR(activeIntercom) = [_vehicle] call _getActiveIntercom;
+        GVAR(activeIntercom) = [_vehicle] call FUNC(getFirstConnectedIntercom);
     };
 };
 

--- a/addons/sys_intercom/fnc_switchWorkKnobFast.sqf
+++ b/addons/sys_intercom/fnc_switchWorkKnobFast.sqf
@@ -1,17 +1,17 @@
 #include "script_component.hpp"
 /*
  * Author: ACRE2Team
- * Handles the working radio switching keybind.
+ * Handles the work knob switching keybind.
  *
  * Arguments:
- * 0: Working radio switch amount (expected -1 or 1) <NUMBER>
+ * 0: Work knob switch amount (expected -1 or 1) <NUMBER>
  * 1: Play sound <BOOL> (default: false)
  *
  * Return Value:
  * Handled <BOOL>
  *
  * Example:
- * [1, true] call acre_sys_intercom_fnc_switchWorkingRadioFast
+ * [1, true] call acre_sys_intercom_fnc_switchWorkKnobFast
  *
  * Public: No
  */

--- a/addons/sys_intercom/fnc_switchWorkingRadioFast.sqf
+++ b/addons/sys_intercom/fnc_switchWorkingRadioFast.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Handles the working radio switching keybind.
+ *
+ * Arguments:
+ * 0: Working radio switch amount (expected -1 or 1) <NUMBER>
+ * 1: Play sound <BOOL> (default: false)
+ *
+ * Return Value:
+ * Handled <BOOL>
+ *
+ * Example:
+ * [1, true] call acre_sys_intercom_fnc_switchWorkingRadioFast
+ *
+ * Public: No
+ */
+
+params ["_dir", ["_playSound", false, [false]]];
+
+private _vehicle = vehicle acre_player;
+private _intercomNetwork = [_vehicle] call FUNC(getFirstConnectedIntercom);
+private _workPos = [_vehicle, acre_player, _intercomNetwork, INTERCOM_STATIONSTATUS_WORKKNOB] call FUNC(getStationConfiguration);
+private _success = [_intercomNetwork, _workPos + _dir] call FUNC(vic3ffcsSetWork);
+
+if (!_success) exitWith {false};
+
+if (_playSound) then {
+    ["Acre_GenericClick", [0,0,0], [0,0,0], 1, false] call EFUNC(sys_sounds,playSound);
+};
+
+true

--- a/addons/sys_intercom/fnc_switchWorkingRadioFast.sqf
+++ b/addons/sys_intercom/fnc_switchWorkingRadioFast.sqf
@@ -20,6 +20,8 @@ params ["_dir", ["_playSound", false, [false]]];
 
 private _vehicle = vehicle acre_player;
 private _intercomNetwork = [_vehicle] call FUNC(getFirstConnectedIntercom);
+if (_intercomNetwork < 0) exitWith {false};
+
 private _workPos = [_vehicle, acre_player, _intercomNetwork, INTERCOM_STATIONSTATUS_WORKKNOB] call FUNC(getStationConfiguration);
 private _success = [_intercomNetwork, _workPos + _dir] call FUNC(vic3ffcsSetWork);
 

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -594,19 +594,19 @@
         </Key>
         <Key ID="STR_ACRE_sys_intercom_previousWorkKnobKey">
             <English>Previous Work Knob Position</English>
-            <German>Vorheriger Funkkreis</German>
+            <German>Vorherige Work-Knopfposition</German>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_previousWorkKnobKey_description">
-            <English>Switches to the previous radio rack and sets it as the work knob within the first connected intercom network.</English>
-            <German>Setzt das vorherige Funkgerät als aktiven Funkkreis im ersten verbundenen Bordfunknetzwerk.</German>
+            <English>Switches to the previous radio rack and sets it as the transmitting radio within the first connected intercom network.</English>
+            <German>Setzt das vorherige Fahrzeugfunkgerät als sendendes Funkgerät im ersten verbundenen Bordfunknetzwerk.</German>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_nextWorkKnobKey">
             <English>Next Work Knob Position</English>
-            <German>Nächster Funkkreis</German>
+            <German>Nächste Work-Knopfposition</German>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_nextWorkKnobKey_description">
-            <English>Switches to the next radio rack and sets it as the work knob within the first connected intercom network.</English>
-            <German>Setzt das nächste Funkgerät als aktiven Funkkreis im ersten verbundenen Bordfunknetzwerk.</German>
+            <English>Switches to the next radio rack and sets it as the transmitting radio within the first connected intercom network.</English>
+            <German>Setzt das nächste Fahrzeugfunkgerät als sendendes Funkgerät im ersten verbundenen Bordfunknetzwerk.</German>
         </Key>
     </Package>
 </Project>

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -597,16 +597,16 @@
             <German>Vorheriger Funkkreis</German>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_previousWorkingRadioKey_description">
-            <English>Switch to the previous radio rack capable of receiving and transmitting.</English>
-            <German>Setzt das vorherige Funkgerät als aktiven Funkkreis.</German>
+            <English>Switches to the previous radio rack and sets it as the working radio within the first connected intercom network.</English>
+            <German>Setzt das vorherige Funkgerät als aktiven Funkkreis im ersten verbundenen Bordfunknetzwerk.</German>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_nextWorkingRadioKey">
             <English>Next Working Radio</English>
             <German>Nächster Funkkreis</German>
         </Key>
         <Key ID="STR_ACRE_sys_intercom_nextWorkingRadioKey_description">
-            <English>Switch to the next radio rack capable of receiving and transmitting.</English>
-            <German>Setzt das nächste Funkgerät als aktiven Funkkreis.</German>
+            <English>Switches to the next radio rack and sets it as the working radio within the first connected intercom network.</English>
+            <German>Setzt das nächste Funkgerät als aktiven Funkkreis im ersten verbundenen Bordfunknetzwerk.</German>
         </Key>
     </Package>
 </Project>

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -592,5 +592,21 @@
             <Portuguese>Situação da Intercomunicação está sendo forçado. As configurações não podem ser alteraradas.</Portuguese>
             <Turkish>İnterkom ayarı zorla atanmış. Ayarlar değiştirilemiyor. </Turkish>
         </Key>
+        <Key ID="STR_ACRE_sys_intercom_previousWorkingRadioKey">
+            <English>Previous Working Radio</English>
+            <German>Vorheriger Funkkreis</German>
+        </Key>
+        <Key ID="STR_ACRE_sys_intercom_previousWorkingRadioKey_description">
+            <English>Switch to the previous radio rack capable of receiving and transmitting.</English>
+            <German>Setzt das vorherige Funkgerät als aktiven Funkkreis.</German>
+        </Key>
+        <Key ID="STR_ACRE_sys_intercom_nextWorkingRadioKey">
+            <English>Next Working Radio</English>
+            <German>Nächster Funkkreis</German>
+        </Key>
+        <Key ID="STR_ACRE_sys_intercom_nextWorkingRadioKey_description">
+            <English>Switch to the next radio rack capable of receiving and transmitting.</English>
+            <German>Setzt das nächste Funkgerät als aktiven Funkkreis.</German>
+        </Key>
     </Package>
 </Project>

--- a/addons/sys_intercom/stringtable.xml
+++ b/addons/sys_intercom/stringtable.xml
@@ -592,20 +592,20 @@
             <Portuguese>Situação da Intercomunicação está sendo forçado. As configurações não podem ser alteraradas.</Portuguese>
             <Turkish>İnterkom ayarı zorla atanmış. Ayarlar değiştirilemiyor. </Turkish>
         </Key>
-        <Key ID="STR_ACRE_sys_intercom_previousWorkingRadioKey">
-            <English>Previous Working Radio</English>
+        <Key ID="STR_ACRE_sys_intercom_previousWorkKnobKey">
+            <English>Previous Work Knob Position</English>
             <German>Vorheriger Funkkreis</German>
         </Key>
-        <Key ID="STR_ACRE_sys_intercom_previousWorkingRadioKey_description">
-            <English>Switches to the previous radio rack and sets it as the working radio within the first connected intercom network.</English>
+        <Key ID="STR_ACRE_sys_intercom_previousWorkKnobKey_description">
+            <English>Switches to the previous radio rack and sets it as the work knob within the first connected intercom network.</English>
             <German>Setzt das vorherige Funkgerät als aktiven Funkkreis im ersten verbundenen Bordfunknetzwerk.</German>
         </Key>
-        <Key ID="STR_ACRE_sys_intercom_nextWorkingRadioKey">
-            <English>Next Working Radio</English>
+        <Key ID="STR_ACRE_sys_intercom_nextWorkKnobKey">
+            <English>Next Work Knob Position</English>
             <German>Nächster Funkkreis</German>
         </Key>
-        <Key ID="STR_ACRE_sys_intercom_nextWorkingRadioKey_description">
-            <English>Switches to the next radio rack and sets it as the working radio within the first connected intercom network.</English>
+        <Key ID="STR_ACRE_sys_intercom_nextWorkKnobKey_description">
+            <English>Switches to the next radio rack and sets it as the work knob within the first connected intercom network.</English>
             <German>Setzt das nächste Funkgerät als aktiven Funkkreis im ersten verbundenen Bordfunknetzwerk.</German>
         </Key>
     </Package>

--- a/addons/sys_intercom/vic3/__PREP__.sqf
+++ b/addons/sys_intercom/vic3/__PREP__.sqf
@@ -6,3 +6,4 @@ PREP_MODULE(vic3,vic3ffcsOnMonitorKnobPress);
 PREP_MODULE(vic3,vic3ffcsOnVolumeKnobPress);
 PREP_MODULE(vic3,vic3ffcsOnWorkKnobPress);
 PREP_MODULE(vic3,vic3ffcsRender);
+PREP_MODULE(vic3,vic3ffcsSetWork);

--- a/addons/sys_intercom/vic3/fnc_vic3ffcsOnWorkKnobPress.sqf
+++ b/addons/sys_intercom/vic3/fnc_vic3ffcsOnWorkKnobPress.sqf
@@ -27,58 +27,8 @@ if (_key == 0) then {
 private _vehicle = vehicle acre_player;
 private _workPos = [_vehicle, acre_player, GVAR(activeIntercom), INTERCOM_STATIONSTATUS_WORKKNOB] call FUNC(getStationConfiguration);
 private _newWorkPos = ((_workPos + _currentDirection) max 0) min VIC3FFCS_WORK_KNOB_POSITIONS;
+private _success = [GVAR(activeIntercom), _newWorkPos] call FUNC(vic3ffcsSetWork);
 
-if (_newWorkPos == _workPos) exitWith {};
+if (!_success) exitWith {};
 
-private _wiredRacks = [_vehicle, acre_player, GVAR(activeIntercom), INTERCOM_STATIONSTATUS_WIREDRACKS] call FUNC(getStationConfiguration);
-private _monitorPos = [_vehicle, acre_player, GVAR(activeIntercom), INTERCOM_STATIONSTATUS_MONITORKNOB] call FUNC(getStationConfiguration);
-
-// Set the previous rack to no monitor unless it is selected in the monitor knob
-if (_workPos != 0) then {
-    private _selectedRack = _wiredRacks select (_workPos - 1);
-
-    private _rackId = _selectedRack select 0;
-    if (_rackId != "" && {_selectedRack select 2}) then {
-        if (_workPos != _monitorPos) then {
-            private _radioId = [_rackId] call EFUNC(sys_rack,getMountedRadio);
-
-            if (_monitorPos != VIC3FFCS_MONITOR_KNOB_POSITIONS) then {
-                _selectedRack set [1, RACK_NO_MONITOR];
-                if (_radioId != "") then {
-                    [_vehicle, acre_player, _radioId] call EFUNC(sys_rack,stopUsingMountedRadio);
-                };
-            } else {
-                _selectedRack set [1, RACK_RX_ONLY];
-            };
-        } else {
-            _selectedRack set [1, RACK_RX_ONLY];
-        };
-    };
-};
-
-if (_newWorkPos != 0) then {
-    private _selectedRack = _wiredRacks select (_newWorkPos - 1); // RackID, Functionality, Has Access
-    private _rackId = _selectedRack select 0;
-    if ((_rackId != "") && {_selectedRack select 2}) then {
-        private _radioId = [_rackId] call EFUNC(sys_rack,getMountedRadio);
-        _selectedRack set [1, RACK_RX_AND_TX];
-
-        if ((_newWorkPos != _monitorPos) && {_radioId != ""}) then {
-            [_vehicle, acre_player, _radioId] call EFUNC(sys_rack,startUsingMountedRadio);
-        };
-    };
-} else {
-    private _selectedRack = _wiredRacks select (_workPos - 1);
-    private _rackId = _selectedRack select 0;
-    if ((_rackId != "") && {_selectedRack select 2} && {_workPos != _monitorPos} && {_monitorPos != VIC3FFCS_MONITOR_KNOB_POSITIONS} ) then {
-        private _radioId = [_rackId] call EFUNC(sys_rack,getMountedRadio);
-
-        _selectedRack set [1, RACK_NO_MONITOR];
-        if (_radioId != "") then {
-            [_vehicle, acre_player, _radioId] call EFUNC(sys_rack,stopUsingMountedRadio);
-        };
-    };
-};
-
-[_vehicle, acre_player, GVAR(activeIntercom), INTERCOM_STATIONSTATUS_WORKKNOB, _newWorkPos] call FUNC(setStationConfiguration);
 [MAIN_DISPLAY, _vehicle] call FUNC(vic3ffcsRender);

--- a/addons/sys_intercom/vic3/fnc_vic3ffcsSetWork.sqf
+++ b/addons/sys_intercom/vic3/fnc_vic3ffcsSetWork.sqf
@@ -76,3 +76,5 @@ if (_newWorkPos isNotEqualTo 0) then {
 };
 
 [_vehicle, acre_player, _intercomNetwork, INTERCOM_STATIONSTATUS_WORKKNOB, _newWorkPos] call FUNC(setStationConfiguration);
+
+true

--- a/addons/sys_intercom/vic3/fnc_vic3ffcsSetWork.sqf
+++ b/addons/sys_intercom/vic3/fnc_vic3ffcsSetWork.sqf
@@ -1,0 +1,78 @@
+#include "..\script_component.hpp"
+/*
+ * Author: ACRE2Team
+ * Sets the working radio in the FFCS.
+ *
+ * Arguments:
+ * 0: Intercom network <NUMBER>
+ * 1: Working radio index <NUMBER>
+ *
+ * Return Value:
+ * Success <BOOL>
+ *
+ * Example:
+ * [0, 1] call acre_sys_intercom_fnc_vic3ffcsSetWork
+ *
+ * Public: No
+ */
+
+params ["_intercomNetwork", "_newWorkPos"];
+
+if (_newWorkPos < 0 || _newWorkPos > VIC3FFCS_WORK_KNOB_POSITIONS) exitWith {false};
+
+private _vehicle = vehicle acre_player;
+private _workPos = [_vehicle, acre_player, _intercomNetwork, INTERCOM_STATIONSTATUS_WORKKNOB] call FUNC(getStationConfiguration);
+
+if (_newWorkPos isEqualTo _workPos) exitWith {false};
+
+private _wiredRacks = [_vehicle, acre_player, _intercomNetwork, INTERCOM_STATIONSTATUS_WIREDRACKS] call FUNC(getStationConfiguration);
+private _monitorPos = [_vehicle, acre_player, _intercomNetwork, INTERCOM_STATIONSTATUS_MONITORKNOB] call FUNC(getStationConfiguration);
+
+// Set the previous rack to no monitor unless it is selected in the monitor knob
+if (_workPos isNotEqualTo 0) then {
+    private _selectedRack = _wiredRacks select (_workPos - 1);
+
+    private _rackId = _selectedRack select 0;
+    if (_rackId isNotEqualTo "" && {_selectedRack select 2}) then {
+        if (_workPos isNotEqualTo _monitorPos) then {
+            private _radioId = [_rackId] call EFUNC(sys_rack,getMountedRadio);
+
+            if (_monitorPos isNotEqualTo VIC3FFCS_MONITOR_KNOB_POSITIONS) then {
+                _selectedRack set [1, RACK_NO_MONITOR];
+                if (_radioId isNotEqualTo "") then {
+                    [_vehicle, acre_player, _radioId] call EFUNC(sys_rack,stopUsingMountedRadio);
+                };
+            } else {
+                _selectedRack set [1, RACK_RX_ONLY];
+            };
+        } else {
+            _selectedRack set [1, RACK_RX_ONLY];
+        };
+    };
+};
+
+if (_newWorkPos isNotEqualTo 0) then {
+    private _selectedRack = _wiredRacks select (_newWorkPos - 1); // RackID, Functionality, Has Access
+    private _rackId = _selectedRack select 0;
+    if ((_rackId isNotEqualTo "") && {_selectedRack select 2}) then {
+        private _radioId = [_rackId] call EFUNC(sys_rack,getMountedRadio);
+        _selectedRack set [1, RACK_RX_AND_TX];
+
+        if ((_newWorkPos isNotEqualTo _monitorPos) && {_radioId isNotEqualTo ""}) then {
+            [_vehicle, acre_player, _radioId] call EFUNC(sys_rack,startUsingMountedRadio);
+        };
+    };
+} else {
+    private _selectedRack = _wiredRacks select (_workPos - 1);
+    private _rackId = _selectedRack select 0;
+    if ((_rackId isNotEqualTo "") && {_selectedRack select 2} && {_workPos isNotEqualTo _monitorPos} && {_monitorPos isNotEqualTo VIC3FFCS_MONITOR_KNOB_POSITIONS} ) then {
+        private _radioId = [_rackId] call EFUNC(sys_rack,getMountedRadio);
+
+        _selectedRack set [1, RACK_NO_MONITOR];
+        if (_radioId isNotEqualTo "") then {
+            [_vehicle, acre_player, _radioId] call EFUNC(sys_rack,stopUsingMountedRadio);
+        };
+    };
+};
+
+[_vehicle, acre_player, _intercomNetwork, INTERCOM_STATIONSTATUS_WORKKNOB, _newWorkPos] call FUNC(setStationConfiguration);

--- a/addons/sys_intercom/vic3/fnc_vic3ffcsSetWork.sqf
+++ b/addons/sys_intercom/vic3/fnc_vic3ffcsSetWork.sqf
@@ -1,11 +1,11 @@
 #include "..\script_component.hpp"
 /*
  * Author: ACRE2Team
- * Sets the working radio in the FFCS.
+ * Sets the Work knob in the FFCS.
  *
  * Arguments:
  * 0: Intercom network <NUMBER>
- * 1: Working radio index <NUMBER>
+ * 1: Work knob position <NUMBER>
  *
  * Return Value:
  * Success <BOOL>


### PR DESCRIPTION
**When merged this pull request will:**
- Add keybind for fast switching of working radio
- Categorize all intercom keybinds into its own subcategory

### TODO

- [x] MP Test

### Discussion

I have not found any better keybinds for this. Suggestions are welcome. It should ideally be easy to press with the left hand.