### PR TITLE
Core - Fix error return type for `processRadioSpeaker`

### DIFF
--- a/addons/sys_core/fnc_processRadioSpeaker.sqf
+++ b/addons/sys_core/fnc_processRadioSpeaker.sqf
@@ -26,11 +26,11 @@ params ["_unit","_playerRadios"];
 TRACE_2("",_unit,_playerRadios);
 
 private _radioId = _unit getVariable [QGVAR(currentSpeakingRadio), ""];
-if (_radioId == "") exitWith { false };
+if (_radioId == "") exitWith { [] };
 
 // Workaround #638 - _radioId is nil - TODO investigate further
 // Probable source: https://github.com/IDI-Systems/acre2/blob/c03262be2190cd54c3cb5f27d7ca3eddf7270506/addons/sys_core/fnc_remoteStartSpeaking.sqf#L107
-if (isNil "_radioId") exitWith { false };
+if (isNil "_radioId") exitWith { [] };
 
 // @todo if Underwater Radios are implemented
 //if (ACRE_LISTENER_DIVE == 1) exitWith { false };


### PR DESCRIPTION
```
20:37:39 Error in expression <    };
                };
            } forEach _returnedRadios;
        };
    >
20:37:39   Error position: <forEach _returnedRadios;
        };
    >
20:37:39   Error foreach: Type Bool, expected Array,HashMap
20:37:39 File /idi/acre/addons/sys_core/fnc_speaking.sqf..., line 81
```
`acre_sys_core_fnc_processRadioSpeaker` return type should be array
`acre_sys_core_fnc_speaking` does `forEach` on return and threw error

still not sure of root cause
seems to be releated to old nil bug #638 #1002
