### PR TITLE
PRC-152 - Add/Fix PGM Features

### DIFF
--- a/addons/sys_prc152/farris_menus/Main.sqf
+++ b/addons/sys_prc152/farris_menus/Main.sqf
@@ -1,14 +1,14 @@
 #include "..\script_component.hpp"
 //#define DEBUG_MODE_FULL
 
-
+ #define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
 GVAR(OFF) = ["OFF", "OFF", "", MENUTYPE_STATIC, [],[ nil,nil, nil ] ];
 [GVAR(OFF)] call FUNC(createMenu);
 
 GVAR(INVALID_MODE) = ["INVALID_MODE", "INVALID_MODE", "",
     MENUTYPE_STATIC,
     [
-        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch $cch-encryption"],
         [ROW_XLARGE_1, ALIGN_LEFT, "INVALID MODE"],
         [ROW_LARGE_2, ALIGN_LEFT, "ONLY PT SUPPORTED"]
     ],
@@ -24,7 +24,7 @@ GVAR(INVALID_MODE) = ["INVALID_MODE", "INVALID_MODE", "",
 GVAR(VOLUME) = ["VOLUME", "VOLUME", "",
     MENUTYPE_STATIC,
     [
-        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch $cch-encryption"],
         [ROW_LARGE_2, ALIGN_CENTER, "VOLUME"]
     ],
     [
@@ -48,8 +48,8 @@ GVAR(VOLUME) = ["VOLUME", "VOLUME", "",
 GVAR(NoItems) = ["ERROR_NOENTRY", "ERROR_NOENTRY", "",
     MENUTYPE_STATIC,
     [
-        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
-        [ROW_LARGE_2, ALIGN_LEFT, "<NO ITEMS IN MENU>"],
+        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch $cch-encryption"],
+        [ROW_LARGE_2, ALIGN_CENTER, "<NO ITEMS IN MENU>"],
         [ROW_SMALL_5, ALIGN_CENTER, "ENT OR CLR TO CONT"]
     ],
     [
@@ -77,10 +77,10 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-MAIN", "VULOSHOME-MAIN", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat        $cch-channelmode $cch-squelch $cch-encryption"],
                 [ROW_LARGE_2, ALIGN_LEFT, "$cch-number-$cch-description"],
-                [ROW_LARGE_3, ALIGN_LEFT, "LOS  VOC  $cch-modulation  ---  --"],
-                [ROW_SMALL_5, ALIGN_LEFT, "TYPE    TRF    MOD   CHAN    KEY"]
+                [ROW_LARGE_3, ALIGN_LEFT, "LOS  VOC  $cch-modulation  ---  $cch-tek"],
+                [ROW_SMALL_5, ALIGN_LEFT, " TYPE   TRF    MOD   CHAN   KEY"]
             ],
             [
                 nil,
@@ -109,7 +109,7 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-CHANNEL", "VULOSHOME-CHANNEL", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat        $cch-channelmode $cch-squelch $cch-encryption"],
                 [ROW_LARGE_2, ALIGN_LEFT, "R: $cch-frequencyrx"],
                 [ROW_LARGE_3, ALIGN_LEFT, "T: $cch-frequencytx       ---"],
                 [ROW_SMALL_5, ALIGN_LEFT, " FREQUENCY                  CHAN"]
@@ -141,9 +141,9 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-DATA", "VULOSHOME-DATA", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
-                [ROW_LARGE_2, ALIGN_LEFT, "--- -----   --"],
-                [ROW_LARGE_3, ALIGN_LEFT, "$cch-optioncode ---- ANLG -- OFF"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat        $cch-channelmode $cch-squelch $cch-encryption"],
+                [ROW_LARGE_2, ALIGN_LEFT, "25K $cch-trafficrate.0K   --"],
+                [ROW_LARGE_3, ALIGN_LEFT, "$cch-optioncode ---- CLR  --  OFF"],
                 [ROW_SMALL_5, ALIGN_LEFT, "OPT   DATA   VOICE  INTLV   FEC"]
             ],
             [
@@ -173,7 +173,7 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-LARGEFONT", "VULOSHOME-LARGEFONT", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat        $cch-channelmode $cch-squelch $cch-encryption"],
                 [ROW_XLARGE_2, ALIGN_LEFT, "$cch-number*$cch-description"]
             ],
             [

--- a/addons/sys_prc152/farris_menus/Main.sqf
+++ b/addons/sys_prc152/farris_menus/Main.sqf
@@ -142,7 +142,7 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
             MENUTYPE_STATIC,
             [
                 [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat        $cch-channelmode $cch-squelch $cch-encryption"],
-                [ROW_LARGE_2, ALIGN_LEFT, "25K $cch-trafficrate.0K   --"],
+                [ROW_LARGE_2, ALIGN_LEFT, "25K $cch-trafficrate.0K    $cch-modulation"],
                 [ROW_LARGE_3, ALIGN_LEFT, "$cch-optioncode ---- CLR  --  OFF"],
                 [ROW_SMALL_5, ALIGN_LEFT, "OPT   DATA   VOICE  INTLV   FEC"]
             ],
@@ -174,30 +174,13 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
             MENUTYPE_STATIC,
             [
                 [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat        $cch-channelmode $cch-squelch $cch-encryption"],
-                [ROW_XLARGE_2, ALIGN_LEFT, "$cch-number*$cch-description"]
+                [ROW_XLARGE_2, ALIGN_LEFT, "$cch-number-$cch-description"]
             ],
             [
                 nil, // onEntry
                 nil,  // onExit. Our parent static display generic event handler handles the 'Next' key
                 nil,
-                {
-                    [ICON_BATTERY, false] call FUNC(toggleIcon);
-                    [ICON_VOLUME, true] call FUNC(toggleIcon);
-                    [ICON_TRANSMIT, true] call FUNC(toggleIcon);
-                    [ICON_TRANSMITBAR, true] call FUNC(toggleIcon);
-
-                    private _volume = GET_STATE("volume");
-                    private _display = uiNamespace getVariable [QGVAR(currentDisplay), displayNull];
-                    private _recStrength = SCRATCH_GET_DEF(GVAR(currentRadioID),"receivingSignal",0);
-
-                    TRACE_2("Rendering VOLUME-STAGE-1",_volume,_display);
-                    if (!isNull _display) then {
-                        (_display displayCtrl ICON_VOLUME) progressSetPosition _volume;
-                        (_display displayCtrl ICON_VOLUME) ctrlCommit 0;
-                        (_display displayCtrl ICON_TRANSMITBAR) progressSetPosition _recStrength;
-                        (_display displayCtrl ICON_TRANSMITBAR) ctrlCommit 0;
-                    };
-                }
+                nil
             ]
         ]
     ],

--- a/addons/sys_prc152/farris_menus/OPT.sqf
+++ b/addons/sys_prc152/farris_menus/OPT.sqf
@@ -64,6 +64,7 @@ GVAR(OPT) = ["OPT", "OPT", "OPT",
     MENUTYPE_LIST,
     [
         // TODO: Locks all but next. 1,3,7,9 series unlocks. Display "Keypad is Locked"
+        
         [nil, "LOCK KEYPAD", "", MENU_ACTION_SUBMENU, ["ERROR_NOENTRY"], nil ],
         [nil, "RADIO OPTIONS", "", MENU_ACTION_SUBMENU, ["RADIO_OPTIONS"], nil ],
         [nil, "WAVEFORM OPTIONS", "", MENU_ACTION_SUBMENU, ["ERROR_NOENTRY"], nil ],

--- a/addons/sys_prc152/farris_menus/PGM.sqf
+++ b/addons/sys_prc152/farris_menus/PGM.sqf
@@ -378,7 +378,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                     ],
                     [
                         {
-                            private _encryption = GET_RADIO_VALUE("encryption");                            
+                            private _encryption = GET_RADIO_VALUE("encryption");
                             if (_encryption > 0) exitWith {
                                 SET_STATE("menuSelection",1);
                             };
@@ -411,7 +411,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                     [
                         {
                             private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
-                            private _tek = GET_RADIO_VALUE("TEK");                            
+                            private _tek = GET_RADIO_VALUE("TEK");
                             SET_STATE("menuSelection",_tek-1);
                         },
                         nil,
@@ -457,7 +457,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                 SET_STATE("channels",_channels);
 
                 SET_STATE("pgm_encryption",nil);
-                SET_STATE("pgm_tek",nil);                
+                SET_STATE("pgm_tek",nil);
                 
             }
         ],
@@ -493,7 +493,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                     [
                         {
                             private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
-                            private _txTone = GET_RADIO_VALUE("modulation");                            
+                            private _txTone = GET_RADIO_VALUE("modulation");
                             {
                                 if (_txTone == _x) exitWith {
                                     SET_STATE("menuSelection",_forEachIndex);
@@ -530,7 +530,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                     [
                         {
                             private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
-                            private _deviation = GET_RADIO_VALUE("deviation");                            
+                            private _deviation = GET_RADIO_VALUE("deviation");
                             {
                                 if (_deviation == parseNumber _x) exitWith {
                                     SET_STATE("menuSelection",_forEachIndex);
@@ -575,7 +575,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         HASH_SET(_channel,"optionCode",201);
                     };
                 };
-                HASH_SET(_channel,"modulation",_channelModulation);                
+                HASH_SET(_channel,"modulation",_channelModulation);
                 HASH_SET(_channel,"deviation",_channelDeviation);
 
                 HASHLIST_SET(_channels,_channelNumber,_channel);
@@ -583,7 +583,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
 
                 SET_STATE("pgm_traffic_type",nil);
                 SET_STATE("pgm_modulation",nil);
-                SET_STATE("pgm_deviation",nil);                      
+                SET_STATE("pgm_deviation",nil);
                 
             }
         ],
@@ -727,7 +727,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                             } else {
                                 SCRATCH_SET(GVAR(currentRadioId),"pgm_sq_tx_select","OFF");
                                 SET_STATE("menuSelection",0);
-                            };                           
+                            };
                             
                             private _modulationType = GET_RADIO_VALUE("modulation");  
                             switch _modulationType do {
@@ -816,7 +816,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                                     
                                     private _currentAction = GET_STATE("menuAction");
                                     _currentAction = _currentAction + 999;
-                                    SET_STATE("menuAction",_currentAction);                                    
+                                    SET_STATE("menuAction",_currentAction);
                                 };
                                 case 'CTCSS': {
                                     // Next menu is CTCSS
@@ -904,7 +904,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                 private _squelch = 0;
                 private _CTCSSTx = 0;
                 private _CTCSSRx = 0;
-                switch _sqType do {                    
+                switch _sqType do {
                     case 'TONE': {
                         _squelch = 3;
                         _CTCSSTx = 150;
@@ -920,7 +920,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                          _CTCSSTx = parseNumber _sqToneStr;
                         private _sqToneStr = SCRATCH_GET(GVAR(currentRadioId),"pgm_sq_rx_ctcss_tone");
                         _CTCSSRx = parseNumber _sqToneStr;
-                        _squelch = 3;                        
+                        _squelch = 3;
                     };
                 };
                 HASH_SET(_channel,"squelch",_squelch);

--- a/addons/sys_prc152/farris_menus/PGM.sqf
+++ b/addons/sys_prc152/farris_menus/PGM.sqf
@@ -1,5 +1,5 @@
 #include "..\script_component.hpp"
-//#define DEBUG_MODE_FULL
+#define DEBUG_MODE_FULL
 
 #define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
 
@@ -155,15 +155,15 @@ GVAR(PGM) = ["PGM", "PGM", "PGM",
 GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
     MENUTYPE_LIST,
     [
-        ["RADIO OPTIONS", "RADIO OPTIONS", "",
+        ["GENERAL CONFIG", "GENERAL CONFIG", "",
             MENUTYPE_ACTIONSERIES,
             [
                 [nil, "PRESET DESCRIPTION", "PGM-SYS PRESETS-CFG",
                     MENUTYPE_ALPHANUMERIC,
                     [
-                        [ROW_LARGE_2, ALIGN_CENTER, "PRESET DESCRIPTION"],
+                        [ROW_LARGE_2, ALIGN_CENTER, "PRESET NAME"],
                         [ROW_LARGE_3, ALIGN_LEFT, "%1"],
-                        [ROW_SMALL_5, ALIGN_CENTER, "ENTER DESCRIPTION"]
+                        [ROW_SMALL_5, ALIGN_CENTER, "ENTER ALPHANUMERIC PRESET NAME"]
                     ],
                     [
                         {
@@ -367,10 +367,225 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
             }
         ],
         ["COMSEC", "COMSEC", "PGM-SYS PRESETS-CFG",
-            MENU_ACTION_SUBMENU, ["ERROR_NOENTRY"], nil
+            MENUTYPE_ACTIONSERIES,
+            [               
+                [nil, "CRYPTO MODE", "PGM-SYS PRESETS-CFG-COMSEC",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "CRYPTO MODE"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _encryption = GET_RADIO_VALUE("encryption");                            
+                            if (_encryption > 0) exitWith {
+                                SET_STATE("menuSelection",1);
+                            };
+                        },
+                        nil,  // onExit. Our parent static display generic event handler handles the 'Next' key
+                        nil,
+                        nil,
+                        {
+                            private _check = SCRATCH_GET(GVAR(currentRadioId),"pgm_encryption");
+                            if (_check == "NONE") then {
+                                private _currentAction = GET_STATE("menuAction");
+                                _currentAction = _currentAction + 1;
+                                SET_STATE("menuAction",_currentAction);
+                            };
+                        } 
+                    ],
+                    [
+                        ["NONE", "VINSON", "ANDVT", "KG84", "FASCINATOR"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_encryption"
+                ],
+                [nil, "CRYPTO KEY", "PGM-SYS PRESETS-CFG-COMSEC",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "CRYPTO KEY"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                            private _tek = GET_RADIO_VALUE("TEK");                            
+                            SET_STATE("menuSelection",_tek-1);
+                        },
+                        nil,
+                        nil,
+                        nil,
+                        nil
+                    ],
+                    [
+                        ["TEK01", "TEK02", "TEK03"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_tek"
+                ]
+            ],
+            [nil,
+            nil],    // This will be called after every action within the action list
+             // This will get called on series completion
+            {
+                // Set the current channel to the edited preset, and save the so-far-edited values
+                private _channelEncryption = SCRATCH_GET(GVAR(currentRadioId),"pgm_encryption");
+                
+                private _channelTEK = parseNumber (SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_tek","0") SELECT [3]);
+                
+                systemChat format["pos is %1", _channelTEK];
+                private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+                private _channels = GET_STATE("channels");
+                private _channel = HASHLIST_SELECT(_channels,_channelNumber);
+                switch _channelEncryption do{
+                    default{
+                        HASH_SET(_channel,"encryption",1);
+                        HASH_SET(_channel,"trafficRate",16); 
+                        systemChat format["env is %1", 1];
+                    };
+                    case 'NONE': {
+                        HASH_SET(_channel,"encryption",0);
+                        systemChat format["env is %1", 0];
+                    };
+                };
+                               
+                HASH_SET(_channel,"TEK",_channelTEK);
+
+                HASHLIST_SET(_channels,_channelNumber,_channel);
+                SET_STATE("channels",_channels);
+
+                SET_STATE("pgm_encryption",nil);
+                SET_STATE("pgm_tek",nil);                
+                
+            }
         ],
         ["TRAFFIC", "TRAFFIC", "PGM-SYS PRESETS-CFG",
-            MENU_ACTION_SUBMENU, ["ERROR_NOENTRY"], nil
+            MENUTYPE_ACTIONSERIES,
+            [
+                
+                [nil, "TRAFFIC MODE", "PGM-SYS PRESETS-CFG-TRAFFIC",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "TRAFFIC MODE"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        nil, // onEntry
+                        nil,  // onExit. Our parent static display generic event handler handles the 'Next' key
+                        nil     // We've implemented dynamic button press handlers for static displays
+                    ],
+                    [
+                        ["VOICE", "DATA", "VOICE AND DATA"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_traffic_type"
+                ],
+                [nil, "MODULATION TYPE", "PGM-SYS PRESETS-CFG-TRAFFIC",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "MODULATION TYPE"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                            private _txTone = GET_RADIO_VALUE("modulation");                            
+                            {
+                                if (_txTone == _x) exitWith {
+                                    SET_STATE("menuSelection",_forEachIndex);
+                                };
+                            } forEach _options;
+                        },
+                        nil,
+                        nil,
+                        nil,
+                        {
+                            private _check = SCRATCH_GET(GVAR(currentRadioId),"pgm_modulation");
+                            if (_check == "AM") then {
+                                private _currentAction = GET_STATE("menuAction");
+                                _currentAction = _currentAction + 1;
+                                SET_STATE("pgm_fmd","8.0");
+
+                                SET_STATE("menuAction",_currentAction);
+                            };
+                        } 
+                    ],
+                    [
+                        ["AM", "FM", "FMNB"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_modulation"
+                ],
+                [nil, "FM DEVIATION", "PGM-SYS PRESETS-CFG-TRAFFIC",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "FM DEVIATION"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                            private _deviation = GET_RADIO_VALUE("deviation");                            
+                            {
+                                if (_deviation == parseNumber _x) exitWith {
+                                    SET_STATE("menuSelection",_forEachIndex);
+                                };
+                            } forEach _options;
+                        },
+                        nil,
+                        nil // We've implemented dynamic button press handlers for static displays
+                    ],
+                    [
+                        ["8.0 kHz","6.5 kHz","5.0 kHz","2.5 kHz"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_deviation"
+                ]
+                
+            ],
+            [nil,
+            nil],    // This will be called after every action within the action list
+             // This will get called on series completion
+            {
+                // Set the current channel to the edited preset, and save the so-far-edited values
+                private _channelModulation = SCRATCH_GET(GVAR(currentRadioId),"pgm_modulation");
+                private _channelDeviation = parseNumber SCRATCH_GET(GVAR(currentRadioId),"pgm_deviation");
+                
+                private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+                private _channels = GET_STATE("channels");
+                private _channel = HASHLIST_SELECT(_channels,_channelNumber);
+
+                switch _channelModulation do{
+                    case "AM": {
+                        HASH_SET(_channel,"squelch",0);
+                        HASH_SET(_channel,"CTCSSTx",0);
+                        HASH_SET(_channel,"CTCSSRx",0);
+                        HASH_SET(_channel,"optionCode",200);
+                    };
+                    case "FMNB": {
+                        _channelModulation="NB";
+                        HASH_SET(_channel,"optionCode",201);
+                    };
+                    case "FM": {
+                        HASH_SET(_channel,"optionCode",201);
+                    };
+                };
+                HASH_SET(_channel,"modulation",_channelModulation);                
+                HASH_SET(_channel,"deviation",_channelDeviation);
+
+                HASHLIST_SET(_channels,_channelNumber,_channel);
+                SET_STATE("channels",_channels);
+
+                SET_STATE("pgm_traffic_type",nil);
+                SET_STATE("pgm_modulation",nil);
+                SET_STATE("pgm_deviation",nil);                      
+                
+            }
         ],
         ["TX POWER", "TX POWER", "PGM-SYS PRESETS-CFG",
             MENUTYPE_ACTIONSERIES,
@@ -411,7 +626,9 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         nil,
                         {
                             // If we are not in user mode, just skip this menu item
+                            
                             private _check = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_tx_select","HIGH");
+                            
                             if (_check != "USER") then {
                                 private _currentAction = GET_STATE("menuAction");
                                 _currentAction = _currentAction + 1;
@@ -467,7 +684,6 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                 private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
                 private _channels = GET_STATE("channels");
                 private _channel = HASHLIST_SELECT(_channels,_channelNumber);
-
                 if (_power > 5000) then {
                     _power = 5000;
                 };
@@ -483,7 +699,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
         ["SQUELCH", "SQUELCH", "PGM-SYS PRESETS-CFG",
             MENUTYPE_ACTIONSERIES,
             [
-                [nil, "SQUELCH TYPE", "PGM-SYS PRESETS-SQUELCH",
+                [nil, "SQUELCH TYPEFM", "PGM-SYS PRESETS-SQUELCH",
                     MENUTYPE_SELECTION,
                     [
                         [ROW_LARGE_2, ALIGN_CENTER, "SQUELCH TYPE"],
@@ -492,16 +708,26 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                     ],
                     [
                         {
-                            private _sqType = GET_RADIO_VALUE("squelch");
+                            private _sqType = GET_RADIO_VALUE("squelch");                           
                             switch _sqType do {
                                 default {
-
+                                    SCRATCH_SET(GVAR(currentRadioId),"pgm_sq_tx_select","TONE");
+                                    SET_STATE("menuSelection",1);
                                 };
                                 case 3: {
                                     SCRATCH_SET(GVAR(currentRadioId),"pgm_sq_tx_select","CTCSS");
-                                    SET_STATE("menuSelection",1);
+                                    SET_STATE("menuSelection",3);
                                 };
                             };
+                            private _modulationType = GET_RADIO_VALUE("modulation");  
+                            switch _modulationType do {
+                                default {};
+                                case 'AM': {
+                                    private _currentAction = GET_STATE("menuAction");
+                                    _currentAction = _currentAction + 999;
+                                    SET_STATE("menuAction",_currentAction);
+                                };
+                            }
                         },
                         nil,
                         nil,
@@ -521,7 +747,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         }
                     ],
                     [
-                        ["DISABLED", "CTCSS", "CDCSS", "NOISE", "TONE"],
+                        ["OFF","TONE","NOISE", "CTCSS", "CDCSS"],
                         [ROW_LARGE_3, 0, -1]
                     ],
                     "pgm_sq_tx_select"
@@ -573,6 +799,19 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         nil,
                         {
                             //_sqTone = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_tx_ctcss_tone","250.3");
+                            private _sqType = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_rx_select","CTCSS");
+                            switch _sqType do {
+                                default {        // Default is go to end, we only have 1 configurable SQ for now
+                                    SCRATCH_SET(GVAR(currentRadioId),"pgm_sq_rx_ctcss_tone", "0");
+                                    
+                                    private _currentAction = GET_STATE("menuAction");
+                                    _currentAction = _currentAction + 999;
+                                    SET_STATE("menuAction",_currentAction);                                    
+                                };
+                                case 'CTCSS': {
+                                    // Next menu is CTCSS
+                                };
+                            };
                         }
                     ],
                     [
@@ -580,6 +819,36 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         [ROW_LARGE_3, 0, -1]
                     ],
                     "pgm_sq_rx_select"
+                ],
+                [nil, "CTCSS_TONE_RX", "PGM-SYS PRESETS-SQUELCH-CTCSS",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "CTCSS RX TONE"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                            private _txTone = SCRATCH_GET(GVAR(currentRadioId),"pgm_sq_tx_ctcss_tone");
+                            {
+                                if (_txTone ==  _x )exitWith {
+                                    SET_STATE("menuSelection",_forEachIndex);
+                                };
+                            } forEach _options;
+                        },
+                        nil,
+                        nil,
+                        nil,
+                        {
+                            //_sqTone = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_tx_ctcss_tone","250.3");
+                        }
+                    ],
+                    [
+                        ["67.0", "69.3", "71.9", "74.4", "77.0", "79.7", "82.5", "85.4", "88.5", "91.5", "94.8", "97.4", "100.0", "103.5", "107.2", "110.9", "114.8", "118.8", "123.0", "127.3", "131.8", "136.5", "141.3", "146.2", "151.4", "156.7", "162.2", "167.9", "173.8", "179.9", "186.2", "192.8", "203.5", "206.5", "210.7", "218.1", "225.7", "229.1", "233.6", "241.8", "250.3", "254.1" ],
+                        [ROW_LARGE_3, 0, -1]
+                    ],
+                    "pgm_sq_rx_ctcss_tone"
                 ],
                 [nil, "CHAN_BUSY_PRIORITY", "PGM-SYS PRESETS-SQUELCH",
                     MENUTYPE_SELECTION,
@@ -617,27 +886,33 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
             {
                 TRACE_1("Saving top level squelch information","");
 
-                private _sqType = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_tx_select","CTCSS");
+                private _sqType = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_tx_select","NOISE");
                 TRACE_1("SQUELCH TYPE",_sqType);
+                private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+                private _channels = GET_STATE("channels");
+                private _channel = HASHLIST_SELECT(_channels,_channelNumber);
+
                 switch _sqType do {
-                    default { };
+                    default { 
+                        HASH_SET(_channel,"squelch",0);
+                        HASH_SET(_channel,"CTCSSTx",0);
+                        HASH_SET(_channel,"CTCSSRx",0);
+                    };
                     case 'CTCSS': {
                         private _sqToneStr = SCRATCH_GET(GVAR(currentRadioId),"pgm_sq_tx_ctcss_tone");
-                        private _value = parseNumber _sqToneStr;
+                        private _txValue = parseNumber _sqToneStr;
+                        private _sqToneStr = SCRATCH_GET(GVAR(currentRadioId),"pgm_sq_rx_ctcss_tone");
+                        private _rxValue = parseNumber _sqToneStr;
                         TRACE_3("Set squelch",_sqType,_sqToneStr,_value);
-
-
-                        private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
-                        private _channels = GET_STATE("channels");
-                        private _channel = HASHLIST_SELECT(_channels,_channelNumber);
-
                         HASH_SET(_channel,"squelch",3);
-                        HASH_SET(_channel,"CTCSSTx",_value);
-                        HASH_SET(_channel,"CTCSSRx",_value);
-
-                        SET_STATE("channels",_channels);
+                        HASH_SET(_channel,"CTCSSTx",_txValue);
+                        HASH_SET(_channel,"CTCSSRx",_rxValue);
                     };
                 };
+                
+                
+
+                SET_STATE("channels",_channels);
             }
         ],
         ["EXIT", "EXIT", "PGM-SYS PRESETS-CFG", MENU_ACTION_SUBMENU, ["HOME"], [], nil ]

--- a/addons/sys_prc152/farris_menus/PGM.sqf
+++ b/addons/sys_prc152/farris_menus/PGM.sqf
@@ -1,5 +1,5 @@
 #include "..\script_component.hpp"
-#define DEBUG_MODE_FULL
+//#define DEBUG_MODE_FULL
 
 #define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
 
@@ -435,7 +435,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                 
                 private _channelTEK = parseNumber (SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_tek","0") SELECT [3]);
                 
-                systemChat format["pos is %1", _channelTEK];
+                
                 private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
                 private _channels = GET_STATE("channels");
                 private _channel = HASHLIST_SELECT(_channels,_channelNumber);
@@ -443,11 +443,11 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                     default{
                         HASH_SET(_channel,"encryption",1);
                         HASH_SET(_channel,"trafficRate",16); 
-                        systemChat format["env is %1", 1];
+
                     };
                     case 'NONE': {
                         HASH_SET(_channel,"encryption",0);
-                        systemChat format["env is %1", 0];
+
                     };
                 };
                                

--- a/addons/sys_prc152/farris_menus/PGM.sqf
+++ b/addons/sys_prc152/farris_menus/PGM.sqf
@@ -420,7 +420,7 @@ GVAR(PGMChannelMenu) = ["PGM PRESET", "PGM PRESET", "PGM-SYS PRESETS-CFG",
                         nil
                     ],
                     [
-                        ["TEK01", "TEK02", "TEK03"],
+                        ["TEK01", "TEK02", "TEK03", "TEK04", "TEK05", "TEK06", "TEK07", "TEK08", "TEK09", "TEK10", "TEK11", "TEK12", "TEK13", "TEK14", "TEK15", "TEK16", "TEK17", "TEK18", "TEK19", "TEK20", "TEK21", "TEK22", "TEK23", "TEK24", "TEK25"],
                         [ROW_LARGE_3, 0, -1] // Highlighting cursor information
                     ],
                     "pgm_tek"

--- a/addons/sys_prc152/fnc_formatChannelValue.sqf
+++ b/addons/sys_prc152/fnc_formatChannelValue.sqf
@@ -18,6 +18,7 @@
 
 params ["_name","_value"];
 
+#define SQUELCH_NOISE 0
 #define SQUELCH_CTCSS 3
 
 TRACE_1("Formatting",_this);
@@ -33,16 +34,22 @@ switch _name do {
         _value = [_value, 3, 4] call CBA_fnc_formatNumber;
     };
     case "encryption": {
-        if (_value > 1) then { _value = "CT"; } else { _value = "PT"; };
+        if (_value == 1) then { _value = "VINSON CT"; } else { _value = "------ PT"; };
     };
-    case "channelMode": {
+    case "channelmode": {
         switch _value do {
             case "BASIC": { _value = "VULOS"; }
         };
     };
+    case "tek": {
+        switch _value do {
+            if (_value < 10) then { _value = format["0%1",_value]; } else { };
+        };
+    };
     case "squelch": {
         switch _value do {
-            case SQUELCH_CTCSS: { _value = "TCS"; }
+            case SQUELCH_NOISE: { _value = "NOI"; };
+            case SQUELCH_CTCSS: { _value = "TCS"; };
         };
     };
 };

--- a/addons/sys_prc152/fnc_formatChannelValue.sqf
+++ b/addons/sys_prc152/fnc_formatChannelValue.sqf
@@ -21,6 +21,9 @@ params ["_name","_value"];
 #define SQUELCH_NOISE 0
 #define SQUELCH_CTCSS 3
 
+#define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
+#define GET_CHANNEL_DATA [] call FUNC(CURRENT_RADIO_CHANNEL);
+
 TRACE_1("Formatting",_this);
 
 switch _name do {
@@ -47,9 +50,19 @@ switch _name do {
         };
     };
     case "squelch": {
-        switch _value do {
-            case SQUELCH_NOISE: { _value = "NOI"; };
-            case SQUELCH_CTCSS: { _value = "TCS"; };
+        private _channel = GET_CHANNEL_DATA;
+        private _ctcss = HASH_GET(_channel,"CTCSSTx");
+
+        if (_value > 0) then {
+            _value = "TON";
+            if (_ctcss != 150) then {
+                _value = "TCS";
+            };
+            if (_ctcss == 0) then {
+                _value = "NOI";
+            };
+        } else{
+            _value = "OFF";
         };
     };
 };

--- a/addons/sys_prc152/menus/fnc_drawCursor.sqf
+++ b/addons/sys_prc152/menus/fnc_drawCursor.sqf
@@ -80,11 +80,11 @@ for "_i" from _start to (_start+_len) do {
     private _textCtrl = _display displayCtrl (_id+_i);
     if (_highlight) then {
 
-        _textCtrl ctrlSetBackgroundColor [0.2, 0.2, 0.2, 1];
-        _textCtrl ctrlSetTextColor [115/255, 126/255, 42/255, 1];
+        _textCtrl ctrlSetBackgroundColor [0.1, 0.1, 0.1, 1];
+        _textCtrl ctrlSetTextColor [82/255, 85/255, 74/255, 1];
     } else {
-        _textCtrl ctrlSetBackgroundColor [0.2, 0.2, 0.2 ,0];
-        _textCtrl ctrlSetTextColor [0.2, 0.2, 0.2, 1]
+        _textCtrl ctrlSetBackgroundColor [0.1, 0.1, 0.1 ,0];
+        _textCtrl ctrlSetTextColor [0.1, 0.1, 0.1, 1]
     };
     _textCtrl ctrlCommit 0;
 };

--- a/addons/sys_prc152/menus/fnc_formatText.sqf
+++ b/addons/sys_prc152/menus/fnc_formatText.sqf
@@ -89,8 +89,12 @@ if (_result != -1) then {
     TRACE_2("channel data",_channelNumber,_channel);
     {
         private _repStr = "$cch-" + _x;
+        
         private _value = [ _x, HASH_GET(_channel,_x) ] call FUNC(formatChannelValue);
         TRACE_3("Calling replace",_text,_repStr,_value);
+        if (_x == 'tek' && HASH_GET(_channel,'encryption') == 0) then {
+            _value = '---';
+        }; //One off replacement so key isn't shown in PT... not super elegant
         _result = [_text, _x] call CBA_fnc_find;
         if (_result != -1) then {
             _text = [_text, _repStr, _value] call CBA_fnc_replace;


### PR DESCRIPTION
-Refactored the "main" menu to be more realistic, display things like encryption, squelch and TEK correctly
-Fleshed out PGM->TRAFFIC so that AM/FM/FMNB and FM Deviation can be selected
-Fixed PGM->SQUELTCH such that you can actually disable CTCSS now
-Implemented PGM->COMSEC. Mostly eye candy, but can enable encryption and change the TEK this way

Essentially all the settings can be changed now, just like the PRC-148