### PR TITLE
PRC-117F - Add/Fix PGM Features

### DIFF
--- a/addons/sys_prc117f/farris_menus/Main.sqf
+++ b/addons/sys_prc117f/farris_menus/Main.sqf
@@ -24,7 +24,7 @@ GVAR(INVALID_MODE) = ["INVALID_MODE", "INVALID_MODE", "",
     [
         //[ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
         [ROW_XLARGE_1, ALIGN_LEFT, "INVALID MODE"],
-        [ROW_LARGE_3, ALIGN_LEFT, "ONLY PT SUPPORTED"]
+        [ROW_LARGE_3, ALIGN_LEFT, "ONLY PT/CT SUPPORTED"]
     ],
     [
         nil, // onEntry
@@ -37,7 +37,7 @@ GVAR(INVALID_MODE) = ["INVALID_MODE", "INVALID_MODE", "",
 GVAR(NoItems) = ["ERROR_NOENTRY", "ERROR_NOENTRY", "",
     MENUTYPE_STATIC,
     [
-        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat      $cch-channelmode              $cch-encryption"],
+        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting VOL         $cch-channelmode $cch-squelch $cch-encryption"],
         [ROW_LARGE_2, ALIGN_LEFT, "<NO ITEMS IN MENU>"],
         [ROW_SMALL_5, ALIGN_CENTER, "ENT OR CLR TO CONT"]
     ],
@@ -86,7 +86,7 @@ GVAR(NOT_IMPLEMENTED) = ["NOT_IMPLEMENTED", "NOT_IMPLEMENTED", "",
 GVAR(VOLUME) = ["VOLUME", "VOLUME", "",
     MENUTYPE_STATIC,
     [
-        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting VOL         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+        [ROW_SMALL_1, ALIGN_LEFT, "$transmitting VOL         $cch-channelmode $cch-squelch $cch-encryption"],
         [ROW_LARGE_2, ALIGN_CENTER, "VOLUME"]
     ],
     [
@@ -115,7 +115,7 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-MAIN", "VULOSHOME-MAIN", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat      $cch-channelmode              $cch-encryption"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting VOL     $cch-channelmode $cch-tek $cch-encryption"],
                 [ROW_LARGE_2, ALIGN_LEFT, "$cch-number-$cch-name"],
                 [ROW_LARGE_3, ALIGN_LEFT, "LOS  VOC  OFF $cch-modulation   $cch-squelch"],
                 [ROW_SMALL_5, ALIGN_LEFT, "TYPE    ADF   DATA  MOD     SQL"]
@@ -147,7 +147,7 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-CHANNEL", "VULOSHOME-CHANNEL", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting VOL         $cch-channelmode $cch-squelch $cch-encryption"],
                 [ROW_LARGE_2, ALIGN_LEFT, "R: $cch-frequencyrx"],
                 [ROW_LARGE_3, ALIGN_LEFT, "T: $cch-frequencytx              $cch-trafficrate "],
                 [ROW_SMALL_5, ALIGN_LEFT, " FREQUENCY            RATE"]
@@ -175,7 +175,7 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-DATA", "VULOSHOME-DATA", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting VOL         $cch-channelmode $cch-squelch $cch-encryption"],
                 [ROW_LARGE_2, ALIGN_LEFT, "--- -----   --"],
                 [ROW_LARGE_3, ALIGN_LEFT, "$cch-optioncode ---- ANLG --   OFF"],
                 [ROW_SMALL_5, ALIGN_LEFT, "OPT   DATA   VOICE  INTLV   FEC"]
@@ -203,7 +203,7 @@ GVAR(VULOSHOME) = ["VULOSHOME", "VULOSHOME", "",
         ["VULOSHOME-LARGEFONT", "VULOSHOME-LARGEFONT", "",
             MENUTYPE_STATIC,
             [
-                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting $bat         $cch-channelmode $cch-squelch ----- $cch-encryption"],
+                [ROW_SMALL_1, ALIGN_LEFT, "$transmitting VOL         $cch-channelmode $cch-squelch $cch-encryption"],
                 [ROW_XLARGE_2, ALIGN_LEFT, "$cch-number*$cch-name"]
             ],
             [

--- a/addons/sys_prc117f/farris_menus/PGM.sqf
+++ b/addons/sys_prc117f/farris_menus/PGM.sqf
@@ -334,7 +334,101 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                 SET_STATE("pgm_rx_only",nil);
             }
         ],
-        [nil, "COMSEC", "", MENU_ACTION_SUBMENU, ["ERROR_NOENTRY"], nil ],
+        ["COMSEC", "COMSEC", "", 
+            MENUTYPE_ACTIONSERIES,
+            [               
+                [nil, "CRYPTO MODE", "",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "CRYPTO MODE"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _encryption = GET_RADIO_VALUE("encryption");                            
+                            if (_encryption > 0) exitWith {
+                                SET_STATE("menuSelection",1);
+                            };
+                        },
+                        nil,  // onExit. Our parent static display generic event handler handles the 'Next' key
+                        nil,
+                        nil,
+                        {
+                            private _check = SCRATCH_GET(GVAR(currentRadioId),"pgm_encryption");
+                            systemChat "WTF";
+                            if (_check == "NONE") then {
+                                systemChat "WTF";
+                                private _currentAction = GET_STATE("menuAction");
+                                _currentAction = _currentAction + 1;
+                                SET_STATE("menuAction",_currentAction);
+                            };
+                        } 
+                    ],
+                    [
+                        ["NONE", "VINSON",  "KG84", "FASCINATOR"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_encryption"
+                ],
+                [nil, "ENCRYPTION KEY", "",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "ENCRYPTION KEY"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                            private _tek = GET_RADIO_VALUE("TEK");                            
+                            SET_STATE("menuSelection",_tek-1);
+                        },
+                        nil,
+                        nil,
+                        nil,
+                        nil
+                    ],
+                    [
+                        ["TEK01", "TEK02", "TEK03", "TEK04", "TEK05", "TEK06", "TEK07", "TEK08", "TEK09", "TEK10", "TEK11", "TEK12", "TEK13", "TEK14", "TEK15", "TEK16", "TEK17", "TEK18", "TEK19", "TEK20", "TEK21", "TEK22", "TEK23", "TEK24", "TEK25"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_tek"
+                ]
+            ],
+            [nil,
+            nil],    // This will be called after every action within the action list
+             // This will get called on series completion
+            {
+                // Set the current channel to the edited preset, and save the so-far-edited values
+                private _channelEncryption = SCRATCH_GET(GVAR(currentRadioId),"pgm_encryption");
+
+                private _channelTEK = parseNumber (SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_tek","0") SELECT [3]);
+
+
+                private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+                private _channels = GET_STATE("channels");
+                private _channel = HASHLIST_SELECT(_channels,_channelNumber);
+                switch _channelEncryption do{
+                    default{
+                        HASH_SET(_channel,"trafficRate",16);
+                        HASH_SET(_channel,"TEK",_channelTEK);
+                    };
+                    case 'NONE': {
+                        HASH_SET(_channel,"TEK",1);
+                    };
+                };
+
+                
+
+                HASHLIST_SET(_channels,_channelNumber,_channel);
+                SET_STATE("channels",_channels);
+
+                SET_STATE("pgm_encryption",nil);
+                SET_STATE("pgm_tek",nil);                
+
+            }
+        ],
         ["DATA/VOC", "DATA/VOC", "", 
             MENUTYPE_ACTIONSERIES,
             [                

--- a/addons/sys_prc117f/farris_menus/PGM.sqf
+++ b/addons/sys_prc117f/farris_menus/PGM.sqf
@@ -336,7 +336,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
         ],
         ["COMSEC", "COMSEC", "", 
             MENUTYPE_ACTIONSERIES,
-            [               
+            [
                 [nil, "CRYPTO MODE", "",
                     MENUTYPE_SELECTION,
                     [
@@ -346,7 +346,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                     ],
                     [
                         {
-                            private _encryption = GET_RADIO_VALUE("encryption");                            
+                            private _encryption = GET_RADIO_VALUE("encryption");
                             if (_encryption > 0) exitWith {
                                 SET_STATE("menuSelection",1);
                             };
@@ -380,7 +380,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                     [
                         {
                             private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
-                            private _tek = GET_RADIO_VALUE("TEK");                            
+                            private _tek = GET_RADIO_VALUE("TEK");
                             SET_STATE("menuSelection",_tek-1);
                         },
                         nil,
@@ -424,13 +424,13 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                 SET_STATE("channels",_channels);
 
                 SET_STATE("pgm_encryption",nil);
-                SET_STATE("pgm_tek",nil);                
+                SET_STATE("pgm_tek",nil);
 
             }
         ],
         ["DATA/VOC", "DATA/VOC", "", 
             MENUTYPE_ACTIONSERIES,
-            [                
+            [
                 [nil, "VOICE MODE", "",
                     MENUTYPE_SELECTION,
                     [
@@ -459,7 +459,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                     [
                          {
                             private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
-                            private _txTone = GET_RADIO_VALUE("modulation");                            
+                            private _txTone = GET_RADIO_VALUE("modulation");
                             {
                                 if (_txTone == _x) exitWith {
                                     SET_STATE("menuSelection",_forEachIndex);
@@ -496,7 +496,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                     [
                         {
                             private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
-                            private _deviation = GET_RADIO_VALUE("deviation");                            
+                            private _deviation = GET_RADIO_VALUE("deviation");
                             {
                                 if (_deviation == parseNumber _x) exitWith {
                                     SET_STATE("menuSelection",_forEachIndex);
@@ -534,7 +534,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                         HASH_SET(_channel,"optionCode",201);
                     };
                 };
-                HASH_SET(_channel,"modulation",_channelModulation);                
+                HASH_SET(_channel,"modulation",_channelModulation);
                 HASH_SET(_channel,"deviation",_channelDeviation);
 
                 HASHLIST_SET(_channels,_channelNumber,_channel);

--- a/addons/sys_prc117f/farris_menus/PGM.sqf
+++ b/addons/sys_prc117f/farris_menus/PGM.sqf
@@ -356,9 +356,8 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                         nil,
                         {
                             private _check = SCRATCH_GET(GVAR(currentRadioId),"pgm_encryption");
-                            systemChat "WTF";
+                            
                             if (_check == "NONE") then {
-                                systemChat "WTF";
                                 private _currentAction = GET_STATE("menuAction");
                                 _currentAction = _currentAction + 1;
                                 SET_STATE("menuAction",_currentAction);
@@ -540,7 +539,6 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
 
                 HASHLIST_SET(_channels,_channelNumber,_channel);
                 SET_STATE("channels",_channels);
-
                 SET_STATE("pgm_modulation",nil);
                 SET_STATE("pgm_deviation",nil);  
             }

--- a/addons/sys_prc117f/farris_menus/PGM.sqf
+++ b/addons/sys_prc117f/farris_menus/PGM.sqf
@@ -233,12 +233,12 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
         ["FREQ", "FREQ", "",
             MENUTYPE_ACTIONSERIES,
             [
-                [nil, "RX FREQUENCY", "",
+                [nil, "RECEIVE FREQUENCY", "",
                     MENUTYPE_FREQUENCY,
                     [
-                        [ROW_LARGE_2, ALIGN_CENTER, "RX FREQUENCY"],
+                        [ROW_LARGE_2, ALIGN_CENTER, "RECEIVE FREQUENCY"],
                         [ROW_LARGE_3, ALIGN_CENTER, "%1"],
-                        [ROW_SMALL_5, ALIGN_CENTER, "ENTER FREQUENCY"]
+                        [ROW_SMALL_5, ALIGN_CENTER, "30 MHz - 51.99999 MHz"]
                     ],
                     [
                         {
@@ -249,7 +249,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                         nil     // We've implemented dynamic button press handlers for static displays
                     ],
                     [
-                        0.0001,  // min number/start default
+                        30,  // min number/start default
                         599.9999,  // Max number
                         7,    // Digit count
                         [ROW_LARGE_3, 0, 1] // Highlighting cursor information
@@ -259,9 +259,9 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                 [nil, "TX FREQUENCY", "",
                     MENUTYPE_FREQUENCY,
                     [
-                        [ROW_LARGE_2, ALIGN_CENTER, "TX FREQUENCY"],
+                        [ROW_LARGE_2, ALIGN_CENTER, "TRANSMIT FREQUENCY"],
                         [ROW_LARGE_3, ALIGN_CENTER, "%1"],
-                        [ROW_SMALL_5, ALIGN_CENTER, "ENTER FREQUENCY"]
+                        [ROW_SMALL_5, ALIGN_CENTER, "30 MHz - 51.99999 MHz"]
                     ],
                     [
                         {
@@ -272,7 +272,7 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
                         nil     // We've implemented dynamic button press handlers for static displays
                     ],
                     [
-                        1,  // min number/start default
+                        30,  // min number/start default
                         599.9999,  // Max number
                         7,    // Digit count
                         [ROW_LARGE_3, 0, 1] // Highlighting cursor information
@@ -335,9 +335,124 @@ GVAR(PGM_NORM_LOS) = ["PGM_NORM_LOS", "PGM_NORM_LOS", "",
             }
         ],
         [nil, "COMSEC", "", MENU_ACTION_SUBMENU, ["ERROR_NOENTRY"], nil ],
-        [nil, "DATA", "", MENU_ACTION_SUBMENU, ["ERROR_NOENTRY"], nil ],
-        [nil, "SQUELCH", "", MENU_ACTION_SUBMENU, ["SQ"], nil ],
-        [nil, "TXPOWER", "",
+        ["DATA/VOC", "DATA/VOC", "", 
+            MENUTYPE_ACTIONSERIES,
+            [                
+                [nil, "VOICE MODE", "",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "VOICE MODE"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        nil,
+                        nil,
+                        nil
+                    ],
+                    [
+                        ["CLEAR", "MODEM"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_voice_mode"
+                ],
+                [nil, "MODULATION", "",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "MODULATION"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                         {
+                            private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                            private _txTone = GET_RADIO_VALUE("modulation");                            
+                            {
+                                if (_txTone == _x) exitWith {
+                                    SET_STATE("menuSelection",_forEachIndex);
+                                };
+                            } forEach _options;
+                        },
+                        nil,
+                        nil,
+                        nil,
+                        {
+                            private _check = SCRATCH_GET(GVAR(currentRadioId),"pgm_modulation");
+                            if (_check == "AM") then {
+                                private _currentAction = GET_STATE("menuAction");
+                                _currentAction = _currentAction + 1;
+                                SET_STATE("pgm_fmd","8.0");
+
+                                SET_STATE("menuAction",_currentAction);
+                            };
+                        }
+                    ],
+                    [
+                        ["AM", "FM"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_modulation"
+                ],
+                [nil, "FM DEVIATION", "",
+                    MENUTYPE_SELECTION,
+                    [
+                        [ROW_LARGE_2, ALIGN_CENTER, "FM DEVIATION"],
+                        [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                        [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+                    ],
+                    [
+                        {
+                            private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                            private _deviation = GET_RADIO_VALUE("deviation");                            
+                            {
+                                if (_deviation == parseNumber _x) exitWith {
+                                    SET_STATE("menuSelection",_forEachIndex);
+                                };
+                            } forEach _options;
+                        },
+                        nil,
+                        nil // We've implemented dynamic button press handlers for static displays
+                    ],
+                    [
+                        ["8.0 kHz","6.5 kHz","5.0 kHz"],
+                        [ROW_LARGE_3, 0, -1] // Highlighting cursor information
+                    ],
+                    "pgm_deviation"
+                ]
+            ],
+            [nil, nil],
+            {
+                 // Set the current channel to the edited preset, and save the so-far-edited values
+                private _channelModulation = SCRATCH_GET(GVAR(currentRadioId),"pgm_modulation");
+                private _channelDeviation = parseNumber SCRATCH_GET(GVAR(currentRadioId),"pgm_deviation");
+                
+                private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+                private _channels = GET_STATE("channels");
+                private _channel = HASHLIST_SELECT(_channels,_channelNumber);
+
+                switch _channelModulation do{
+                    case "AM": {
+                        HASH_SET(_channel,"squelch",0);
+                        HASH_SET(_channel,"CTCSSTx",0);
+                        HASH_SET(_channel,"CTCSSRx",0);
+                        HASH_SET(_channel,"optionCode",200);
+                    };
+                    case "FM": {
+                        HASH_SET(_channel,"optionCode",201);
+                    };
+                };
+                HASH_SET(_channel,"modulation",_channelModulation);                
+                HASH_SET(_channel,"deviation",_channelDeviation);
+
+                HASHLIST_SET(_channels,_channelNumber,_channel);
+                SET_STATE("channels",_channels);
+
+                SET_STATE("pgm_modulation",nil);
+                SET_STATE("pgm_deviation",nil);  
+            }
+        ],
+        [nil, "SQ", "", MENU_ACTION_SUBMENU, ["SQ"], nil ],
+        [nil, "PWR", "",
             MENUTYPE_SELECTION,
             [
                 [ROW_LARGE_2, ALIGN_CENTER, "TX POWER LEVEL"],

--- a/addons/sys_prc117f/farris_menus/SQ.sqf
+++ b/addons/sys_prc117f/farris_menus/SQ.sqf
@@ -333,13 +333,13 @@ GVAR(SQ_SELECT_CTCSS) = ["SQ_SELECT_CTCSS", "SQ_SELECT_CTCSS", "",
                             
                             private _currentAction = GET_STATE("menuAction");
                             _currentAction = _currentAction + 999;
-                            SET_STATE("menuAction",_currentAction);                                    
+                            SET_STATE("menuAction",_currentAction);
                         };
                         case 'CTCSS': {
                             // Next menu is CTCSS
                         };
                     };
-                }                    
+                }
             ],
             [
                 ["DISABLED", "CTCSS", "NOISE"],

--- a/addons/sys_prc117f/farris_menus/SQ.sqf
+++ b/addons/sys_prc117f/farris_menus/SQ.sqf
@@ -19,10 +19,10 @@
 #define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
 #define GET_CHANNEL_DATA [] call FUNC(CURRENT_RADIO_CHANNEL);
 
-GVAR(SQ_ONLY_AM) = ["SQ_ONLY_AM", "SQ_ONLY_AM", "",
+GVAR(SQ_ONLY_AM) = ["SQ_ONLY_FM", "SQ_ONLY_FM", "",
     MENUTYPE_STATIC,
     [
-        [ROW_LARGE_2, ALIGN_CENTER, "N/A FOR FM MODULATION"]
+        [ROW_LARGE_2, ALIGN_CENTER, "N/A FOR AM MODULATION"]
     ],
     [
         {
@@ -123,7 +123,12 @@ GVAR(SQ_NO_DIGITAL) = ["SQ_NO_DIGITAL", "SQ_NO_DIGITAL", "",
                             _mode = "TONE";
                         };
                     } else {
-                        _mode = "OFF";
+                        if (_squelch == 0) then {
+                            _mode = "OFF";
+                        } else {
+                            _mode = "NOISE";
+                        };
+                        
                     };
 
                     private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
@@ -155,46 +160,41 @@ GVAR(SQ_NO_DIGITAL) = ["SQ_NO_DIGITAL", "SQ_NO_DIGITAL", "",
         //Call on series completion
         private _selectAnalogSquelch = SCRATCH_GET(GVAR(currentRadioID),"sq_select_analog");
         private _channel = GET_CHANNEL_DATA;
-        private _CTCSS = HASH_GET(_channel,"CTCSSRx");
+        private _CTCSSTx = HASH_GET(_channel,"CTCSSTx");
+        private _CTCSSRx = HASH_GET(_channel,"CTCSSRx");
         private _squelch = HASH_GET(_channel,"squelch");
         private _modulation = HASH_GET(_channel,"modulation");
 
-        switch _selectAnalogSquelch do {
-            case 'OFF': {_selectAnalogSquelch = 0; _CTCSS = 0; _squelch = 0; };
-            case 'TONE': {_selectAnalogSquelch = 1; _CTCSS = 150; _squelch = 3; };
-            case 'NOISE': {_selectAnalogSquelch = 2;  _CTCSS = 0; };
-            case 'CTCSS': {_selectAnalogSquelch = 3; _squelch = 3; };
-            case 'CDCSS': {_selectAnalogSquelch = 4; };
-            default {_selectAnalogSquelch = -1; };
+        private _nextMenu = "";
+        if (_modulation == "FM") then{
+            switch _selectAnalogSquelch do {
+                case 'OFF': {_CTCSSTx = 0; _CTCSSRx = 0; _squelch = 0; };
+                case 'TONE': {_CTCSSTx = 150; _CTCSSRx = 150;; _squelch = 3; };
+                case 'NOISE': {_CTCSSTx = 0; _CTCSSRx = 0; _squelch = 3;};
+                case 'CTCSS': {_squelch = 3; _nextMenu="SQ_SELECT_CTCSS";};
+                case 'CDCSS': {_nextMenu="NOT_IMPLEMENTED";};
+                default {_selectAnalogSquelch = -1;_nextMenu="ERROR_NOENTRY";};
+            };
+        } else {
+            switch _selectAnalogSquelch do {
+                case 'OFF': {_CTCSSTx = 0; _CTCSSRx = 0; _squelch = 0; };
+                case 'NOISE': { _CTCSSTx = 0; _CTCSSRx = 0; _nextMenu="SQ_SELECT_SQUELCH";};                
+                default {_selectAnalogSquelch = 2;  _CTCSSTx = 0; _CTCSSRx = 0; _nextMenu="SQ_ONLY_FM";};
+            };
         };
-
-        if (_selectAnalogSquelch < 0) exitWith {
-            ["ERROR_NOENTRY"] call FUNC(changeMenu);
-        };
-
-        HASH_SET(_channel,"CTCSSTx",_CTCSS);
-        HASH_SET(_channel,"CTCSSRx",_CTCSS);
+        
+        HASH_SET(_channel,"CTCSSTx",_CTCSSTx);
+        HASH_SET(_channel,"CTCSSRx",_CTCSSRx);
         HASH_SET(_channel,"squelch",_squelch);
 
         SCRATCH_SET(GVAR(currentRadioID),"sq_select_analog",nil);
-
-        if (_selectAnalogSquelch > 1) exitWith {
-            if (_selectAnalogSquelch > 2) exitWith {
-                if (_selectAnalogSquelch > 3) exitWith {
-                    ["NOT_IMPLEMENTED"] call FUNC(changeMenu);
-                    true
-                };
-                ["SQ_SELECT_CTCSS"] call FUNC(changeMenu);
-                true
-            };
-            if (_modulation == "AM") then {
-                ["SQ_SELECT_SQUELCH"] call FUNC(changeMenu);
-                true
-            } else {
-                ["SQ_ONLY_AM"] call FUNC(changeMenu);
-                true
-            };
+        _selectAnalogSquelch = 4;
+        
+        if (_nextMenu != "") exitWith {
+            
+            [_nextMenu] call FUNC(changeMenu);
         };
+        
         private _home = GET_STATE_DEF("currentHome",GVAR(VULOSHOME));
         [_home] call FUNC(changeMenu);
         true
@@ -216,7 +216,13 @@ GVAR(SQ_SELECT_SQUELCH) = ["SQ_SELECT_SQUELCH", "SQ_SELECT_SQUELCH", "",
             ],
             [
                 {
-                    // Need to pull the current squelch type and set to selection correctly
+                    private _squelch = GET_RADIO_VALUE("squelch");
+                    if (_squelch == 0) then {
+                        _squelch = 3;
+                    };
+                    _squelch=_squelch-1;
+                    SET_STATE("menuSelection",_squelch);
+                    
 
                 }, // onEntry,,
                 nil,
@@ -252,12 +258,14 @@ GVAR(SQ_SELECT_SQUELCH) = ["SQ_SELECT_SQUELCH", "SQ_SELECT_SQUELCH", "",
             ["ERROR_NOENTRY"] call FUNC(changeMenu);
         };
 
-        HASH_SET(_channel,"squelch",_squelch);
+        HASH_SET(_channel,"squelch",_selectSquelch);
 
         SCRATCH_SET(GVAR(currentRadioID),"sq_select_squelch",nil);
-
+        private _home = GET_STATE_DEF("currentHome",GVAR(VULOSHOME));
+        [_home] call FUNC(changeMenu);
+        true
     },
-    "SQ_NO_DIGITAL"
+    "VULOSHOME"
 ];
 [GVAR(SQ_SELECT_SQUELCH)] call FUNC(createMenu);
 
@@ -265,25 +273,19 @@ GVAR(SQ_SELECT_SQUELCH) = ["SQ_SELECT_SQUELCH", "SQ_SELECT_SQUELCH", "",
 GVAR(SQ_SELECT_CTCSS) = ["SQ_SELECT_CTCSS", "SQ_SELECT_CTCSS", "",
     MENUTYPE_ACTIONSERIES,
     [
-        [nil, "SQ_SELECT_CTCSS", "",
+        [nil, "SQ_SELECT_CTCSSTx", "",
             MENUTYPE_SELECTION,
             [
-                [ROW_LARGE_2, ALIGN_CENTER, "SELECT CTCSS FREQ"],
+                [ROW_LARGE_2, ALIGN_CENTER, "CTCSS TX TONE"],
                 [ROW_LARGE_3, ALIGN_CENTER, "%1"],
                 [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
             ],
             [
                 {
-                    TRACE_1("Entering ctcss value","");
-                    private _ctcss = GET_RADIO_VALUE("CTCSSRx");
-                    SET_STATE("menuSelection",0);
-
                     private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                    private _txTone = GET_RADIO_VALUE("CTCSSTx");
                     {
-                        private _ctcssInt = (parseNumber _x);
-                        TRACE_2("COMPARE",_ctcssInt,_ctcss);
-                        if (_ctcssInt == _ctcss) exitWith {
-                            TRACE_1("FOUND MATCH",_forEachIndex);
+                        if (_txTone ==  (parseNumber _x))exitWith {
                             SET_STATE("menuSelection",_forEachIndex);
                         };
                     } forEach _options;
@@ -296,7 +298,75 @@ GVAR(SQ_SELECT_CTCSS) = ["SQ_SELECT_CTCSS", "SQ_SELECT_CTCSS", "",
                 ],
                 [ROW_LARGE_3, 0, -1]
             ],
-            "sq_select_ctcss"
+            "sq_select_ctcsstx"
+        ],
+        [nil, "RX_SQUELCH_TYPE", "",
+        MENUTYPE_SELECTION,
+            [
+                [ROW_LARGE_2, ALIGN_CENTER, "RX SQUELCH TYPE"],
+                [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+            ],
+            [
+                {
+                    SCRATCH_SET(GVAR(currentRadioId),"pgm_sq_rx_select","CTCSS");
+                    SET_STATE("menuSelection",1);
+                },
+                nil,
+                nil,
+                nil,
+                {
+                    //_sqTone = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_tx_ctcss_tone","250.3");
+                    private _sqType = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_rx_select","CTCSS");
+                    switch _sqType do {
+                        default {        // Default is go to end, we only have 1 configurable SQ for now
+                            SCRATCH_SET(GVAR(currentRadioId),"sq_select_ctcssrx", "0");
+                            
+                            private _currentAction = GET_STATE("menuAction");
+                            _currentAction = _currentAction + 999;
+                            SET_STATE("menuAction",_currentAction);                                    
+                        };
+                        case 'CTCSS': {
+                            // Next menu is CTCSS
+                        };
+                    };
+                }                    
+            ],
+            [
+                ["DISABLED", "CTCSS", "NOISE"],
+                [ROW_LARGE_3, 0, -1]
+            ],
+            "pgm_sq_rx_select"
+        ],
+        [nil, "SQ_SELECT_CTCSSRx", "",
+            MENUTYPE_SELECTION,
+            [
+                [ROW_LARGE_2, ALIGN_CENTER, "CTCSS RX TONE"],
+                [ROW_LARGE_3, ALIGN_CENTER, "%1"],
+                [ROW_SMALL_5, ALIGN_CENTER, "^ TO SCROLL / ENT TO CONT"]
+            ],
+            [
+                {
+                    private _options = MENU_SELECTION_DISPLAYSET(_this) select 0;
+                    private _txTone = SCRATCH_GET(GVAR(currentRadioId),"sq_select_ctcsstx");
+                    {
+                        if (_txTone ==  _x )exitWith {
+                            SET_STATE("menuSelection",_forEachIndex);
+                        };
+                    } forEach _options;
+                },
+                nil,
+                nil,
+                nil,
+                {
+                    //_sqTone = SCRATCH_GET_DEF(GVAR(currentRadioId),"pgm_sq_tx_ctcss_tone","250.3");
+                }
+            ],
+            [
+                ["67.0", "69.3", "71.9", "74.4", "77.0", "79.7", "82.5", "85.4", "88.5", "91.5", "94.8", "97.4", "100.0", "103.5", "107.2", "110.9", "114.8", "118.8", "123.0", "127.3", "131.8", "136.5", "141.3", "146.2", "151.4", "156.7", "162.2", "167.9", "173.8", "179.9", "186.2", "192.8", "203.5", "206.5", "210.7", "218.1", "225.7", "229.1", "233.6", "241.8", "250.3", "254.1" ],
+                [ROW_LARGE_3, 0, -1]
+            ],
+            "sq_select_ctcssrx"
         ]
     ],
     [
@@ -305,16 +375,16 @@ GVAR(SQ_SELECT_CTCSS) = ["SQ_SELECT_CTCSS", "SQ_SELECT_CTCSS", "",
     ],
     {
         //Call on series completion
-        private _selectctcss = SCRATCH_GET(GVAR(currentRadioID),"sq_select_ctcss");
+        private _selectctcsstx = SCRATCH_GET(GVAR(currentRadioID),"sq_select_ctcsstx");
+        private _selectctcssrx = SCRATCH_GET(GVAR(currentRadioID),"sq_select_ctcssrx");
         private _channel = GET_CHANNEL_DATA;
-        private _ctcss = HASH_GET(_channel,"CTCSSRx");
-
-        _ctcss = parseNumber _selectctcss;
-
-        HASH_SET(_channel,"CTCSSRx",_ctcss);
-        HASH_SET(_channel,"CTCSSTx",_ctcss);
-        TRACE_1("SERIES COMPLETE ON CTCSS",_ctcss);
-        SCRATCH_SET(GVAR(currentRadioID),"sq_select_ctcss",nil);
+        
+        private _ctcsstx = parseNumber _selectctcsstx;
+        private _ctcssrx = parseNumber _selectctcssrx;
+        HASH_SET(_channel,"CTCSSRx",_ctcssrx);
+        HASH_SET(_channel,"CTCSSTx",_ctcsstx);        
+        SCRATCH_SET(GVAR(currentRadioID),"sq_select_ctcsstx",nil);
+        SCRATCH_SET(GVAR(currentRadioID),"sq_select_ctcssrx",nil);
         false
     },
     "VULOSHOME"

--- a/addons/sys_prc117f/farris_menus/SQ.sqf
+++ b/addons/sys_prc117f/farris_menus/SQ.sqf
@@ -158,8 +158,12 @@ GVAR(SQ_NO_DIGITAL) = ["SQ_NO_DIGITAL", "SQ_NO_DIGITAL", "",
     ],
     {
         //Call on series completion
-        private _selectAnalogSquelch = SCRATCH_GET(GVAR(currentRadioID),"sq_select_analog");
-        private _channel = GET_CHANNEL_DATA;
+        private _selectAnalogSquelch = SCRATCH_GET(GVAR(currentRadioID),"sq_select_analog"); 
+
+        private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+        private _channels = GET_STATE("channels");
+        private _channel = HASHLIST_SELECT(_channels,_channelNumber);
+
         private _CTCSSTx = HASH_GET(_channel,"CTCSSTx");
         private _CTCSSRx = HASH_GET(_channel,"CTCSSRx");
         private _squelch = HASH_GET(_channel,"squelch");
@@ -186,7 +190,8 @@ GVAR(SQ_NO_DIGITAL) = ["SQ_NO_DIGITAL", "SQ_NO_DIGITAL", "",
         HASH_SET(_channel,"CTCSSTx",_CTCSSTx);
         HASH_SET(_channel,"CTCSSRx",_CTCSSRx);
         HASH_SET(_channel,"squelch",_squelch);
-
+        
+        
         SCRATCH_SET(GVAR(currentRadioID),"sq_select_analog",nil);
         _selectAnalogSquelch = 4;
         
@@ -194,7 +199,8 @@ GVAR(SQ_NO_DIGITAL) = ["SQ_NO_DIGITAL", "SQ_NO_DIGITAL", "",
             
             [_nextMenu] call FUNC(changeMenu);
         };
-        
+        HASHLIST_SET(_channels,_channelNumber,_channel);
+        SET_STATE("channels",_channels);  
         private _home = GET_STATE_DEF("currentHome",GVAR(VULOSHOME));
         [_home] call FUNC(changeMenu);
         true
@@ -242,7 +248,9 @@ GVAR(SQ_SELECT_SQUELCH) = ["SQ_SELECT_SQUELCH", "SQ_SELECT_SQUELCH", "",
     {
         //Call on series completion
         private _selectSquelch = SCRATCH_GET(GVAR(currentRadioID),"sq_select_squelch");
-        private _channel = GET_CHANNEL_DATA;
+        private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+        private _channels = GET_STATE("channels");
+        private _channel = HASHLIST_SELECT(_channels,_channelNumber);
         private _squelch = HASH_GET(_channel,"squelch");
 
         switch _selectSquelch do {
@@ -258,8 +266,9 @@ GVAR(SQ_SELECT_SQUELCH) = ["SQ_SELECT_SQUELCH", "SQ_SELECT_SQUELCH", "",
             ["ERROR_NOENTRY"] call FUNC(changeMenu);
         };
 
-        HASH_SET(_channel,"squelch",_selectSquelch);
-
+        HASH_SET(_channel,"squelch",_selectSquelch);      
+        HASHLIST_SET(_channels,_channelNumber,_channel);
+        SET_STATE("channels",_channels);  
         SCRATCH_SET(GVAR(currentRadioID),"sq_select_squelch",nil);
         private _home = GET_STATE_DEF("currentHome",GVAR(VULOSHOME));
         [_home] call FUNC(changeMenu);
@@ -377,12 +386,16 @@ GVAR(SQ_SELECT_CTCSS) = ["SQ_SELECT_CTCSS", "SQ_SELECT_CTCSS", "",
         //Call on series completion
         private _selectctcsstx = SCRATCH_GET(GVAR(currentRadioID),"sq_select_ctcsstx");
         private _selectctcssrx = SCRATCH_GET(GVAR(currentRadioID),"sq_select_ctcssrx");
-        private _channel = GET_CHANNEL_DATA;
+        private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+        private _channels = GET_STATE("channels");
+        private _channel = HASHLIST_SELECT(_channels,_channelNumber);
         
         private _ctcsstx = parseNumber _selectctcsstx;
         private _ctcssrx = parseNumber _selectctcssrx;
         HASH_SET(_channel,"CTCSSRx",_ctcssrx);
-        HASH_SET(_channel,"CTCSSTx",_ctcsstx);        
+        HASH_SET(_channel,"CTCSSTx",_ctcsstx);
+        HASHLIST_SET(_channels,_channelNumber,_channel);
+        SET_STATE("channels",_channels);  
         SCRATCH_SET(GVAR(currentRadioID),"sq_select_ctcsstx",nil);
         SCRATCH_SET(GVAR(currentRadioID),"sq_select_ctcssrx",nil);
         false

--- a/addons/sys_prc117f/fnc_formatChannelValue.sqf
+++ b/addons/sys_prc117f/fnc_formatChannelValue.sqf
@@ -37,16 +37,33 @@ switch _name do {
         _value = [_value, 3, 4] call CBA_fnc_formatNumber;
     };
     case "encryption": {
-        if (_value > 1) then { _value = "CT"; } else { _value = "PT"; };
+        if (_value > 0) then { _value = "CT"; } else { _value = "PT"; };
     };
     case "channelmode": {
         switch _value do {
             case "BASIC": { _value = "NORM"; }
         };
     };
+    case "tek": {
+        private _channel = GET_CHANNEL_DATA;
+        private _encryption = HASH_GET(_channel,"encryption");
+        switch _encryption do {
+            case 0: { 
+                _value = "              "
+            };
+            case 1: { 
+                if (_value< 10) then {
+                    _value = format["VINSON  TEK0%1 ", _value];
+                } else{
+                    _value = format["VINSON  TEK%1 ", _value];
+                }
+                
+            };
+        };
+    };
     case "squelch": {
         private _channel = GET_CHANNEL_DATA;
-        private _ctcss = HASH_GET(_channel,"CTCSSRx");
+        private _ctcss = HASH_GET(_channel,"CTCSSTx");
 
         if (_value > 0) then {
             _value = "TONE";

--- a/addons/sys_prc117f/fnc_formatChannelValue.sqf
+++ b/addons/sys_prc117f/fnc_formatChannelValue.sqf
@@ -39,7 +39,7 @@ switch _name do {
     case "encryption": {
         if (_value > 1) then { _value = "CT"; } else { _value = "PT"; };
     };
-    case "channelMode": {
+    case "channelmode": {
         switch _value do {
             case "BASIC": { _value = "NORM"; }
         };

--- a/addons/sys_prc117f/menus/fnc_changeMode.sqf
+++ b/addons/sys_prc117f/menus/fnc_changeMode.sqf
@@ -33,6 +33,11 @@ if (_mode == 0) then {
         switch _mode do {
             case 1: {
                 [GVAR(VULOSHOME)] call FUNC(changeMenu);
+                HASH_SET([] call FUNC(CURRENT_RADIO_CHANNEL), "encryption", 0);
+            };
+            case 2: {
+                [GVAR(VULOSHOME)] call FUNC(changeMenu);
+                HASH_SET([] call FUNC(CURRENT_RADIO_CHANNEL), "encryption", 1);
             };
             default {
                 [GVAR(INVALID_MODE)] call FUNC(changeMenu);

--- a/addons/sys_prc117f/menus/fnc_changeMode.sqf
+++ b/addons/sys_prc117f/menus/fnc_changeMode.sqf
@@ -30,19 +30,24 @@ if (_mode == 0) then {
     private _onOffState = [GVAR(currentRadioId), "getOnOffState"] call EFUNC(sys_data,dataEvent);
     TRACE_2("State",_mode,_onOffState);
     if (_onOffState >= 1) then {
+        private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+        private _channels = GET_STATE("channels");
+        private _channel = HASHLIST_SELECT(_channels,_channelNumber);
         switch _mode do {
-            case 1: {
+            case 1: {                
                 [GVAR(VULOSHOME)] call FUNC(changeMenu);
-                HASH_SET([] call FUNC(CURRENT_RADIO_CHANNEL), "encryption", 0);
+                HASH_SET(_channel,"encryption",0);                
             };
             case 2: {
                 [GVAR(VULOSHOME)] call FUNC(changeMenu);
-                HASH_SET([] call FUNC(CURRENT_RADIO_CHANNEL), "encryption", 1);
+                HASH_SET(_channel,"encryption",1);
             };
             default {
                 [GVAR(INVALID_MODE)] call FUNC(changeMenu);
             };
         };
+        HASHLIST_SET(_channels,_channelNumber,_channel);
+        SET_STATE("channels",_channels);
     } else {
         if (_onOffState == 0) then {
             [GVAR(currentRadioId), "setOnOffState", 0.2] call EFUNC(sys_data,dataEvent);

--- a/addons/sys_prc117f/menus/fnc_changeMode.sqf
+++ b/addons/sys_prc117f/menus/fnc_changeMode.sqf
@@ -36,7 +36,7 @@ if (_mode == 0) then {
         switch _mode do {
             case 1: {                
                 [GVAR(VULOSHOME)] call FUNC(changeMenu);
-                HASH_SET(_channel,"encryption",0);                
+                HASH_SET(_channel,"encryption",0);
             };
             case 2: {
                 [GVAR(VULOSHOME)] call FUNC(changeMenu);

--- a/addons/sys_prc117f/menus/fnc_drawCursor.sqf
+++ b/addons/sys_prc117f/menus/fnc_drawCursor.sqf
@@ -79,11 +79,11 @@ for "_i" from _start to (_start+_len) do {
     private _textCtrl = _display displayCtrl (_id+_i);
     if (_highlight) then {
 
-        _textCtrl ctrlSetBackgroundColor [0.2, 0.2, 0.2, 1];
-        _textCtrl ctrlSetTextColor [115/255, 126/255, 42/255, 1];
+        _textCtrl ctrlSetBackgroundColor [0.1, 0.1, 0.1, 1];
+        _textCtrl ctrlSetTextColor [82/255, 85/255, 74/255, 1];
     } else {
-        _textCtrl ctrlSetBackgroundColor [0.2, 0.2, 0.2 ,0];
-        _textCtrl ctrlSetTextColor [0.2, 0.2, 0.2, 1]
+        _textCtrl ctrlSetBackgroundColor [0.1, 0.1, 0.1 ,0];
+        _textCtrl ctrlSetTextColor [0.1, 0.1, 0.1, 1]
     };
     _textCtrl ctrlCommit 0;
 };

--- a/addons/sys_prc117f/menus/types/ActionSeries.sqf
+++ b/addons/sys_prc117f/menus/types/ActionSeries.sqf
@@ -46,7 +46,7 @@ DFUNC(renderMenu_ActionSeries) = {
 
             [_subMenu] call FUNC(changeMenu);
         };
-
+        _currentAction = GET_STATE_DEF("menuAction",0);
         _currentAction = _currentAction + 1;
         SET_STATE("menuAction",_currentAction);
 

--- a/addons/sys_prc117f/menus/types/Display.sqf
+++ b/addons/sys_prc117f/menus/types/Display.sqf
@@ -27,6 +27,7 @@ DFUNC(onButtonPress_Display) = {
     switch (_event select 0) do {
         case 'PRE_UP': {     // OPT
             private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+            private _channels = GET_STATE("channels");
 
             private _active = false;
             private _encryption = GET_RADIO_VALUE("encryption");
@@ -38,6 +39,8 @@ DFUNC(onButtonPress_Display) = {
                 };
                 private _channel = [GVAR(currentRadioId), _channelNumber] call FUNC(getChannelDataInternal);
                 HASH_SET(_channel, "encryption", _encryption );
+                HASHLIST_SET(_channels,_channelNumber,_channel);
+                SET_STATE("channels",_channels);  
                 _active = HASH_GET(_channel,"active");
 
             };
@@ -49,6 +52,7 @@ DFUNC(onButtonPress_Display) = {
         };
         case 'PRE_DOWN': { // PGM
             private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
+            private _channels = GET_STATE("channels");
 
             private _active = false;
             private _encryption = GET_RADIO_VALUE("encryption");
@@ -60,6 +64,8 @@ DFUNC(onButtonPress_Display) = {
                 };
                 private _channel = [GVAR(currentRadioId), _channelNumber] call FUNC(getChannelDataInternal);
                 HASH_SET(_channel, "encryption", _encryption );
+                HASHLIST_SET(_channels,_channelNumber,_channel);
+                SET_STATE("channels",_channels); 
                 _active = HASH_GET(_channel,"active");
 
             };

--- a/addons/sys_prc117f/menus/types/Display.sqf
+++ b/addons/sys_prc117f/menus/types/Display.sqf
@@ -40,7 +40,7 @@ DFUNC(onButtonPress_Display) = {
                 private _channel = [GVAR(currentRadioId), _channelNumber] call FUNC(getChannelDataInternal);
                 HASH_SET(_channel, "encryption", _encryption );
                 HASHLIST_SET(_channels,_channelNumber,_channel);
-                SET_STATE("channels",_channels);  
+                SET_STATE("channels",_channels);
                 _active = HASH_GET(_channel,"active");
 
             };

--- a/addons/sys_prc117f/menus/types/Display.sqf
+++ b/addons/sys_prc117f/menus/types/Display.sqf
@@ -16,6 +16,8 @@
  * Public: No
  */
 
+#define GET_RADIO_VALUE(x) [x] call FUNC(CURRENT_RADIO_VALUE)
+
 DFUNC(onButtonPress_Display) = {
 
     TRACE_1("onButtonPress_Display",_this);
@@ -27,6 +29,7 @@ DFUNC(onButtonPress_Display) = {
             private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
 
             private _active = false;
+            private _encryption = GET_RADIO_VALUE("encryption");
             while { !_active } do {
                 if (_channelNumber < 98) then {
                     _channelNumber = _channelNumber + 1;
@@ -34,17 +37,21 @@ DFUNC(onButtonPress_Display) = {
                     _channelNumber = 0;
                 };
                 private _channel = [GVAR(currentRadioId), _channelNumber] call FUNC(getChannelDataInternal);
+                HASH_SET(_channel, "encryption", _encryption );
                 _active = HASH_GET(_channel,"active");
+
             };
 
 
             ["setCurrentChannel", _channelNumber] call GUI_DATA_EVENT;
+
             [MENU_SUBMENUS_ITEM(_menu,_currentSelection)] call CALLSTACK(FUNC(renderMenu_Static));
         };
         case 'PRE_DOWN': { // PGM
             private _channelNumber = ["getCurrentChannel"] call GUI_DATA_EVENT;
 
             private _active = false;
+            private _encryption = GET_RADIO_VALUE("encryption");
             while { !_active } do {
                 if (_channelNumber > 0) then {
                     _channelNumber = _channelNumber - 1;
@@ -52,10 +59,13 @@ DFUNC(onButtonPress_Display) = {
                     _channelNumber = 98;
                 };
                 private _channel = [GVAR(currentRadioId), _channelNumber] call FUNC(getChannelDataInternal);
+                HASH_SET(_channel, "encryption", _encryption );
                 _active = HASH_GET(_channel,"active");
+
             };
 
             ["setCurrentChannel", _channelNumber] call GUI_DATA_EVENT;
+
             [MENU_SUBMENUS_ITEM(_menu,_currentSelection)] call CALLSTACK(FUNC(renderMenu_Static));
         };
         case '4': {     // SQ


### PR DESCRIPTION
-Refactored the "main" menu to display things like encryption, squelch and TEK correctly
-Fleshed out VOICE/DATA menu so that AM/FM/FMNB and FM Deviation can be selected
-Implemented COMSEC selection and CT switch. Mostly eye candy, but can enable encryption and change the TEK this way

Essentially all the settings can be changed now, just like the PRC-148 and the other PR for the 152