### PR TITLE
Core - Skip setting plugin setting on dedicated

### DIFF
--- a/addons/sys_core/fnc_setPluginSetting.sqf
+++ b/addons/sys_core/fnc_setPluginSetting.sqf
@@ -20,6 +20,7 @@
 #ifndef DEBUG_MODE_FULL
 if (!isMultiplayer) exitWith {};
 #endif
+if (!hasInterface) exitWith {};
 
 params ["_name", "_value"];
 


### PR DESCRIPTION
on dedicated server
`isNil "acre_sys_io_serverStarted"` = true
so the PFEH runs forever
e.g. `cba_common_perFrameHandlerArray # 17` = `[{if (acre_sys_io_serverStarted) then {....`