### PR TITLE
Extensions - Fix Longley-Rice segfault

### DIFF
--- a/extensions/src/ACRE2Arma/signal/models/longleyRice_itm.cpp
+++ b/extensions/src/ACRE2Arma/signal/models/longleyRice_itm.cpp
@@ -1550,7 +1550,7 @@ namespace acre {
 #endif
 
                     ja = (long) (3.0 + 0.1 * elev[0]);
-                    jb = np - ja + 6;
+                    jb = std::min<long>(np - ja + 6, np + 1);
                     for (i = ja - 1; i < jb; ++i)
                         zsys += elev[i];
                     zsys /= (jb - ja + 1);


### PR DESCRIPTION
3 Crashdumps from dedman
Different maps, but all using long rice, crashing in same spot

![Untitled](https://github.com/user-attachments/assets/85a0e98f-1bd5-4980-b202-4709e51c30e4)

in all 3 cases elev is only size 3 and `i` is going off the end

This PR should fix the overrun (and keep the average correct)
But I couldn't replicate issue locally, so I can't be positive it will fully solve root issue