### PR TITLE
Addresses issue #1412 and fixes SEM52SL RX

### DIFF
--- a/addons/sys_sem52sl/functions/fnc_renderDisplay.sqf
+++ b/addons/sys_sem52sl/functions/fnc_renderDisplay.sqf
@@ -78,9 +78,9 @@ private _fourthDigit = [
 
 private _fifthDigit = [
     QPATHTOF(data\display\5char_0.paa),
-    QPATHTOF(data\display\5char_2.paa),
+    //QPATHTOF(data\display\5char_2.paa),
     QPATHTOF(data\display\5char_5.paa),
-    QPATHTOF(data\display\5char_6.paa),
+    //QPATHTOF(data\display\5char_6.paa),
     QPATHTOF(data\display\5char_8.paa)
 ];
 
@@ -146,9 +146,9 @@ if (GVAR(backlightOn)) then {
 
     _fifthDigit = [
         QPATHTOF(data\display\backlight\5char_0.paa),
-        QPATHTOF(data\display\backlight\5char_2.paa),
+        //QPATHTOF(data\display\backlight\5char_2.paa),
         QPATHTOF(data\display\backlight\5char_5.paa),
-        QPATHTOF(data\display\backlight\5char_6.paa),
+        //QPATHTOF(data\display\backlight\5char_6.paa),
         QPATHTOF(data\display\backlight\5char_8.paa)
     ];
 
@@ -166,7 +166,7 @@ if (GVAR(booting)) exitWith {
     RADIO_CTRL(302) ctrlSetText (_secondDigit select 8);
     RADIO_CTRL(303) ctrlSetText (_thirdDigit select 8);
     RADIO_CTRL(304) ctrlSetText (_fourthDigit select 8);
-    RADIO_CTRL(305) ctrlSetText (_fifthDigit select 4);
+    RADIO_CTRL(305) ctrlSetText (_fifthDigit select 2);
 };
 
 
@@ -259,10 +259,7 @@ switch _channelKnobPosition do {
                     RADIO_CTRL(304) ctrlSetText (_fourthDigit select (_numbers select 3));
                     switch (_numbers select 4) do {
                         case 0: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 0); };
-                        case 2: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 1); };
-                        case 5: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 2); };
-                        case 6: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 3); };
-                        case 8: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 4); };
+                        case 5: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 1); };
                     };
 
                 };
@@ -282,10 +279,7 @@ switch _channelKnobPosition do {
                         RADIO_CTRL(304) ctrlSetText (_fourthDigit select (_numbers select 3));
                         switch (_numbers select 4) do {
                             case 0: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 0); };
-                            case 2: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 1); };
-                            case 5: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 2); };
-                            case 6: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 3); };
-                            case 8: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 4); };
+                            case 5: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 1); };
                         };
                     };
                 }; // PTT = confirm (back to step 0).
@@ -313,10 +307,7 @@ switch _channelKnobPosition do {
                 RADIO_CTRL(304) ctrlSetText (_fourthDigit select (_numbers select 3));
                 switch (_numbers select 4) do {
                     case 0: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 0); };
-                    case 2: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 1); };
-                    case 5: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 2); };
-                    case 6: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 3); };
-                    case 8: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 4); };
+                    case 5: { RADIO_CTRL(305) ctrlSetText (_fifthDigit select 1); };
                 };
             };
 

--- a/addons/sys_sem52sl/radio/fnc_handleMultipleTransmissions.sqf
+++ b/addons/sys_sem52sl/radio/fnc_handleMultipleTransmissions.sqf
@@ -271,9 +271,7 @@ if (_transmissionsChanged) then {
     if (_okRadios isNotEqualTo []) then {
         private _signalData = (_okRadios select 0) select 2;
         _signalData params ["_signalPercent","_signalDbM"];
-        private _channelNum = [_radioId, "getCurrentChannel"] call EFUNC(sys_data,dataEvent);
-        private _channels = [_radioId, "getState", "channels"] call EFUNC(sys_data,dataEvent);
-        private _channel = HASHLIST_SELECT(_channels,_channelNum);
+        private _channel = [_radioId, "getCurrentChannelData"] call EFUNC(sys_data,dataEvent);
         private _squelch = -117 + HASH_GET(_channel,"squelch");
         // diag_log text format["squelch: %1 signal: %2", _squelch, _signalDbM];
         if (_signalDbM < _squelch) then {


### PR DESCRIPTION
The channel spacing is hard-coded to 25 Khz, meaning the 5th digit can only ever be a 0 or 5 or 8 (radio set to show 88888 on startup). 2 and 6 are unused and not included in backlit versions so a simple comment fixes this.

To address SM52 SL not receiving, the issue was caused by a NaN comparison. For whatever reason the same channel selection that is used on other radios in the fnc_handleMultipleTransmissions fails, simply replaced it with a known working method in the same function.