### PR TITLE
Compat SPE - Fix SPEX fakewrp

### DIFF
--- a/addons/compat_spe/compat_spex/config.cpp
+++ b/addons/compat_spe/compat_spex/config.cpp
@@ -17,9 +17,9 @@ class CfgPatches {
 
 class CfgAcreWorlds {
     class SPEX_Carentan {
-        wrp = QPATHTOF(SPEX_Carentan.fakewrp);
+        wrp = QPATHTOEF(compat_spe,compat_spex\SPEX_Carentan.fakewrp);
     };
     class SPEX_Utah_Beach {
-        wrp = QPATHTOF(SPEX_Utah_Beach.fakewrp);
+        wrp = QPATHTOEF(compat_spe,compat_spex\SPEX_Utah_Beach.fakewrp);
     };
 };


### PR DESCRIPTION
ref #1335 
@Drofseh - I don't have spearhead to test this but it looks like the path was set to
`wrp = "\idi\acre\addons\compat_spex\SPEX_Carentan.fakewrp";`
and the actual relative path is
`\idi\addons\compat_spe\compat_spex\SPEX_Carentan.fakewrp`
